### PR TITLE
feat: close Phase 1.5 — integration tests, Makefile, coverage, CONTRIBUTING

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,14 @@ jobs:
         run: uv run mypy src/
 
       - name: Test
-        run: uv run pytest tests/ -v --cov=hive --cov-report=term-missing
+        run: uv run pytest tests/ -v --cov=hive --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
 
       - name: Build
         run: uv build

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ dist/
 .mypy_cache/
 .pytest_cache/
 .coverage
+coverage.xml
 htmlcov/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+## Setup
+
+```bash
+git clone https://github.com/mlorentedev/hive.git
+cd hive
+make install
+```
+
+## Development
+
+```bash
+make check    # lint + typecheck + test (run before every PR)
+make lint     # ruff only
+make test     # pytest only
+make build    # full build (runs check first)
+```
+
+## Pull Requests
+
+1. Create a feature branch from `master`
+2. Follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
+3. Run `make check` — all gates must pass
+4. Open a PR against `master`
+5. CI runs automatically (Python 3.12 + 3.13)
+6. Squash merge after CI passes
+
+## Code Standards
+
+- Python 3.12+, type hints everywhere (`mypy --strict`)
+- Formatting: Ruff
+- Tests: pytest, TDD preferred (write test first)
+- Functions < 40 lines, nesting < 4 levels
+
+## Release Process
+
+Automated via [release-please](https://github.com/googleapis/release-please). Merging to `master` with conventional commits triggers:
+
+1. Release PR with changelog (auto-created)
+2. Merge Release PR → GitHub Release + PyPI publish (trusted publishing)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: install lint typecheck test check build clean
+
+install:
+	uv venv && uv pip install -e ".[dev]"
+
+lint:
+	uv run ruff check src/ tests/
+
+typecheck:
+	uv run mypy src/
+
+test:
+	uv run pytest tests/ -v --cov=hive --cov-report=term-missing
+
+check: lint typecheck test
+
+build: check
+	uv build
+
+clean:
+	rm -rf dist/ .venv/ *.egg-info/ .ruff_cache/ .mypy_cache/ .pytest_cache/ htmlcov/ .coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # hive-vault
 
+[![CI](https://github.com/mlorentedev/hive/actions/workflows/ci.yml/badge.svg)](https://github.com/mlorentedev/hive/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/hive-vault)](https://pypi.org/project/hive-vault/)
+[![codecov](https://codecov.io/gh/mlorentedev/hive/graph/badge.svg)](https://codecov.io/gh/mlorentedev/hive)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 Context infrastructure for AI-assisted development — on-demand Obsidian vault access via MCP.
 
 ## The Problem

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,125 @@
+"""Integration tests — multi-tool workflows and end-to-end scenarios."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from hive.vault_server import create_server
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from fastmcp.tools import ToolResult
+
+
+def _text(result: ToolResult) -> str:
+    return result.content[0].text  # type: ignore[union-attr]
+
+
+class TestWorkflowListThenQuery:
+    """List projects, then query a specific section."""
+
+    async def test_discover_and_read(self, mock_vault: Path) -> None:
+        mcp = create_server(vault_path=mock_vault)
+
+        projects = _text(await mcp.call_tool("vault_list_projects", {}))
+        assert "testproject" in projects
+
+        context = _text(
+            await mcp.call_tool("vault_query", {"project": "testproject"})
+        )
+        assert "# Test Project" in context
+
+
+class TestWorkflowCreateThenQuery:
+    """Create a file, then query it back."""
+
+    async def test_create_and_read_back(self, git_vault: Path) -> None:
+        mcp = create_server(vault_path=git_vault)
+
+        create_result = _text(
+            await mcp.call_tool(
+                "vault_create",
+                {
+                    "project": "testproject",
+                    "path": "40-runbooks/deploy-guide.md",
+                    "content": "# Deploy Guide\n\nStep 1: push to main.\n",
+                    "doc_type": "runbook",
+                },
+            )
+        )
+        assert "created" in create_result.lower()
+
+        query_result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "testproject", "path": "40-runbooks/deploy-guide.md"},
+            )
+        )
+        assert "Deploy Guide" in query_result
+        assert "type: runbook" in query_result
+
+
+class TestWorkflowUpdateThenSearch:
+    """Append content, then search for it."""
+
+    async def test_append_and_find(self, git_vault: Path) -> None:
+        mcp = create_server(vault_path=git_vault)
+
+        await mcp.call_tool(
+            "vault_update",
+            {
+                "project": "testproject",
+                "section": "lessons",
+                "operation": "append",
+                "content": "\n## Unique Marker 7x9z\nThis is searchable.\n",
+            },
+        )
+
+        search_result = _text(
+            await mcp.call_tool("vault_search", {"query": "Unique Marker 7x9z"})
+        )
+        assert "90-lessons.md" in search_result
+        assert "Unique Marker 7x9z" in search_result
+
+
+class TestWorkflowHealthAfterChanges:
+    """Health metrics should reflect newly created files."""
+
+    async def test_health_counts_new_files(self, git_vault: Path) -> None:
+        mcp = create_server(vault_path=git_vault)
+
+        health_before = _text(await mcp.call_tool("vault_health", {}))
+
+        await mcp.call_tool(
+            "vault_create",
+            {
+                "project": "testproject",
+                "path": "new-doc.md",
+                "content": "# New Document\n",
+                "doc_type": "lesson",
+            },
+        )
+
+        health_after = _text(await mcp.call_tool("vault_health", {}))
+        assert health_before != health_after
+
+
+class TestWorkflowCrossProjectAccess:
+    """Query project content and meta patterns in the same session."""
+
+    async def test_project_and_meta_in_one_session(self, mock_vault: Path) -> None:
+        mcp = create_server(vault_path=mock_vault)
+
+        project_ctx = _text(
+            await mcp.call_tool("vault_query", {"project": "testproject"})
+        )
+        assert "Test Project" in project_ctx
+
+        meta_pattern = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "_meta", "path": "patterns/pattern-tdd.md"},
+            )
+        )
+        assert "Test-Driven Development" in meta_pattern


### PR DESCRIPTION
## Summary
- 5 integration tests: multi-tool workflows (list→query, create→query, update→search, health after changes, cross-project access)
- Makefile: `make check` runs all quality gates, `make build` includes check
- CONTRIBUTING.md: dev setup, PR process, code standards, release process
- Codecov: coverage upload in CI, badge in README
- 49 tests total, 92% coverage

## Test plan
- [x] `make check` passes locally (49 tests, 92% coverage)
- [ ] CI matrix passes (3.12 + 3.13)
- [ ] Coverage badge renders after merge