### PR TITLE
feat: add vault_validate tool for drift detection

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,7 +24,7 @@ See ADR: `~/Projects/knowledge/10_projects/hive/30-architecture/adr-001-orchestr
 
 | Path | Role |
 |---|---|
-| `src/hive/server.py` | Unified Hive MCP server (vault + worker, 18 tools) |
+| `src/hive/server.py` | Unified Hive MCP server (vault + worker, 19 tools) |
 | `src/hive/config.py` | Configuration (vault path, Ollama endpoint, OpenRouter key) |
 | `tests/` | pytest suite |
 | `~/Projects/knowledge/` | Obsidian vault (source of truth) |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ That's it. You're running.
 
 ## What You Get
 
-### 15 Vault Tools — your knowledge, on demand
+### 16 Vault Tools — your knowledge, on demand
 
 | Tool | What it does |
 |---|---|
@@ -79,6 +79,7 @@ That's it. You're running.
 | `vault_list_projects` | See all projects in your vault |
 | `vault_list_files` | Browse project structure with glob pattern filtering |
 | `vault_health` | File counts, staleness metrics, coverage gaps per project |
+| `vault_validate` | Drift detector — find broken frontmatter, stale files, broken wikilinks |
 | `vault_recent` | What changed in the last N days (via git + frontmatter) |
 | `vault_update` | Write to vault with YAML validation + auto git commit |
 | `vault_create` | Create files with auto-generated frontmatter + auto git commit |
@@ -237,10 +238,11 @@ Without these instructions, your assistant uses Hive inconsistently. With them, 
 ```
 MCP Host (Claude Code, Gemini CLI, Codex CLI, Cursor, ...)
     └── hive-vault (MCP server, stdio)
-            ├── Vault Tools (14) ── Obsidian vault (Markdown + YAML frontmatter)
+            ├── Vault Tools (16) ── Obsidian vault (Markdown + YAML frontmatter)
             │     query, search, smart_search, list_files, patch,
-            │     update, create, capture_lesson, summarize,
-            │     session_briefing, recent, usage, health, list_projects
+            │     update, create, capture_lesson, extract_lessons,
+            │     summarize, validate, session_briefing, recent,
+            │     usage, health, list_projects
             │
             └── Worker Tools (3) ── Task delegation + routing:
                   delegate_task        1. Ollama (local, free)

--- a/site/src/content/docs/guides/use-cases.md
+++ b/site/src/content/docs/guides/use-cases.md
@@ -162,6 +162,24 @@ The `vault_sync` prompt walks through:
 3. Updating stale documentation
 4. Flagging gaps that need new docs
 
+## Detecting Vault Drift
+
+Find broken frontmatter, stale docs, and dead links before they cause problems:
+
+> "Validate my vault for issues"
+
+```python
+vault_validate(project="my-project")
+```
+
+Returns categorized issues: missing frontmatter fields, files that haven't been updated in 180+ days, and `[[wikilinks]]` pointing to nonexistent files. Run it after shipping a feature to catch documentation that drifted from reality.
+
+You can also target specific checks:
+
+```python
+vault_validate(checks=["stale"])  # Only flag stale files across all projects
+```
+
 ## Monitoring Token Savings
 
 Curious how much Hive is saving you?

--- a/site/src/content/docs/tools/vault.md
+++ b/site/src/content/docs/tools/vault.md
@@ -1,6 +1,6 @@
 ---
 title: Vault Tools
-description: 15 tools for querying, searching, and managing your Obsidian vault.
+description: 16 tools for querying, searching, and managing your Obsidian vault.
 ---
 
 ## vault_list_projects
