### PR TITLE
feat: Worker MCP Server — task delegation with budget tracking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hive-vault"
-version = "0.1.0"
+version = "0.2.0"
 description = "Context infrastructure for AI-assisted development — on-demand Obsidian vault access via MCP"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -32,6 +32,7 @@ dev = [
 
 [project.scripts]
 hive-vault = "hive.vault_server:main"
+hive-worker = "hive.worker_server:main"
 
 [project.urls]
 Homepage = "https://github.com/mlorentedev/hive"

--- a/src/hive/budget.py
+++ b/src/hive/budget.py
@@ -1,0 +1,93 @@
+"""BudgetTracker — SQLite-backed monthly budget tracking for worker requests."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS requests (
+    id INTEGER PRIMARY KEY,
+    timestamp TEXT DEFAULT (datetime('now')),
+    month TEXT DEFAULT (strftime('%Y-%m', 'now')),
+    model TEXT NOT NULL,
+    cost_usd REAL NOT NULL,
+    tokens INTEGER NOT NULL,
+    latency_ms INTEGER NOT NULL,
+    task_type TEXT DEFAULT 'general'
+);
+"""
+
+_CURRENT_MONTH = "strftime('%Y-%m', 'now')"
+
+
+class BudgetTracker:
+    """Track worker request costs against a monthly budget cap."""
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        if db_path != ":memory:":
+            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+
+        self._conn = sqlite3.connect(db_path)
+        if db_path != ":memory:":
+            self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.executescript(_SCHEMA)
+
+    def record_request(
+        self,
+        model: str,
+        cost_usd: float,
+        tokens: int,
+        latency_ms: int,
+        task_type: str = "general",
+    ) -> None:
+        """Insert a completed request into the tracking table."""
+        self._conn.execute(
+            "INSERT INTO requests (model, cost_usd, tokens, latency_ms, task_type) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (model, cost_usd, tokens, latency_ms, task_type),
+        )
+        self._conn.commit()
+
+    def month_spent(self) -> float:
+        """Total USD spent in the current month."""
+        row = self._conn.execute(
+            f"SELECT COALESCE(SUM(cost_usd), 0.0) FROM requests WHERE month = {_CURRENT_MONTH}"
+        ).fetchone()
+        return float(row[0]) if row else 0.0
+
+    def month_remaining(self, budget: float) -> float:
+        """How much budget remains this month."""
+        return budget - self.month_spent()
+
+    def can_spend(self, budget: float, amount: float) -> bool:
+        """Check if spending `amount` would stay within budget."""
+        return self.month_remaining(budget) >= amount
+
+    def month_stats(self, budget: float) -> dict[str, Any]:
+        """Aggregate stats for the current month."""
+        spent = self.month_spent()
+        count_row = self._conn.execute(
+            f"SELECT COUNT(*) FROM requests WHERE month = {_CURRENT_MONTH}"
+        ).fetchone()
+        request_count = count_row[0] if count_row else 0
+
+        by_model: dict[str, dict[str, Any]] = {}
+        rows = self._conn.execute(
+            f"SELECT model, COUNT(*), SUM(cost_usd), AVG(latency_ms) "
+            f"FROM requests WHERE month = {_CURRENT_MONTH} GROUP BY model"
+        ).fetchall()
+        for model, cnt, total_cost, avg_latency in rows:
+            by_model[model] = {
+                "count": cnt,
+                "total_cost": total_cost,
+                "avg_latency_ms": int(avg_latency),
+            }
+
+        return {
+            "spent": spent,
+            "remaining": budget - spent,
+            "request_count": request_count,
+            "by_model": by_model,
+        }

--- a/src/hive/clients.py
+++ b/src/hive/clients.py
@@ -1,0 +1,180 @@
+"""HTTP clients for Ollama and OpenRouter APIs."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import httpx
+
+
+@dataclass(frozen=True)
+class ClientResponse:
+    """Unified response from any LLM provider."""
+
+    text: str
+    model: str
+    tokens: int
+    cost_usd: float
+    latency_ms: int
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    """Model metadata from OpenRouter catalog."""
+
+    id: str
+    name: str
+    context_length: int
+    cost_per_million_input: float
+    cost_per_million_output: float
+    is_free: bool
+
+
+class OllamaClient:
+    """Async client for Ollama's /api/chat endpoint."""
+
+    def __init__(self, endpoint: str, model: str) -> None:
+        self._endpoint = endpoint.rstrip("/")
+        self._model = model
+        self._http = httpx.AsyncClient(base_url=self._endpoint, timeout=120.0)
+
+    async def generate(
+        self, prompt: str, context: str = "", max_tokens: int = 2000
+    ) -> ClientResponse:
+        """Send a chat completion to Ollama and return a unified response."""
+        messages: list[dict[str, str]] = []
+        if context:
+            messages.append({"role": "system", "content": context})
+        messages.append({"role": "user", "content": prompt})
+
+        try:
+            start = time.monotonic()
+            resp = await self._http.post(
+                "/api/chat",
+                json={
+                    "model": self._model,
+                    "messages": messages,
+                    "stream": False,
+                    "options": {"num_predict": max_tokens},
+                },
+            )
+            elapsed_ms = int((time.monotonic() - start) * 1000)
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            msg = f"Ollama unavailable at {self._endpoint}: {exc}"
+            raise ConnectionError(msg) from exc
+
+        data = resp.json()
+        # Ollama returns total_duration in nanoseconds
+        total_ns = data.get("total_duration", 0)
+        latency = int(total_ns / 1_000_000) if total_ns else elapsed_ms
+
+        return ClientResponse(
+            text=data["message"]["content"],
+            model=self._model,
+            tokens=data.get("eval_count", 0),
+            cost_usd=0.0,
+            latency_ms=latency,
+        )
+
+    async def is_available(self) -> bool:
+        """Check if Ollama is reachable."""
+        try:
+            resp = await self._http.get("/")
+            return resp.status_code == 200
+        except (httpx.ConnectError, httpx.ConnectTimeout):
+            return False
+
+
+class OpenRouterClient:
+    """Async client for OpenRouter's chat completions API."""
+
+    _BASE_URL = "https://openrouter.ai"
+
+    def __init__(self, api_key: str, default_model: str) -> None:
+        self._api_key = api_key
+        self._default_model = default_model
+        self._http = httpx.AsyncClient(
+            base_url=self._BASE_URL,
+            timeout=120.0,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "X-OpenRouter-Title": "hive-worker",
+            },
+        )
+
+    async def generate(
+        self,
+        prompt: str,
+        context: str = "",
+        model: str | None = None,
+        max_tokens: int = 2000,
+    ) -> ClientResponse:
+        """Send a chat completion to OpenRouter and return a unified response."""
+        resolved_model = model or self._default_model
+        messages: list[dict[str, str]] = []
+        if context:
+            messages.append({"role": "system", "content": context})
+        messages.append({"role": "user", "content": prompt})
+
+        try:
+            start = time.monotonic()
+            resp = await self._http.post(
+                "/api/v1/chat/completions",
+                json={
+                    "model": resolved_model,
+                    "messages": messages,
+                    "max_tokens": max_tokens,
+                },
+            )
+            elapsed_ms = int((time.monotonic() - start) * 1000)
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            msg = f"OpenRouter unavailable: {exc}"
+            raise ConnectionError(msg) from exc
+
+        if resp.status_code == 429:
+            msg = "OpenRouter rate limit exceeded. Retry later."
+            raise RuntimeError(msg)
+
+        if resp.status_code >= 400:
+            data = resp.json()
+            error_msg = data.get("error", {}).get("message", resp.text)
+            msg = f"OpenRouter API error ({resp.status_code}): {error_msg}"
+            raise RuntimeError(msg)
+
+        data = resp.json()
+        usage = data.get("usage", {})
+
+        return ClientResponse(
+            text=data["choices"][0]["message"]["content"],
+            model=data.get("model", resolved_model),
+            tokens=usage.get("total_tokens", 0),
+            cost_usd=usage.get("cost", 0.0),
+            latency_ms=elapsed_ms,
+        )
+
+    async def list_models(self) -> list[ModelInfo]:
+        """Fetch available models from the OpenRouter catalog."""
+        try:
+            resp = await self._http.get("/api/v1/models")
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            msg = f"OpenRouter unavailable: {exc}"
+            raise ConnectionError(msg) from exc
+
+        data = resp.json()
+        models: list[ModelInfo] = []
+        for m in data.get("data", []):
+            pricing = m.get("pricing", {})
+            input_cost = float(pricing.get("prompt", "0"))
+            output_cost = float(pricing.get("completion", "0"))
+            models.append(
+                ModelInfo(
+                    id=m["id"],
+                    name=m.get("name", m["id"]),
+                    context_length=m.get("context_length", 0),
+                    cost_per_million_input=input_cost * 1_000_000,
+                    cost_per_million_output=output_cost * 1_000_000,
+                    is_free=(input_cost == 0.0 and output_cost == 0.0),
+                )
+            )
+        return models

