### PR TITLE
feat: add multi-replacement support to vault_patch

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -890,20 +890,64 @@ Total estimated savings: ~C tokens
     def vault_patch(
         project: str,
         path: str,
-        old_text: str,
-        new_text: str,
+        old_text: str | None = None,
+        new_text: str | None = None,
+        patches: list[dict[str, str]] | None = None,
     ) -> str:
         """Surgical text replacement in a vault file with auto git commit.
 
-        Replaces exactly one occurrence of old_text with new_text. Rejects ambiguous
-        matches (old_text appears more than once) to prevent unintended changes.
+        Supports single or multi-replacement. For single replacement, provide
+        old_text and new_text. For multiple replacements, provide patches — a list
+        of {old_text, new_text} dicts applied in sequence. Do not mix both modes.
+
+        Each old_text must appear exactly once in the file (after prior patches in
+        the list have been applied). If any patch fails validation, no changes are
+        written.
 
         Args:
             project: Project slug or '_meta' for cross-project content.
             path: Relative path to the file within the project.
-            old_text: Exact text to find and replace (must appear exactly once).
-            new_text: Replacement text.
+            old_text: Exact text to find and replace (single mode).
+            new_text: Replacement text (single mode).
+            patches: List of {old_text, new_text} dicts (multi mode).
         """
+        has_single = old_text is not None or new_text is not None
+        has_multi = patches is not None
+
+        if has_single and has_multi:
+            return _track(
+                "vault_patch",
+                "Cannot mix old_text/new_text with patches. "
+                "Use one mode or the other.",
+                project,
+            )
+
+        if has_single:
+            if old_text is None or new_text is None:
+                return _track(
+                    "vault_patch",
+                    "Provide both old_text and new_text for single replacement.",
+                    project,
+                )
+            patch_list: list[dict[str, str]] = [
+                {"old_text": old_text, "new_text": new_text},
+            ]
+        elif has_multi:
+            assert patches is not None  # narrowing for mypy
+            if len(patches) == 0:
+                return _track(
+                    "vault_patch",
+                    "Empty patches list. Provide at least one patch.",
+                    project,
+                )
+            patch_list = patches
+        else:
+            return _track(
+                "vault_patch",
+                "Provide old_text/new_text or a patches list.",
+                project,
+            )
+
         resolved = _resolve_project_dir(resolved_path, project, scopes)
         if resolved is None:
             return _track("vault_patch",
@@ -917,25 +961,41 @@ Total estimated savings: ~C tokens
                           project)
 
         content = filepath.read_text(encoding="utf-8")
-        count = content.count(old_text)
 
-        if count == 0:
-            return _track("vault_patch",
-                          f"old_text not found in file '{path}'.", project)
-        if count > 1:
-            return _track("vault_patch",
-                          f"Ambiguous: old_text appears {count} times in '{path}'. "
-                          "Provide more context to make the match unique.",
-                          project)
+        # Validate and apply all patches on a working copy first
+        working = content
+        for i, patch in enumerate(patch_list, 1):
+            old = patch["old_text"]
+            new = patch["new_text"]
+            count = working.count(old)
 
-        new_content = content.replace(old_text, new_text, 1)
-        filepath.write_text(new_content, encoding="utf-8")
+            if count == 0:
+                label = f"patch {i}: " if len(patch_list) > 1 else ""
+                return _track(
+                    "vault_patch",
+                    f"{label}old_text not found in file '{path}'.",
+                    project,
+                )
+            if count > 1:
+                label = f"patch {i}: " if len(patch_list) > 1 else ""
+                return _track(
+                    "vault_patch",
+                    f"{label}Ambiguous: old_text appears {count} times "
+                    f"in '{path}'. "
+                    "Provide more context to make the match unique.",
+                    project,
+                )
+            working = working.replace(old, new, 1)
+
+        filepath.write_text(working, encoding="utf-8")
 
         rel = filepath.relative_to(resolved_path)