@@ -65,6 +65,27 @@ vault_health()
 ```
 
 Reports per-project: file count, total lines, stale files (>180 days by default, configurable via `HIVE_STALE_THRESHOLD_DAYS`), section coverage.
+
+## vault_validate
+
+Drift detector — validate vault files for common issues.
+
+```python
+vault_validate(project="my-project", checks=["frontmatter", "stale", "links"], max_issues=50)
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `project` | `""` (all) | Project to validate. Empty scans all projects |
+| `checks` | `[]` (all) | Which checks to run: `frontmatter`, `stale`, `links` |
+| `max_issues` | `50` | Maximum issues to report |
+
+**Checks:**
+- **frontmatter**: Missing or malformed YAML frontmatter, missing required fields (id, type, status), unparseable dates
+- **stale**: Active files not modified in `HIVE_STALE_THRESHOLD_DAYS` (default 180)
+- **links**: Broken `[[wikilinks]]` pointing to nonexistent files
+
+Issues are categorized as `[error]` or `[warning]` with file path and description.
 
 ## vault_update
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -759,6 +759,143 @@ Total estimated savings: ~C tokens
         """Return health metrics for all vault projects."""
         return _track("vault_health", _health_report_text())
 
+    all_checks = frozenset({"frontmatter", "stale", "links"})
+    wikilink_re = re.compile(r"\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]")
+
+    @mcp.tool(annotations=_READ_ONLY)
+    def vault_validate(
+        project: str = "",
+        checks: list[str] = [],  # noqa: B006
+        max_issues: int = 50,
+    ) -> str:
+        """Validate vault files for common issues (drift detector).
+
+        Checks for: missing/incomplete frontmatter, stale active files,
+        and broken wikilinks. Returns a list of issues found.
+
+        Args:
+            project: Project slug to validate. Empty = all projects.
+            checks: Which checks to run. Empty = all. Options: frontmatter, stale, links.
+            max_issues: Maximum issues to report. Default 50.
+        """
+        active_checks = frozenset(checks) & all_checks if checks else all_checks
+
+        # Collect project dirs to scan
+        project_dirs: list[tuple[Path, str]] = []
+        if project:
+            resolved = _resolve_project_dir(resolved_path, project, scopes)
+            if resolved is None:
+                return _track("vault_validate",
+                              f"Project '{project}' not found in vault.", project)
+            project_dirs.append(resolved)
+        else:
+            for scope_name, dir_name in scopes.items():
+                if scope_name == "meta":
+                    continue
+                scope_dir = resolved_path / dir_name
+                if not scope_dir.is_dir():
+                    continue
+                for d in sorted(scope_dir.iterdir()):
+                    if d.is_dir():
+                        project_dirs.append((d, scope_name))
+
+        if not project_dirs:
+            return _track("vault_validate", "No projects found in vault.")
+
+        # Build index of all known file stems for wikilink resolution
+        all_stems: set[str] = set()
+        if "links" in active_checks:
+            for pd, _ in project_dirs:
+                for f in pd.rglob("*.md"):
+                    all_stems.add(f.stem)
+
+        issues: list[str] = []
+        stale_threshold = date.today() - timedelta(days=stale_days)
+
+        for project_dir, _scope_name in project_dirs:
+            proj_name = project_dir.name
+            for f in sorted(project_dir.rglob("*.md")):
+                if len(issues) >= max_issues:
+                    break
+                rel = f.relative_to(project_dir).as_posix()
+                content = _safe_read(f)
+                if content is None:
+                    continue
+
+                fm = parse_frontmatter(content)
+
+                # ── frontmatter checks ──
+                if "frontmatter" in active_checks:
+                    if fm is None:
+                        issues.append(
+                            f"[error] {proj_name}/{rel}: "
+                            "Missing or invalid frontmatter"
+                        )
+                        continue
+                    missing = {"id", "type", "status"} - fm.raw.keys()
+                    if missing:
+                        issues.append(
+                            f"[error] {proj_name}/{rel}: "
+                            f"Frontmatter missing fields: "
+                            f"{', '.join(sorted(missing))}"
+                        )
+                    if fm.created and parse_date(fm.created) is None:
+                        issues.append(
+                            f"[warning] {proj_name}/{rel}: "
+                            f"Unparseable date: '{fm.created}'"
+                        )
+
+                # ── stale checks ──
+                if (
+                    "stale" in active_checks
+                    and fm is not None
+                    and fm.status not in _TERMINAL_STATUSES
+                ):
+                        created_date = parse_date(fm.created) if fm.created else None
+                        if created_date is None:
+                            try:
+                                created_date = date.fromtimestamp(f.stat().st_mtime)
+                            except OSError:
+                                continue
+                        if created_date < stale_threshold:
+                            issues.append(
+                                f"[warning] {proj_name}/{rel}: "
+                                f"Stale (active since {created_date.isoformat()}, "
+                                f">{stale_days}d)"
+                            )
+
+                # ── link checks ──
+                if "links" in active_checks:
+                    body = extract_body(content)
+                    for m in wikilink_re.finditer(body):
+                        target = m.group(1).strip()
+                        if target not in all_stems:
+                            issues.append(
+                                f"[warning] {proj_name}/{rel}: "
+                                f"Broken link [[{target}]]"
+                            )
+                            if len(issues) >= max_issues:
+                                break
+
+            if len(issues) >= max_issues:
+                break
+
+        # Build output
+        if not issues:
+            scope_label = f" for '{project}'" if project else ""
+            return _track("vault_validate",
+                          f"Vault clean{scope_label}. "
+                          f"0 issues found ({', '.join(sorted(active_checks))}).")
+
+        errors = sum(1 for i in issues if i.startswith("[error]"))
+        warnings = sum(1 for i in issues if i.startswith("[warning]"))
+        header = f"Found {len(issues)} issues ({errors} errors, {warnings} warnings)"
+        if len(issues) >= max_issues:
+            header += f" — truncated at {max_issues}, more may exist"
+        lines = [header, ""]
+        lines.extend(issues)
+        return _track("vault_validate", "\n".join(lines), project)
+
     @mcp.tool(annotations=_WRITE)
     def vault_update(
         project: str,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2601,3 +2601,140 @@ class TestExtractLessons:
         # Newline sanitized: "### Fake Lesson" must NOT appear as a standalone heading
         for line in lessons.splitlines():
             assert not line.startswith("### Fake Lesson")
+
+
+# ── vault_validate ─────────────────────────────────────────────────
+
+
+class TestVaultValidate:
+    """vault_validate tool — drift detection and vault linting."""
+
+    async def test_healthy_vault_no_errors(self, mock_vault: Path) -> None:
+        """Well-formed vault produces no error-level issues."""
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool("vault_validate", {}))
+        assert "error" not in result.lower() or "0 errors" in result.lower()
+
+    async def test_missing_frontmatter_detected(self, mock_vault: Path) -> None:
+        """File with no frontmatter is flagged."""
+        bad = mock_vault / "10_projects" / "testproject" / "no-frontmatter.md"
+        bad.write_text("# Just a heading\n\nNo frontmatter here.\n")
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool("vault_validate", {}))
+        assert "no-frontmatter.md" in result
+        assert "frontmatter" in result.lower()
+
+    async def test_incomplete_frontmatter_detected(self, mock_vault: Path) -> None:
+        """Frontmatter missing required fields is flagged."""
+        bad = mock_vault / "10_projects" / "testproject" / "incomplete.md"
+        bad.write_text("---\nid: incomplete\n---\n\n# Missing type and status\n")
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool("vault_validate", {}))
+        assert "incomplete.md" in result
+        assert "type" in result.lower() or "status" in result.lower()
+
+    async def test_unparseable_date_detected(self, mock_vault: Path) -> None:
+        """Frontmatter with bad created date is flagged."""
+        bad = mock_vault / "10_projects" / "testproject" / "bad-date.md"
+        bad.write_text(
+            '---\nid: bad-date\ntype: note\nstatus: active\ncreated: "not-a-date"\n'
+            "---\n\n# Bad date\n"
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool("vault_validate", {}))
+        assert "bad-date.md" in result
+        assert "date" in result.lower()
+
+    async def test_stale_file_detected(self, mock_vault: Path) -> None:
+        """Active file with old created date is flagged as stale."""
+        stale = mock_vault / "10_projects" / "testproject" / "ancient.md"
+        stale.write_text(
+            '---\nid: ancient\ntype: note\nstatus: active\ncreated: "2020-01-01"\n'
+            "---\n\n# Very old file\n"
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool("vault_validate", {}))
+        assert "ancient.md" in result
+        assert "stale" in result.lower()
+
+    async def test_terminal_status_not_flagged_stale(self, mock_vault: Path) -> None:
+        """Completed/archived files are NOT flagged as stale."""
+        old = mock_vault / "10_projects" / "testproject" / "old-done.md"
+        old.write_text(
+            '---\nid: old-done\ntype: note\nstatus: completed\ncreated: "2020-01-01"\n'
+            "---\n\n# Old but done\n"
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool("vault_validate", {}))
+        assert "old-done.md" not in result
+
+    async def test_broken_wikilink_detected(self, mock_vault: Path) -> None:
+        """Wikilink pointing to nonexistent file is flagged."""
+        doc = mock_vault / "10_projects" / "testproject" / "with-links.md"
+        doc.write_text(
+            "---\nid: with-links\ntype: note\nstatus: active\n---\n\n"
+            "See [[nonexistent-doc]] for details.\n"
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool("vault_validate", {}))
+        assert "nonexistent-doc" in result
+        assert "link" in result.lower() or "broken" in result.lower()
+
+    async def test_valid_wikilink_not_flagged(self, mock_vault: Path) -> None:
+        """Wikilink to existing file is NOT flagged."""
+        doc = mock_vault / "10_projects" / "testproject" / "good-link.md"
+        doc.write_text(
+            "---\nid: good-link\ntype: note\nstatus: active\n---\n\n"
+            "See [[adr-001-test]] for details.\n"
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool("vault_validate", {}))
+        assert "adr-001-test" not in result
+
+    async def test_project_filter(self, mock_vault: Path) -> None:
+        """Only validates the specified project."""
+        # Add a bad file to a different project
+        other = mock_vault / "10_projects" / "otherproject"
+        other.mkdir(parents=True)
+        (other / "broken.md").write_text("No frontmatter here.\n")
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool(
+            "vault_validate", {"project": "testproject"},
+        ))
+        assert "broken.md" not in result
+
+    async def test_checks_filter(self, mock_vault: Path) -> None:
+        """Only runs specified checks."""
+        stale = mock_vault / "10_projects" / "testproject" / "ancient2.md"
+        stale.write_text(
+            '---\nid: ancient2\ntype: note\nstatus: active\ncreated: "2020-01-01"\n'
+            "---\n\n# Very old\n"
+        )
+        bad = mock_vault / "10_projects" / "testproject" / "no-fm.md"
+        bad.write_text("No frontmatter.\n")
+        mcp = create_server(vault_path=mock_vault)
+        # Only run frontmatter check — stale should not appear
+        result = _text(await mcp.call_tool(
+            "vault_validate", {"checks": ["frontmatter"]},
+        ))
+        assert "no-fm.md" in result
+        assert "ancient2.md" not in result
+
+    async def test_max_issues_cap(self, mock_vault: Path) -> None:
+        """Output is capped at max_issues."""
+        project = mock_vault / "10_projects" / "testproject"
+        for i in range(20):
+            (project / f"bad-{i}.md").write_text("No frontmatter.\n")
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool(
+            "vault_validate", {"max_issues": 5},
+        ))
+        assert "truncated" in result.lower() or "more" in result.lower()
+
+    async def test_project_not_found(self, mock_vault: Path) -> None:
+        """Unknown project returns error."""
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool(
+            "vault_validate", {"project": "nonexistent"},
+        ))
+        assert "not found" in result.lower()


### PR DESCRIPTION
## Summary

- New `vault_validate` tool — drift detector for Obsidian vaults
- Checks: missing/incomplete frontmatter, stale active files, broken `[[wikilinks]]`
- Supports project filtering, check selection (`frontmatter`, `stale`, `links`), and `max_issues` cap
- Issues categorized as `[error]` or `[warning]` with file path and description
- 12 new tests, 322 total, 90% coverage

## Test plan

- [x] Healthy vault produces no errors
- [x] Missing frontmatter detected
- [x] Incomplete frontmatter (missing fields) detected
- [x] Unparseable dates flagged
- [x] Stale active files flagged, terminal status files excluded
- [x] Broken wikilinks detected, valid links not flagged
- [x] Project filter scopes validation to single project
- [x] Checks filter runs only selected checks
- [x] Max issues cap with truncation message
- [x] Unknown project returns error
- [x] `make check` passes (lint + mypy strict + 322 tests)