--- a/src/hive/config.py
+++ b/src/hive/config.py
@@ -24,11 +24,28 @@ def _resolve_openrouter_key() -> str | None:
 
 def _resolve_openrouter_budget() -> float:
     """Monthly budget cap for OpenRouter in USD."""
-    return float(os.environ.get("HIVE_OPENROUTER_BUDGET", "10.0"))
+    return float(os.environ.get("HIVE_OPENROUTER_BUDGET", "5.0"))
 
 
+def _resolve_db_path() -> str:
+    """Resolve SQLite database path for worker budget tracking."""
+    env = os.environ.get("HIVE_DB_PATH")
+    if env:
+        return env
+    return str(Path.home() / ".local" / "share" / "hive" / "worker.db")
+
+
+# Vault config
 VAULT_PATH: Path = _resolve_vault_path()
+
+# Ollama config
 OLLAMA_ENDPOINT: str = _resolve_ollama_endpoint()
+OLLAMA_MODEL: str = os.environ.get("HIVE_OLLAMA_MODEL", "qwen2.5-coder:3b")
+
+# OpenRouter config
 OPENROUTER_API_KEY: str | None = _resolve_openrouter_key()
 OPENROUTER_BUDGET_USD: float = _resolve_openrouter_budget()
-OPENROUTER_MODEL: str = os.environ.get("HIVE_OPENROUTER_MODEL", "qwen/qwen-2.5-coder-32b-instruct")
+OPENROUTER_MODEL: str = os.environ.get("HIVE_OPENROUTER_MODEL", "qwen/qwen3-coder:free")
+
+# Worker config
+DB_PATH: str = _resolve_db_path()

--- a/src/hive/vault_server.py
+++ b/src/hive/vault_server.py
@@ -87,14 +87,11 @@ def create_server(vault_path: Path | None = None) -> FastMCP:
         for name in projects:
             project_dir = projects_dir / name
             sections = [
-                s
-                for s, filename in SECTION_SHORTCUTS.items()
-                if (project_dir / filename).exists()
+                s for s, filename in SECTION_SHORTCUTS.items() if (project_dir / filename).exists()
             ]
             md_count = len(list(project_dir.rglob("*.md")))
             lines.append(
-                f"- **{name}** — {md_count} files, "
-                f"shortcuts: {', '.join(sections) or 'none'}"
+                f"- **{name}** — {md_count} files, shortcuts: {', '.join(sections) or 'none'}"
             )
 
         return "\n".join(lines)
@@ -124,10 +121,7 @@ def create_server(vault_path: Path | None = None) -> FastMCP:
             filename = SECTION_SHORTCUTS.get(section)
             if filename is None:
                 available = ", ".join(SECTION_SHORTCUTS)
-                return (
-                    f"Section '{section}' not found. "
-                    f"Available shortcuts: {available}"
-                )
+                return f"Section '{section}' not found. Available shortcuts: {available}"
             filepath = project_dir / filename
 
         if not filepath.exists():
@@ -155,9 +149,7 @@ def create_server(vault_path: Path | None = None) -> FastMCP:
                 continue
 
             matching_lines = [
-                line.strip()
-                for line in content.splitlines()
-                if query_lower in line.lower()
+                line.strip() for line in content.splitlines() if query_lower in line.lower()
             ]
             if matching_lines:
                 rel = md_file.relative_to(resolved_path)
@@ -194,8 +186,7 @@ def create_server(vault_path: Path | None = None) -> FastMCP:
                     continue
 
             missing = [
-                s for s, fname in SECTION_SHORTCUTS.items()
-                if not (project_dir / fname).exists()
+                s for s, fname in SECTION_SHORTCUTS.items() if not (project_dir / fname).exists()
             ]
 
             lines.append(f"## {project_dir.name}")
@@ -285,7 +276,7 @@ def create_server(vault_path: Path | None = None) -> FastMCP:
             f"id: {stem}\n"
             f"type: {doc_type}\n"
             f"status: active\n"
-            f"created: \"{date.today().isoformat()}\"\n"
+            f'created: "{date.today().isoformat()}"\n'
             f"---\n\n"
         )
 