+        n = len(patch_list)
         _git_commit(resolved_path, rel, f"vault: patch {project}/{path}")
 
+        noun = "patch" if n == 1 else "patches"
         return _track("vault_patch",
-                       f"Patched {project}/{path} (1 replacement).",
+                       f"Applied {n} {noun} to {project}/{path}.",
                        project, path)
 
     @mcp.tool

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1842,6 +1842,252 @@ class TestPathTraversal:
         assert "\ntype: adr" in content
 
 
+# ── vault_patch ─────────────────────────────────────────────────────
+
+
+class TestVaultPatch:
+    """Tests for vault_patch single and multi-replacement."""
+
+    async def test_single_patch_legacy_params(self, git_vault: Path) -> None:
+        """Existing single old_text/new_text still works."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "old_text": "- [ ] Task one",
+                "new_text": "- [x] Task one",
+            },
+        ))
+        assert "1 patch" in result.lower()
+        content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
+        assert "- [x] Task one" in content
+
+    async def test_multi_patch_applies_all(self, git_vault: Path) -> None:
+        """Multiple patches applied in sequence to the same file."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "patches": [
+                    {"old_text": "- [ ] Task one", "new_text": "- [x] Task one"},
+                    {"old_text": "- [x] Task two", "new_text": "- [ ] Task two reopened"},
+                ],
+            },
+        ))
+        assert "2 patches" in result.lower()
+        content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
+        assert "- [x] Task one" in content
+        assert "- [ ] Task two reopened" in content
+
+    async def test_multi_patch_single_item(self, git_vault: Path) -> None:
+        """A patches list with one item works fine."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "patches": [
+                    {"old_text": "- [ ] Task one", "new_text": "- [x] Task one"},
+                ],
+            },
+        ))
+        assert "1 patch" in result.lower()
+
+    async def test_multi_patch_rejects_mixed_params(self, git_vault: Path) -> None:
+        """Providing both patches AND old_text/new_text is an error."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "old_text": "- [ ] Task one",
+                "new_text": "- [x] Task one",
+                "patches": [
+                    {"old_text": "- [x] Task two", "new_text": "- [ ] Task two"},
+                ],
+            },
+        ))
+        assert "error" in result.lower() or "cannot" in result.lower() or "mix" in result.lower()
+        # File must remain unchanged
+        content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
+        assert "- [ ] Task one" in content
+
+    async def test_multi_patch_empty_list(self, git_vault: Path) -> None:
+        """An empty patches list is an error."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "patches": [],
+            },
+        ))
+        assert "empty" in result.lower() or "error" in result.lower()
+
+    async def test_multi_patch_ambiguous_aborts_all(self, git_vault: Path) -> None:
+        """If any patch in the list is ambiguous, no patches are applied."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "patches": [
+                    {"old_text": "- [ ] Task one", "new_text": "- [x] Task one"},
+                    {"old_text": "Task", "new_text": "Item"},  # ambiguous
+                ],
+            },
+        ))
+        assert "ambiguous" in result.lower()
+        # File must remain unchanged — first patch NOT applied
+        content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
+        assert "- [ ] Task one" in content
+
+    async def test_multi_patch_not_found_aborts_all(self, git_vault: Path) -> None:
+        """If any patch old_text is not found, no patches are applied."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "patches": [
+                    {"old_text": "- [ ] Task one", "new_text": "- [x] Task one"},
+                    {"old_text": "nonexistent text", "new_text": "something"},
+                ],
+            },
+        ))
+        assert "not found" in result.lower()
+        # File must remain unchanged
+        content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
+        assert "- [ ] Task one" in content
+
+    async def test_multi_patch_sequential_dependency(self, git_vault: Path) -> None:
+        """Later patches see the result of earlier patches."""
+        mcp = create_server(vault_path=git_vault)
+        # First patch changes text, second patch modifies the result of the first
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "patches": [
+                    {"old_text": "- [ ] Task one", "new_text": "- [x] Task alpha"},
+                    {"old_text": "- [x] Task alpha", "new_text": "- [x] Task alpha (done)"},
+                ],
+            },
+        ))
+        assert "2 patches" in result.lower()
+        content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
+        assert "- [x] Task alpha (done)" in content
+
+    async def test_single_patch_project_not_found(self, git_vault: Path) -> None:
+        """Single patch with unknown project returns error."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "nonexistent",
+                "path": "11-tasks.md",
+                "old_text": "foo",
+                "new_text": "bar",
+            },
+        ))
+        assert "not found" in result.lower()
+
+    async def test_single_patch_file_not_found(self, git_vault: Path) -> None:
+        """Single patch with unknown file returns error."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "nonexistent.md",
+                "old_text": "foo",
+                "new_text": "bar",
+            },
+        ))
+        assert "not found" in result.lower()
+
+    async def test_single_patch_ambiguous(self, git_vault: Path) -> None:
+        """Single patch with ambiguous match returns error."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "old_text": "Task",
+                "new_text": "Item",
+            },
+        ))
+        assert "ambiguous" in result.lower()
+
+    async def test_single_patch_not_found_in_file(self, git_vault: Path) -> None:
+        """Single patch with text not in file returns error."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "old_text": "nonexistent text here",
+                "new_text": "replacement",
+            },
+        ))
+        assert "not found" in result.lower()
+
+    async def test_no_params_error(self, git_vault: Path) -> None:
+        """Neither old_text/new_text nor patches provided is an error."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+            },
+        ))
+        assert "error" in result.lower() or "provide" in result.lower()
+
+    async def test_multi_patch_single_git_commit(self, git_vault: Path) -> None:
+        """Multi-patch produces exactly one git commit."""
+        import subprocess
+
+        mcp = create_server(vault_path=git_vault)
+        # Count commits before
+        before = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=git_vault, capture_output=True, text=True, check=True,
+        )
+        count_before = int(before.stdout.strip())
+
+        await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "patches": [
+                    {"old_text": "- [ ] Task one", "new_text": "- [x] Task one"},
+                    {"old_text": "- [x] Task two", "new_text": "- [ ] Task two reopened"},
+                ],
+            },
+        )
+
+        after = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=git_vault, capture_output=True, text=True, check=True,
+        )
+        count_after = int(after.stdout.strip())
+        assert count_after == count_before + 1
+
+
 class TestSectionFallback:
     async def test_bare_name_takes_priority(self, mock_vault: Path) -> None:
         # Create a bare context.md alongside the legacy 00-context.md

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -337,7 +337,7 @@ class TestVaultSmoke:
                 "new_text": "- [x] Task alpha",
             },
         ))
-        assert "patched" in result.lower()
+        assert "patch" in result.lower()
         content = (smoke_vault / "10_projects" / "smoketest" / "11-tasks.md").read_text()
         assert "- [x] Task alpha" in content
 


### PR DESCRIPTION
## Summary

Extends `vault_patch` to accept a `patches` parameter — a list of `{old_text, new_text}` pairs applied atomically in sequence.

**Problem:** AI assistants chose native Edit tools over Hive for vault writes because `vault_patch` only supported one replacement per call. Multiple surgical changes in a large file required 3+ round-trips.

**Solution:** New `patches` parameter enables batch replacements in a single call with a single git commit.

### Behavior

- `patches=[{old_text: "A", new_text: "B"}, ...]` — multi-replacement mode
- `old_text="A", new_text="B"` — single replacement (backwards compatible)
- Mixed modes → error
- Atomic: all patches validated on a working copy first. If any fails, no changes are written
- Single git commit regardless of patch count

### Tests

14 new tests covering: happy path, backwards compat, atomicity (ambiguous/not-found abort all), sequential dependency, error paths. 279 total tests, 89% coverage.

## Test plan

- [x] `make check` passes (lint + typecheck + 279 tests)
- [ ] Smoke test with real vault (manual)