### PR TITLE
chore: update Ollama default model + register hive-worker MCP

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,11 +38,19 @@ See ADR: `~/Projects/knowledge/10_projects/hive/30-architecture/adr-001-orchestr
 - All vault writes MUST validate YAML frontmatter
 - Project vault entry: `~/Projects/knowledge/10_projects/hive/`
 
+## Key Modules
+
+| Module | Role |
+|---|---|
+| `src/hive/budget.py` | SQLite budget tracker ($5/mo cap, WAL mode) |
+| `src/hive/clients.py` | Async HTTP clients (Ollama + OpenRouter) |
+
 ## Worker Routing
 
-1. Ollama (homelab, configurable endpoint) → primary, free
-2. OpenRouter Qwen API → fallback, budget-capped
-3. Reject → return error, Claude handles it
+1. Ollama `qwen2.5-coder:7b` (homelab mini PC) → primary, free
+2. OpenRouter `qwen/qwen3-coder:free` → fallback, free tier
+3. OpenRouter paid (DeepSeek) → if `max_cost_per_request > 0` and budget allows
+4. Reject → return error, Claude handles it
 
 ## Verification Commands
 

--- a/src/hive/config.py
+++ b/src/hive/config.py
@@ -40,7 +40,7 @@ VAULT_PATH: Path = _resolve_vault_path()
 
 # Ollama config
 OLLAMA_ENDPOINT: str = _resolve_ollama_endpoint()
-OLLAMA_MODEL: str = os.environ.get("HIVE_OLLAMA_MODEL", "qwen2.5-coder:3b")
+OLLAMA_MODEL: str = os.environ.get("HIVE_OLLAMA_MODEL", "qwen2.5-coder:7b")
 
 # OpenRouter config
 OPENROUTER_API_KEY: str | None = _resolve_openrouter_key()

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -33,7 +33,7 @@ class TestOllamaGenerate:
 
     @pytest.mark.asyncio
     async def test_generate_success(self) -> None:
-        client = OllamaClient(endpoint="http://localhost:11434", model="qwen2.5-coder:3b")
+        client = OllamaClient(endpoint="http://localhost:11434", model="qwen2.5-coder:7b")
         mock_resp = _mock_response(
             json_data={
                 "message": {"content": "def hello(): pass"},
@@ -46,7 +46,7 @@ class TestOllamaGenerate:
 
         assert isinstance(result, ClientResponse)
         assert result.text == "def hello(): pass"
-        assert result.model == "qwen2.5-coder:3b"
+        assert result.model == "qwen2.5-coder:7b"
         assert result.tokens == 42
         assert result.cost_usd == 0.0
         assert result.latency_ms == 1500

--- a/tests/test_worker_server.py
+++ b/tests/test_worker_server.py
@@ -28,7 +28,7 @@ def budget() -> BudgetTracker:
 
 @pytest.fixture
 def ollama() -> OllamaClient:
-    return OllamaClient(endpoint="http://localhost:11434", model="qwen2.5-coder:3b")
+    return OllamaClient(endpoint="http://localhost:11434", model="qwen2.5-coder:7b")
 
 
 @pytest.fixture
@@ -53,7 +53,7 @@ class TestDelegateTaskAutoRouting:
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=ClientResponse(
                 text="hello world",
-                model="qwen2.5-coder:3b",
+                model="qwen2.5-coder:7b",
                 tokens=10,
                 cost_usd=0.0,
                 latency_ms=200,
@@ -61,7 +61,7 @@ class TestDelegateTaskAutoRouting:
         )
         result = _text(await worker.call_tool("delegate_task", {"prompt": "say hello"}))
         assert "hello world" in result
-        assert "qwen2.5-coder:3b" in result
+        assert "qwen2.5-coder:7b" in result
 
     @pytest.mark.asyncio
     async def test_fallback_to_openrouter_free_when_ollama_down(
@@ -193,7 +193,7 @@ class TestDelegateTaskExplicitModel:
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=ClientResponse(
                 text="explicit ollama",
-                model="qwen2.5-coder:3b",
+                model="qwen2.5-coder:7b",
                 tokens=20,
                 cost_usd=0.0,
                 latency_ms=150,
@@ -236,7 +236,7 @@ class TestDelegateTaskRecording:
         ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=ClientResponse(
-                text="ok", model="qwen2.5-coder:3b", tokens=10, cost_usd=0.0, latency_ms=100
+                text="ok", model="qwen2.5-coder:7b", tokens=10, cost_usd=0.0, latency_ms=100
             )
         )
         await worker.call_tool("delegate_task", {"prompt": "test"})
@@ -267,7 +267,7 @@ class TestListModels:
             ]
         )
         result = _text(await worker.call_tool("list_models", {}))
-        assert "qwen2.5-coder:3b" in result
+        assert "qwen2.5-coder:7b" in result
         assert "qwen/qwen3-coder:free" in result
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Default Ollama model changed from `qwen2.5-coder:3b` to `qwen2.5-coder:7b` (matches homelab 8GB mini PC)
- Updated CLAUDE.md with full routing tiers and new modules section
- Tests updated accordingly

## Configuration done locally

- `hive-worker` MCP server registered with `HIVE_OLLAMA_ENDPOINT=http://ollama.kubelab.live:11434`
- Both `hive-vault` and `hive-worker` available in `~/.claude.json`

## Remaining manual steps

- [ ] Set `OPENROUTER_API_KEY` in shell profile
- [ ] Pull `qwen2.5-coder:7b` on mini PC: `ollama pull qwen2.5-coder:7b`
- [ ] End-to-end smoke test with `delegate_task`