--- a/src/hive/worker_server.py
+++ b/src/hive/worker_server.py
@@ -1,0 +1,248 @@
+"""Worker MCP Server — task delegation to Ollama/OpenRouter with budget tracking."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from hive.budget import BudgetTracker
+from hive.clients import ClientResponse, OllamaClient, OpenRouterClient
+from hive.config import (
+    DB_PATH,
+    OLLAMA_ENDPOINT,
+    OLLAMA_MODEL,
+    OPENROUTER_API_KEY,
+    OPENROUTER_BUDGET_USD,
+    OPENROUTER_MODEL,
+)
+
+
+def _format_response(resp: ClientResponse) -> str:
+    """Format a model response with metadata footer."""
+    cost_str = f"${resp.cost_usd:.4f}" if resp.cost_usd > 0 else "$0.00"
+    latency_str = f"{resp.latency_ms / 1000:.1f}s"
+    header = (
+        f"## Worker Response (model: {resp.model}, {resp.tokens} tokens, {cost_str}, {latency_str})"
+    )
+    return f"{header}\n\n{resp.text}"
+
+
+def create_server(
+    budget_tracker: BudgetTracker | None = None,
+    ollama_client: OllamaClient | None = None,
+    openrouter_client: OpenRouterClient | None = None,
+) -> FastMCP:
+    """Create and configure the Worker MCP server."""
+    budget = budget_tracker or BudgetTracker(db_path=DB_PATH)
+    ollama = ollama_client or OllamaClient(endpoint=OLLAMA_ENDPOINT, model=OLLAMA_MODEL)
+    openrouter: OpenRouterClient | None = None
+    if openrouter_client is not None:
+        openrouter = openrouter_client
+    elif OPENROUTER_API_KEY:
+        openrouter = OpenRouterClient(api_key=OPENROUTER_API_KEY, default_model=OPENROUTER_MODEL)
+
+    mcp = FastMCP("Hive Worker")
+
+    @mcp.tool
+    async def delegate_task(
+        prompt: str,
+        context: str = "",
+        model: str = "auto",
+        max_tokens: int = 2000,
+        max_cost_per_request: float = 0.0,
+    ) -> str:
+        """Delegate a task to a cheaper model (Ollama or OpenRouter).
+
+        Args:
+            prompt: The task description or code to process.
+            context: Optional system context for the model.
+            model: Routing — 'auto', 'ollama', 'openrouter-free', or a model ID.
+            max_tokens: Maximum tokens in the response.
+            max_cost_per_request: Max USD to spend on this request. 0 = free models only.
+        """
+        if model == "ollama":
+            return await _try_ollama(prompt, context, max_tokens)
+        if model == "openrouter-free":
+            return await _try_openrouter_free(prompt, context, max_tokens)
+        if model == "openrouter":
+            return await _try_openrouter_paid(prompt, context, max_tokens, max_cost_per_request)
+        if model != "auto":
+            return await _try_openrouter_specific(prompt, context, max_tokens, model)
+
+        # Auto routing: Ollama → OpenRouter free → OpenRouter paid → reject
+        errors: list[str] = []
+
+        # Tier 1: Ollama
+        if await ollama.is_available():
+            try:
+                resp = await ollama.generate(prompt, context=context, max_tokens=max_tokens)
+                _record(resp)
+                return _format_response(resp)
+            except (ConnectionError, RuntimeError) as exc:
+                errors.append(f"Ollama: {exc}")
+        else:
+            errors.append("Ollama: offline")
+
+        # Tier 2: OpenRouter free
+        if openrouter is not None:
+            try:
+                resp = await openrouter.generate(prompt, context=context, max_tokens=max_tokens)
+                _record(resp)
+                return _format_response(resp)
+            except (ConnectionError, RuntimeError) as exc:
+                errors.append(f"OpenRouter free: {exc}")
+        else:
+            errors.append("OpenRouter: no API key configured")
+
+        # Tier 3: OpenRouter paid (only if max_cost > 0 and budget allows)
+        if (
+            max_cost_per_request > 0
+            and openrouter is not None
+            and budget.can_spend(OPENROUTER_BUDGET_USD, max_cost_per_request)
+        ):
+            try:
+                resp = await openrouter.generate(
+                    prompt,
+                    context=context,
+                    model="deepseek/deepseek-chat-v3-0324:free",
+                    max_tokens=max_tokens,
+                )
+                _record(resp)
+                return _format_response(resp)
+            except (ConnectionError, RuntimeError) as exc:
+                errors.append(f"OpenRouter paid: {exc}")
+
+        # All tiers exhausted
+        reasons = "; ".join(errors)
+        return f"All workers unavailable. [{reasons}]. Claude should handle this task directly."
+
+    @mcp.tool
+    async def list_models() -> str:
+        """List available models across all providers."""
+        lines = ["# Available Models", ""]
+
+        # Ollama
+        ollama_status = "online" if await ollama.is_available() else "offline / unavailable"
+        lines.append(f"## Ollama ({ollama_status})")
+        if "online" in ollama_status:
+            lines.append(f"- **{ollama._model}** — local, free, no token limit")
+        lines.append("")
+
+        # OpenRouter
+        lines.append("## OpenRouter")
+        if openrouter is not None:
+            try:
+                models = await openrouter.list_models()
+                for m in models:
+                    cost_label = "free" if m.is_free else f"${m.cost_per_million_input:.2f}/M in"
+                    lines.append(f"- **{m.id}** — {m.name}, ctx: {m.context_length}, {cost_label}")
+            except (ConnectionError, RuntimeError) as exc:
+                lines.append(f"- Error fetching models: {exc}")
+        else:
+            lines.append("- No API key configured")
+
+        return "\n".join(lines)
+
+    @mcp.tool
+    async def worker_status() -> str:
+        """Show worker health: budget, connectivity, usage stats."""
+        stats = budget.month_stats(OPENROUTER_BUDGET_USD)
+        ollama_up = await ollama.is_available()
+
+        lines = [
+            "# Worker Status",
+            "",
+            "## Budget",
+            f"- Spent this month: ${stats['spent']:.2f}",
+            f"- Remaining: ${stats['remaining']:.2f} / ${OPENROUTER_BUDGET_USD:.1f}",
+            f"- Requests: {stats['request_count']}",
+            "",
+            "## Connectivity",
+            f"- Ollama: {'online' if ollama_up else 'offline / unavailable'}",
+            f"- OpenRouter: {'configured' if openrouter is not None else 'no API key'}",
+            "",
+        ]
+
+        if stats["by_model"]:
+            lines.append("## Top Models")
+            for model_name, model_stats in stats["by_model"].items():
+                lines.append(
+                    f"- **{model_name}**: {model_stats['count']} requests, "
+                    f"${model_stats['total_cost']:.4f}, avg {model_stats['avg_latency_ms']}ms"
+                )
+
+        return "\n".join(lines)
+
+    def _record(resp: ClientResponse) -> None:
+        """Record a successful response in the budget tracker."""
+        budget.record_request(
+            model=resp.model,
+            cost_usd=resp.cost_usd,
+            tokens=resp.tokens,
+            latency_ms=resp.latency_ms,
+            task_type="delegate",
+        )
+
+    async def _try_ollama(prompt: str, context: str, max_tokens: int) -> str:
+        try:
+            resp = await ollama.generate(prompt, context=context, max_tokens=max_tokens)
+            _record(resp)
+            return _format_response(resp)
+        except (ConnectionError, RuntimeError) as exc:
+            return f"Ollama error: {exc}. Claude should handle this task directly."
+
+    async def _try_openrouter_free(prompt: str, context: str, max_tokens: int) -> str:
+        if openrouter is None:
+            return "OpenRouter not configured. Claude should handle this task directly."
+        try:
+            resp = await openrouter.generate(prompt, context=context, max_tokens=max_tokens)
+            _record(resp)
+            return _format_response(resp)
+        except (ConnectionError, RuntimeError) as exc:
+            return f"OpenRouter error: {exc}. Claude should handle this task directly."
+
+    async def _try_openrouter_paid(
+        prompt: str, context: str, max_tokens: int, max_cost: float
+    ) -> str:
+        if openrouter is None:
+            return "OpenRouter not configured. Claude should handle this task directly."
+        if not budget.can_spend(OPENROUTER_BUDGET_USD, max_cost):
+            return "Monthly budget exhausted. Claude should handle this task directly."
+        try:
+            resp = await openrouter.generate(
+                prompt,
+                context=context,
+                model="deepseek/deepseek-chat-v3-0324:free",
+                max_tokens=max_tokens,
+            )
+            _record(resp)
+            return _format_response(resp)
+        except (ConnectionError, RuntimeError) as exc:
+            return f"OpenRouter paid error: {exc}. Claude should handle this task directly."
+
+    async def _try_openrouter_specific(
+        prompt: str, context: str, max_tokens: int, model_id: str
+    ) -> str:
+        if openrouter is None:
+            return "OpenRouter not configured. Claude should handle this task directly."
+        try:
+            resp = await openrouter.generate(
+                prompt, context=context, model=model_id, max_tokens=max_tokens
+            )
+            _record(resp)
+            return _format_response(resp)
+        except (ConnectionError, RuntimeError) as exc:
+            return f"OpenRouter error ({model_id}): {exc}. Claude should handle this task directly."
+
+    return mcp
+
+
+server = create_server()
+
+
+def main() -> None:
+    """Entry point for the hive-worker CLI command."""
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,15 +51,21 @@ def git_vault(mock_vault: Path) -> Path:
     subprocess.run(["git", "init"], cwd=mock_vault, capture_output=True, check=True)
     subprocess.run(
         ["git", "config", "user.email", "test@test.com"],
-        cwd=mock_vault, capture_output=True, check=True,
+        cwd=mock_vault,
+        capture_output=True,
+        check=True,
     )
     subprocess.run(
         ["git", "config", "user.name", "Test"],
-        cwd=mock_vault, capture_output=True, check=True,
+        cwd=mock_vault,
+        capture_output=True,
+        check=True,
     )
     subprocess.run(["git", "add", "."], cwd=mock_vault, capture_output=True, check=True)
     subprocess.run(
         ["git", "commit", "-m", "init"],
-        cwd=mock_vault, capture_output=True, check=True,
+        cwd=mock_vault,
+        capture_output=True,
+        check=True,
     )
     return mock_vault

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -62,8 +62,7 @@ def bench_vault(mock_vault: Path) -> Path:
 
     # Simulate a realistic 90-lessons.md (~50 lines)
     lessons_content = (
-        "---\nid: testproject-lessons\ntype: lesson\nstatus: active\n---\n\n"
-        "# Lessons\n\n"
+        "---\nid: testproject-lessons\ntype: lesson\nstatus: active\n---\n\n# Lessons\n\n"
     )
     for i in range(10):
         lessons_content += f"## Lesson {i}\n- Detail A\n- Detail B\n\n"
@@ -97,13 +96,13 @@ class TestContextBenchmark:
 
         savings_pct = (1 - ondemand_tokens / static_tokens) * 100
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("CONTEXT BENCHMARK")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
         print(f"Static load (all sections):  {static_tokens:>6} tokens")
         print(f"On-demand (context only):    {ondemand_tokens:>6} tokens")
         print(f"Savings:                     {savings_pct:>5.1f}%")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
         # We should save at least 40% by loading only context
         assert savings_pct > 40, f"Expected >40% savings, got {savings_pct:.1f}%"
@@ -117,20 +116,18 @@ class TestContextBenchmark:
         static_tokens = _count_file_tokens(static_file)
 
         # ON-DEMAND: search for a specific topic
-        result = await mcp.call_tool(
-            "vault_search", {"query": "Task item", "max_lines": 20}
-        )
+        result = await mcp.call_tool("vault_search", {"query": "Task item", "max_lines": 20})
         search_tokens = _tokens(_text(result))
 
         savings_pct = (1 - search_tokens / static_tokens) * 100
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("SEARCH BENCHMARK")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
         print(f"Static load (all sections):  {static_tokens:>6} tokens")
         print(f"Search (targeted, 20 lines): {search_tokens:>6} tokens")
         print(f"Savings:                     {savings_pct:>5.1f}%")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
         assert savings_pct > 60, f"Expected >60% savings, got {savings_pct:.1f}%"
 
@@ -149,30 +146,24 @@ class TestContextBenchmark:
         # ON-DEMAND: context + tasks + search
         total_ondemand = 0
 
-        r1 = await mcp.call_tool(
-            "vault_query", {"project": "testproject", "section": "context"}
-        )
+        r1 = await mcp.call_tool("vault_query", {"project": "testproject", "section": "context"})
         total_ondemand += _tokens(_text(r1))
 
-        r2 = await mcp.call_tool(
-            "vault_query", {"project": "testproject", "section": "tasks"}
-        )
+        r2 = await mcp.call_tool("vault_query", {"project": "testproject", "section": "tasks"})
         total_ondemand += _tokens(_text(r2))
 
-        r3 = await mcp.call_tool(
-            "vault_search", {"query": "Lesson", "max_lines": 10}
-        )
+        r3 = await mcp.call_tool("vault_search", {"query": "Lesson", "max_lines": 10})
         total_ondemand += _tokens(_text(r3))
 
         # On-demand loads MORE than one section but still less than everything
         # The key insight: you only load what you need, when you need it
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("TYPICAL SESSION BENCHMARK")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
         print(f"Static load (everything):    {static_tokens:>6} tokens")
         print(f"On-demand (3 queries):       {total_ondemand:>6} tokens")
-        print(f"Ratio:                       {total_ondemand/static_tokens:>5.2f}x")
-        print(f"{'='*60}")
+        print(f"Ratio:                       {total_ondemand / static_tokens:>5.2f}x")
+        print(f"{'=' * 60}")
 
         # Even with 3 queries, we should use less than static
         assert total_ondemand < static_tokens

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,140 @@
+"""Tests for BudgetTracker — SQLite-backed budget tracking."""
+
+from __future__ import annotations
+
+import pytest
+
+from hive.budget import BudgetTracker
+
+
+@pytest.fixture
+def tracker() -> BudgetTracker:
+    """In-memory budget tracker for tests."""
+    return BudgetTracker(db_path=":memory:")
+
+
+class TestRecordAndSpent:
+    """Recording requests and querying monthly spend."""
+
+    def test_record_single_request(self, tracker: BudgetTracker) -> None:
+        tracker.record_request(
+            model="qwen/qwen3-coder:free",
+            cost_usd=0.0,
+            tokens=100,
+            latency_ms=500,
+            task_type="code_review",
+        )
+        assert tracker.month_spent() == 0.0
+
+    def test_record_multiple_requests_sums_cost(self, tracker: BudgetTracker) -> None:
+        tracker.record_request(
+            "model-a", cost_usd=0.10, tokens=200, latency_ms=300, task_type="general"
+        )
+        tracker.record_request(
+            "model-b", cost_usd=0.25, tokens=500, latency_ms=600, task_type="general"
+        )
+        assert tracker.month_spent() == pytest.approx(0.35)
+
+    def test_empty_db_returns_zero_spent(self, tracker: BudgetTracker) -> None:
+        assert tracker.month_spent() == 0.0
+
+
+class TestBudgetGuards:
+    """Budget cap enforcement."""
+
+    def test_month_remaining_with_no_spend(self, tracker: BudgetTracker) -> None:
+        assert tracker.month_remaining(budget=5.0) == 5.0
+
+    def test_month_remaining_after_spend(self, tracker: BudgetTracker) -> None:
+        tracker.record_request("m", cost_usd=1.50, tokens=100, latency_ms=100, task_type="general")
+        assert tracker.month_remaining(budget=5.0) == pytest.approx(3.50)
+
+    def test_can_spend_within_budget(self, tracker: BudgetTracker) -> None:
+        assert tracker.can_spend(budget=5.0, amount=1.0) is True
+
+    def test_can_spend_exceeds_budget(self, tracker: BudgetTracker) -> None:
+        tracker.record_request("m", cost_usd=4.50, tokens=100, latency_ms=100, task_type="general")
+        assert tracker.can_spend(budget=5.0, amount=1.0) is False
+
+    def test_can_spend_exact_boundary(self, tracker: BudgetTracker) -> None:
+        tracker.record_request("m", cost_usd=4.00, tokens=100, latency_ms=100, task_type="general")
+        assert tracker.can_spend(budget=5.0, amount=1.0) is True
+
+
+class TestMonthStats:
+    """Monthly statistics aggregation."""
+
+    def test_empty_stats(self, tracker: BudgetTracker) -> None:
+        stats = tracker.month_stats(budget=5.0)
+        assert stats["spent"] == 0.0
+        assert stats["remaining"] == 5.0
+        assert stats["request_count"] == 0
+        assert stats["by_model"] == {}
+
+    def test_stats_with_requests(self, tracker: BudgetTracker) -> None:
+        tracker.record_request(
+            "model-a", cost_usd=0.10, tokens=200, latency_ms=300, task_type="code"
+        )
+        tracker.record_request(
+            "model-a", cost_usd=0.15, tokens=300, latency_ms=500, task_type="code"
+        )
+        tracker.record_request(
+            "model-b", cost_usd=0.00, tokens=100, latency_ms=200, task_type="general"
+        )
+
+        stats = tracker.month_stats(budget=5.0)
+        assert stats["spent"] == pytest.approx(0.25)
+        assert stats["remaining"] == pytest.approx(4.75)
+        assert stats["request_count"] == 3
+        assert stats["by_model"]["model-a"]["count"] == 2
+        assert stats["by_model"]["model-a"]["total_cost"] == pytest.approx(0.25)
+        assert stats["by_model"]["model-a"]["avg_latency_ms"] == 400
+        assert stats["by_model"]["model-b"]["count"] == 1
+
+    def test_stats_only_current_month(self, tracker: BudgetTracker) -> None:
+        """Requests from other months should not appear in stats."""
+        tracker.record_request("m", cost_usd=1.00, tokens=100, latency_ms=100, task_type="general")
+        # Manually insert a row with a different month
+        tracker._conn.execute(
+            "INSERT INTO requests (month, model, cost_usd, tokens, latency_ms, task_type) "
+            "VALUES ('2020-01', 'old-model', 99.0, 100, 100, 'general')"
+        )
+        tracker._conn.commit()
+
+        stats = tracker.month_stats(budget=5.0)
+        assert stats["spent"] == pytest.approx(1.00)
+        assert stats["request_count"] == 1
+
+
+class TestWALMode:
+    """SQLite WAL mode is enabled for file-backed databases."""
+
+    def test_wal_mode_enabled_on_file_db(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        db_file = Path(str(tmp_path)) / "wal_test.db"
+        file_tracker = BudgetTracker(db_path=str(db_file))
+        result = file_tracker._conn.execute("PRAGMA journal_mode").fetchone()
+        assert result is not None
+        assert result[0] == "wal"
+
+    def test_memory_db_skips_wal(self, tracker: BudgetTracker) -> None:
+        result = tracker._conn.execute("PRAGMA journal_mode").fetchone()
+        assert result is not None
+        assert result[0] == "memory"
+
+
+class TestFileDB:
+    """Database persistence to file."""
+
+    def test_creates_parent_dirs(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        db_file = Path(str(tmp_path)) / "sub" / "dir" / "test.db"
+        tracker = BudgetTracker(db_path=str(db_file))
+        tracker.record_request("m", cost_usd=0.5, tokens=10, latency_ms=50, task_type="test")
+        assert db_file.exists()
+
+        # Verify data persists across instances
+        tracker2 = BudgetTracker(db_path=str(db_file))
+        assert tracker2.month_spent() == pytest.approx(0.5)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,0 +1,238 @@
+"""Tests for Ollama and OpenRouter HTTP clients."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from hive.clients import ClientResponse, ModelInfo, OllamaClient, OpenRouterClient
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _mock_response(
+    status_code: int = 200, json_data: dict[str, Any] | None = None
+) -> httpx.Response:
+    """Build a fake httpx.Response."""
+    resp = httpx.Response(
+        status_code=status_code,
+        json=json_data or {},
+        request=httpx.Request("POST", "http://test"),
+    )
+    return resp
+
+
+# ── OllamaClient ────────────────────────────────────────────────────
+
+
+class TestOllamaGenerate:
+    """Ollama /api/chat generation."""
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self) -> None:
+        client = OllamaClient(endpoint="http://localhost:11434", model="qwen2.5-coder:3b")
+        mock_resp = _mock_response(
+            json_data={
+                "message": {"content": "def hello(): pass"},
+                "eval_count": 42,
+                "total_duration": 1_500_000_000,  # 1.5s in nanoseconds
+            }
+        )
+        with patch.object(client._http, "post", new_callable=AsyncMock, return_value=mock_resp):
+            result = await client.generate("Write a hello function")
+
+        assert isinstance(result, ClientResponse)
+        assert result.text == "def hello(): pass"
+        assert result.model == "qwen2.5-coder:3b"
+        assert result.tokens == 42
+        assert result.cost_usd == 0.0
+        assert result.latency_ms == 1500
+
+    @pytest.mark.asyncio
+    async def test_generate_timeout(self) -> None:
+        client = OllamaClient(endpoint="http://localhost:11434", model="test")
+        with (
+            patch.object(
+                client._http,
+                "post",
+                new_callable=AsyncMock,
+                side_effect=httpx.ConnectTimeout("timeout"),
+            ),
+            pytest.raises(ConnectionError, match="Ollama"),
+        ):
+            await client.generate("test")
+
+    @pytest.mark.asyncio
+    async def test_generate_connection_error(self) -> None:
+        client = OllamaClient(endpoint="http://localhost:11434", model="test")
+        with (
+            patch.object(
+                client._http,
+                "post",
+                new_callable=AsyncMock,
+                side_effect=httpx.ConnectError("refused"),
+            ),
+            pytest.raises(ConnectionError, match="Ollama"),
+        ):
+            await client.generate("test")
+
+
+class TestOllamaAvailability:
+    """Ollama health check."""
+
+    @pytest.mark.asyncio
+    async def test_is_available_true(self) -> None:
+        client = OllamaClient(endpoint="http://localhost:11434", model="test")
+        mock_resp = _mock_response(200)
+        with patch.object(client._http, "get", new_callable=AsyncMock, return_value=mock_resp):
+            assert await client.is_available() is True
+
+    @pytest.mark.asyncio
+    async def test_is_available_false_on_error(self) -> None:
+        client = OllamaClient(endpoint="http://localhost:11434", model="test")
+        with patch.object(
+            client._http, "get", new_callable=AsyncMock, side_effect=httpx.ConnectError("down")
+        ):
+            assert await client.is_available() is False
+
+
+# ── OpenRouterClient ────────────────────────────────────────────────
+
+
+class TestOpenRouterGenerate:
+    """OpenRouter /api/v1/chat/completions."""
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self) -> None:
+        client = OpenRouterClient(api_key="sk-test", default_model="qwen/qwen3-coder:free")
+        mock_resp = _mock_response(
+            json_data={
+                "choices": [{"message": {"content": "result text"}}],
+                "usage": {"total_tokens": 150},
+                "model": "qwen/qwen3-coder:free",
+            }
+        )
+        with patch.object(client._http, "post", new_callable=AsyncMock, return_value=mock_resp):
+            result = await client.generate("Explain this code")
+
+        assert isinstance(result, ClientResponse)
+        assert result.text == "result text"
+        assert result.tokens == 150
+        assert result.model == "qwen/qwen3-coder:free"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_explicit_model(self) -> None:
+        client = OpenRouterClient(api_key="sk-test", default_model="default-model")
+        mock_resp = _mock_response(
+            json_data={
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {"total_tokens": 10},
+                "model": "deepseek/deepseek-chat-v3-0324:free",
+            }
+        )
+        with patch.object(
+            client._http, "post", new_callable=AsyncMock, return_value=mock_resp
+        ) as mock_post:
+            await client.generate("test", model="deepseek/deepseek-chat-v3-0324:free")
+
+        # Verify the explicit model was sent in the request body
+        call_kwargs = mock_post.call_args
+        assert call_kwargs[1]["json"]["model"] == "deepseek/deepseek-chat-v3-0324:free"
+
+    @pytest.mark.asyncio
+    async def test_generate_rate_limit(self) -> None:
+        client = OpenRouterClient(api_key="sk-test", default_model="m")
+        mock_resp = _mock_response(
+            status_code=429, json_data={"error": {"message": "rate limited"}}
+        )
+        with (
+            patch.object(client._http, "post", new_callable=AsyncMock, return_value=mock_resp),
+            pytest.raises(RuntimeError, match="rate limit"),
+        ):
+            await client.generate("test")
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error(self) -> None:
+        client = OpenRouterClient(api_key="sk-test", default_model="m")
+        mock_resp = _mock_response(
+            status_code=500, json_data={"error": {"message": "internal error"}}
+        )
+        with (
+            patch.object(client._http, "post", new_callable=AsyncMock, return_value=mock_resp),
+            pytest.raises(RuntimeError, match="OpenRouter API error"),
+        ):
+            await client.generate("test")
+
+    @pytest.mark.asyncio
+    async def test_generate_connection_error(self) -> None:
+        client = OpenRouterClient(api_key="sk-test", default_model="m")
+        with (
+            patch.object(
+                client._http, "post", new_callable=AsyncMock, side_effect=httpx.ConnectError("down")
+            ),
+            pytest.raises(ConnectionError, match="OpenRouter"),
+        ):
+            await client.generate("test")
+
+    @pytest.mark.asyncio
+    async def test_generate_extracts_cost(self) -> None:
+        client = OpenRouterClient(api_key="sk-test", default_model="m")
+        mock_resp = _mock_response(
+            json_data={
+                "choices": [{"message": {"content": "x"}}],
+                "usage": {"total_tokens": 50, "cost": 0.0012},
+                "model": "m",
+            }
+        )
+        with patch.object(client._http, "post", new_callable=AsyncMock, return_value=mock_resp):
+            result = await client.generate("test")
+
+        assert result.cost_usd == pytest.approx(0.0012)
+
+
+class TestOpenRouterListModels:
+    """OpenRouter /api/v1/models."""
+
+    @pytest.mark.asyncio
+    async def test_list_models(self) -> None:
+        client = OpenRouterClient(api_key="sk-test", default_model="m")
+        mock_resp = _mock_response(
+            json_data={
+                "data": [
+                    {
+                        "id": "qwen/qwen3-coder:free",
+                        "name": "Qwen3 Coder (free)",
+                        "context_length": 65536,
+                        "pricing": {"prompt": "0.0", "completion": "0.0"},
+                    },
+                    {
+                        "id": "deepseek/deepseek-v3",
+                        "name": "DeepSeek V3",
+                        "context_length": 128000,
+                        "pricing": {"prompt": "0.00014", "completion": "0.00028"},
+                    },
+                ],
+            }
+        )
+        with patch.object(client._http, "get", new_callable=AsyncMock, return_value=mock_resp):
+            models = await client.list_models()
+
+        assert len(models) == 2
+        assert isinstance(models[0], ModelInfo)
+        assert models[0].id == "qwen/qwen3-coder:free"
+        assert models[0].is_free is True
+        assert models[1].is_free is False
+
+    @pytest.mark.asyncio
+    async def test_list_models_connection_error(self) -> None:
+        client = OpenRouterClient(api_key="sk-test", default_model="m")
+        with (
+            patch.object(
+                client._http, "get", new_callable=AsyncMock, side_effect=httpx.ConnectError("down")
+            ),
+            pytest.raises(ConnectionError, match="OpenRouter"),
+        ):
+            await client.list_models()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,9 +25,7 @@ class TestWorkflowListThenQuery:
         projects = _text(await mcp.call_tool("vault_list_projects", {}))
         assert "testproject" in projects
 
-        context = _text(
-            await mcp.call_tool("vault_query", {"project": "testproject"})
-        )
+        context = _text(await mcp.call_tool("vault_query", {"project": "testproject"}))
         assert "# Test Project" in context
 
 
@@ -76,9 +74,7 @@ class TestWorkflowUpdateThenSearch:
             },
         )
 
-        search_result = _text(
-            await mcp.call_tool("vault_search", {"query": "Unique Marker 7x9z"})
-        )
+        search_result = _text(await mcp.call_tool("vault_search", {"query": "Unique Marker 7x9z"}))
         assert "90-lessons.md" in search_result
         assert "Unique Marker 7x9z" in search_result
 
@@ -111,9 +107,7 @@ class TestWorkflowCrossProjectAccess:
     async def test_project_and_meta_in_one_session(self, mock_vault: Path) -> None:
         mcp = create_server(vault_path=mock_vault)
 
-        project_ctx = _text(
-            await mcp.call_tool("vault_query", {"project": "testproject"})
-        )
+        project_ctx = _text(await mcp.call_tool("vault_query", {"project": "testproject"}))
         assert "Test Project" in project_ctx
 
         meta_pattern = _text(

--- a/tests/test_vault_server.py
+++ b/tests/test_vault_server.py
@@ -66,9 +66,7 @@ class TestVaultQuery:
     # -- Shortcuts (backward compat) --
 
     async def test_shortcut_context(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_query", {"project": "testproject"}
-        )
+        result = await vault_mcp.call_tool("vault_query", {"project": "testproject"})
         assert "# Test Project" in _text(result)
 
     async def test_shortcut_tasks(self, vault_mcp: FastMCP) -> None:
@@ -154,9 +152,7 @@ class TestVaultQuery:
     # -- Error cases --
 
     async def test_missing_project(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_query", {"project": "nonexistent"}
-        )
+        result = await vault_mcp.call_tool("vault_query", {"project": "nonexistent"})
         assert "not found" in _text(result).lower()
 
     async def test_missing_section(self, vault_mcp: FastMCP) -> None:
@@ -171,43 +167,31 @@ class TestVaultQuery:
 
 class TestVaultSearch:
     async def test_finds_matching_content(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "Task one"}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "Task one"})
         text = _text(result)
         assert "testproject" in text
         assert "11-tasks.md" in text
 
     async def test_case_insensitive(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "task one"}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "task one"})
         assert "11-tasks.md" in _text(result)
 
     async def test_no_results(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "xyznonexistent"}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "xyznonexistent"})
         assert "no matches" in _text(result).lower()
 
     async def test_searches_across_files(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "active"}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "active"})
         text = _text(result)
         assert "00-context.md" in text
         assert "11-tasks.md" in text
 
     async def test_returns_matching_lines(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "Some lesson"}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "Some lesson"})
         assert "Some lesson" in _text(result)
 
     async def test_max_lines_limits_output(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "active", "max_lines": 5}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "active", "max_lines": 5})
         text = _text(result)
         assert "truncated" in text.lower()
         content_lines = text.split("[...")[0].strip().splitlines()
@@ -336,7 +320,10 @@ class TestVaultUpdate:
         )
         log = subprocess.run(
             ["git", "log", "--oneline", "-1"],
-            cwd=git_vault, capture_output=True, text=True, check=True,
+            cwd=git_vault,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         assert "testproject" in log.stdout.lower()
 
@@ -430,8 +417,7 @@ class TestVaultCreate:
             },
         )
         filepath = (
-            git_vault / "10_projects" / "testproject"
-            / "50-troubleshooting" / "error-timeout.md"
+            git_vault / "10_projects" / "testproject" / "50-troubleshooting" / "error-timeout.md"
         )
         content = filepath.read_text()
         assert content.startswith("---\n")
@@ -454,7 +440,10 @@ class TestVaultCreate:
         )
         log = subprocess.run(
             ["git", "log", "--oneline", "-1"],
-            cwd=git_vault, capture_output=True, text=True, check=True,
+            cwd=git_vault,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         assert "testproject" in log.stdout.lower()
 

--- a/tests/test_worker_server.py
+++ b/tests/test_worker_server.py
@@ -1,0 +1,309 @@
+"""Tests for Worker MCP Server tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hive.budget import BudgetTracker
+from hive.clients import ClientResponse, ModelInfo, OllamaClient, OpenRouterClient
+from hive.worker_server import create_server
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from fastmcp.tools import ToolResult
+
+
+def _text(result: ToolResult) -> str:
+    """Extract text from a ToolResult."""
+    return result.content[0].text  # type: ignore[union-attr]
+
+
+@pytest.fixture
+def budget() -> BudgetTracker:
+    return BudgetTracker(db_path=":memory:")
+
+
+@pytest.fixture
+def ollama() -> OllamaClient:
+    return OllamaClient(endpoint="http://localhost:11434", model="qwen2.5-coder:3b")
+
+
+@pytest.fixture
+def openrouter() -> OpenRouterClient:
+    return OpenRouterClient(api_key="sk-test", default_model="qwen/qwen3-coder:free")
+
+
+@pytest.fixture
+def worker(budget: BudgetTracker, ollama: OllamaClient, openrouter: OpenRouterClient) -> FastMCP:
+    return create_server(budget_tracker=budget, ollama_client=ollama, openrouter_client=openrouter)
+
+
+# ── delegate_task: auto routing ─────────────────────────────────────
+
+
+class TestDelegateTaskAutoRouting:
+    """Auto routing: Ollama first, then OpenRouter free, then paid."""
+
+    @pytest.mark.asyncio
+    async def test_ollama_first_when_available(self, worker: FastMCP, ollama: OllamaClient) -> None:
+        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+            return_value=ClientResponse(
+                text="hello world",
+                model="qwen2.5-coder:3b",
+                tokens=10,
+                cost_usd=0.0,
+                latency_ms=200,
+            )
+        )
+        result = _text(await worker.call_tool("delegate_task", {"prompt": "say hello"}))
+        assert "hello world" in result
+        assert "qwen2.5-coder:3b" in result
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_openrouter_free_when_ollama_down(
+        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    ) -> None:
+        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        openrouter.generate = AsyncMock(  # type: ignore[method-assign]
+            return_value=ClientResponse(
+                text="from openrouter",
+                model="qwen/qwen3-coder:free",
+                tokens=50,
+                cost_usd=0.0,
+                latency_ms=800,
+            )
+        )
+        result = _text(await worker.call_tool("delegate_task", {"prompt": "test"}))
+        assert "from openrouter" in result
+
+    @pytest.mark.asyncio
+    async def test_ollama_error_falls_to_openrouter(
+        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    ) -> None:
+        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        ollama.generate = AsyncMock(side_effect=ConnectionError("ollama failed"))  # type: ignore[method-assign]
+        openrouter.generate = AsyncMock(  # type: ignore[method-assign]
+            return_value=ClientResponse(
+                text="fallback ok",
+                model="qwen/qwen3-coder:free",
+                tokens=30,
+                cost_usd=0.0,
+                latency_ms=500,
+            )
+        )
+        result = _text(await worker.call_tool("delegate_task", {"prompt": "test"}))
+        assert "fallback ok" in result
+
+    @pytest.mark.asyncio
+    async def test_all_unavailable_returns_reject(
+        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    ) -> None:
+        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        openrouter.generate = AsyncMock(side_effect=ConnectionError("down"))  # type: ignore[method-assign]
+        result = _text(await worker.call_tool("delegate_task", {"prompt": "test"}))
+        assert "Claude should handle this task directly" in result
+
+
+# ── delegate_task: budget enforcement ───────────────────────────────
+
+
+class TestDelegateTaskBudget:
+    """Budget cap enforcement for paid models."""
+
+    @pytest.mark.asyncio
+    async def test_max_cost_zero_skips_paid(
+        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    ) -> None:
+        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        # Free model fails
+        openrouter.generate = AsyncMock(side_effect=RuntimeError("rate limit"))  # type: ignore[method-assign]
+        result = _text(
+            await worker.call_tool("delegate_task", {"prompt": "test", "max_cost_per_request": 0.0})
+        )
+        assert "Claude should handle this task directly" in result
+
+    @pytest.mark.asyncio
+    async def test_max_cost_allows_paid_fallback(
+        self,
+        worker: FastMCP,
+        ollama: OllamaClient,
+        openrouter: OpenRouterClient,
+    ) -> None:
+        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        call_count = 0
+
+        async def _side_effect(*args: object, **kwargs: object) -> ClientResponse:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call: free model fails
+                raise RuntimeError("rate limit")
+            # Second call: paid model succeeds
+            return ClientResponse(
+                text="paid result",
+                model="deepseek/deepseek-v3",
+                tokens=100,
+                cost_usd=0.03,
+                latency_ms=1000,
+            )
+
+        openrouter.generate = AsyncMock(side_effect=_side_effect)  # type: ignore[method-assign]
+
+        result = _text(
+            await worker.call_tool(
+                "delegate_task", {"prompt": "test", "max_cost_per_request": 0.05}
+            )
+        )
+        assert "paid result" in result
+
+    @pytest.mark.asyncio
+    async def test_budget_exhausted_rejects_paid(
+        self,
+        worker: FastMCP,
+        budget: BudgetTracker,
+        ollama: OllamaClient,
+        openrouter: OpenRouterClient,
+    ) -> None:
+        # Exhaust budget
+        budget.record_request("m", cost_usd=5.0, tokens=100, latency_ms=100, task_type="general")
+        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        openrouter.generate = AsyncMock(side_effect=RuntimeError("rate limit"))  # type: ignore[method-assign]
+
+        result = _text(
+            await worker.call_tool(
+                "delegate_task", {"prompt": "test", "max_cost_per_request": 0.10}
+            )
+        )
+        assert "Claude should handle this task directly" in result
+
+
+# ── delegate_task: explicit model ───────────────────────────────────
+
+
+class TestDelegateTaskExplicitModel:
+    """Explicit model selection bypasses auto-routing."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_ollama(self, worker: FastMCP, ollama: OllamaClient) -> None:
+        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+            return_value=ClientResponse(
+                text="explicit ollama",
+                model="qwen2.5-coder:3b",
+                tokens=20,
+                cost_usd=0.0,
+                latency_ms=150,
+            )
+        )
+        result = _text(
+            await worker.call_tool("delegate_task", {"prompt": "test", "model": "ollama"})
+        )
+        assert "explicit ollama" in result
+
+    @pytest.mark.asyncio
+    async def test_explicit_openrouter_free(
+        self, worker: FastMCP, openrouter: OpenRouterClient
+    ) -> None:
+        openrouter.generate = AsyncMock(  # type: ignore[method-assign]
+            return_value=ClientResponse(
+                text="explicit free",
+                model="qwen/qwen3-coder:free",
+                tokens=30,
+                cost_usd=0.0,
+                latency_ms=400,
+            )
+        )
+        result = _text(
+            await worker.call_tool("delegate_task", {"prompt": "test", "model": "openrouter-free"})
+        )
+        assert "explicit free" in result
+
+
+# ── delegate_task: records to budget tracker ────────────────────────
+
+
+class TestDelegateTaskRecording:
+    """Successful requests are recorded in the budget tracker."""
+
+    @pytest.mark.asyncio
+    async def test_records_on_success(
+        self, worker: FastMCP, budget: BudgetTracker, ollama: OllamaClient
+    ) -> None:
+        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+            return_value=ClientResponse(
+                text="ok", model="qwen2.5-coder:3b", tokens=10, cost_usd=0.0, latency_ms=100
+            )
+        )
+        await worker.call_tool("delegate_task", {"prompt": "test"})
+        assert budget.month_stats(5.0)["request_count"] == 1
+
+
+# ── list_models ─────────────────────────────────────────────────────
+
+
+class TestListModels:
+    """list_models tool combines Ollama + OpenRouter info."""
+
+    @pytest.mark.asyncio
+    async def test_list_models_output(
+        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    ) -> None:
+        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        openrouter.list_models = AsyncMock(  # type: ignore[method-assign]
+            return_value=[
+                ModelInfo(
+                    id="qwen/qwen3-coder:free",
+                    name="Qwen3 Coder",
+                    context_length=65536,
+                    cost_per_million_input=0.0,
+                    cost_per_million_output=0.0,
+                    is_free=True,
+                ),
+            ]
+        )
+        result = _text(await worker.call_tool("list_models", {}))
+        assert "qwen2.5-coder:3b" in result
+        assert "qwen/qwen3-coder:free" in result
+
+    @pytest.mark.asyncio
+    async def test_list_models_ollama_down(
+        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    ) -> None:
+        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        openrouter.list_models = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        result = _text(await worker.call_tool("list_models", {}))
+        assert "offline" in result.lower() or "unavailable" in result.lower()
+
+
+# ── worker_status ───────────────────────────────────────────────────
+
+
+class TestWorkerStatus:
+    """worker_status tool shows budget + connectivity."""
+
+    @pytest.mark.asyncio
+    async def test_status_shows_budget(
+        self,
+        worker: FastMCP,
+        budget: BudgetTracker,
+        ollama: OllamaClient,
+        openrouter: OpenRouterClient,
+    ) -> None:
+        budget.record_request("m", cost_usd=1.23, tokens=100, latency_ms=100, task_type="general")
+        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        result = _text(await worker.call_tool("worker_status", {}))
+        assert "1.23" in result
+        assert "5.0" in result or "3.77" in result
+
+    @pytest.mark.asyncio
+    async def test_status_shows_ollama_connectivity(
+        self, worker: FastMCP, ollama: OllamaClient
+    ) -> None:
+        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        result = _text(await worker.call_tool("worker_status", {}))
+        assert "offline" in result.lower() or "unavailable" in result.lower()


### PR DESCRIPTION
## Summary

- **BudgetTracker** (`src/hive/budget.py`): SQLite-backed monthly spend tracking with WAL mode, $5/mo cap, per-model aggregation
- **HTTP Clients** (`src/hive/clients.py`): Async Ollama + OpenRouter clients with unified `ClientResponse` dataclass, graceful error handling
- **Worker Server** (`src/hive/worker_server.py`): 3 MCP tools — `delegate_task` (tiered fallback: Ollama → OpenRouter free → paid), `list_models`, `worker_status`
- Config updates: `OLLAMA_MODEL`, `DB_PATH`, updated defaults (`qwen/qwen3-coder:free`, `$5` budget)
- Version bump: `0.1.0 → 0.2.0`, new `hive-worker` entry point

## Test plan

- [x] 14 budget tracker tests (record, spend guards, stats, WAL, persistence)
- [x] 13 client tests (Ollama generate/availability, OpenRouter generate/rate-limit/models)
- [x] 14 worker server tests (auto routing, budget enforcement, explicit model, recording, list/status)
- [x] All 90 tests pass, 88% coverage
- [x] `ruff check` clean, `mypy --strict` clean
- [ ] CI green on both Python 3.12 and 3.13