### PR TITLE
feat: consolidate 19 MCP tools into 10

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,7 +24,7 @@ See ADR: `~/Projects/knowledge/10_projects/hive/30-architecture/adr-001-orchestr
 
 | Path | Role |
 |---|---|
-| `src/hive/server.py` | Unified Hive MCP server (vault + worker, 19 tools) |
+| `src/hive/server.py` | Unified Hive MCP server (vault + worker, 10 tools) |
 | `src/hive/config.py` | Configuration (vault path, Ollama endpoint, OpenRouter key) |
 | `tests/` | pytest suite |
 | `~/Projects/knowledge/` | Obsidian vault (source of truth) |

--- a/README.md
+++ b/README.md
@@ -62,44 +62,30 @@ args = ["--upgrade", "hive-vault"]
 
 Then ask your assistant:
 
-> "Use vault_list_projects to see my vault"
+> "Use vault_list to see my vault"
 
 That's it. You're running.
 
 ## What You Get
 
-### 16 Vault Tools — your knowledge, on demand
+### 10 Tools — your knowledge, on demand
 
 | Tool | What it does |
 |---|---|
 | `vault_query` | Load project context, tasks, roadmap, lessons — or any file by path |
-| `vault_search` | Full-text search with metadata filters and regex support |
-| `vault_smart_search` | Ranked results with relevance scoring (status + recency + match density) |
-| `session_briefing` | One call = tasks + lessons + git log + health. Start every session here |
-| `vault_list_projects` | See all projects in your vault |
-| `vault_list_files` | Browse project structure with glob pattern filtering |
-| `vault_health` | File counts, staleness metrics, coverage gaps per project |
-| `vault_validate` | Drift detector — find broken frontmatter, stale files, broken wikilinks |
-| `vault_recent` | What changed in the last N days (via git + frontmatter) |
-| `vault_update` | Write to vault with YAML validation + auto git commit |
-| `vault_create` | Create files with auto-generated frontmatter + auto git commit |
+| `vault_search` | Full-text search with metadata filters, regex, ranked results, and recent changes |
+| `vault_list` | List projects (no args) or browse files within a project with glob filtering |
+| `vault_health` | Health metrics, drift detection (frontmatter, stale, wikilinks), and usage stats |
+| `vault_write` | Create, append, or replace vault files with YAML validation + auto git commit |
 | `vault_patch` | Surgical find-and-replace with ambiguity rejection + auto git commit |
-| `capture_lesson` | Capture a lesson inline — deduplicates, appends to `90-lessons.md` |
-| `extract_lessons` | Worker-powered batch extraction — send text, get structured lessons |
-| `vault_summarize` | Small files returned directly, large files delegated for compression |
-| `vault_usage` | Tool call analytics — which tools, which projects, how many tokens |
+| `capture_lesson` | Capture lessons inline (structured) or batch-extract from text via worker |
+| `session_briefing` | One call = tasks + lessons + git log + health. Start every session here |
+| `delegate_task` | Route tasks to cheaper models, or summarize vault files automatically |
+| `worker_status` | Budget remaining, connectivity, available models, usage stats |
 
-### 3 Worker Tools — delegate to cheaper models
+**Worker routing:** Ollama first (free) → OpenRouter free tier → OpenRouter paid ($1/mo cap) → reject.
 
-| Tool | What it does |
-|---|---|
-| `delegate_task` | Route tasks to Ollama (free, local) or OpenRouter (free/paid cloud) |
-| `list_models` | See all available models across providers |
-| `worker_status` | Budget remaining, connectivity, usage stats |
-
-**Routing:** Ollama first (free) → OpenRouter free tier → OpenRouter paid ($1/mo cap) → reject.
-
-Your primary model handles architecture. Cheaper models handle boilerplate. `extract_lessons` uses workers to batch-extract lessons from session notes — saving your primary model's tokens.
+Your primary model handles architecture. Cheaper models handle boilerplate. `capture_lesson(text=...)` uses workers to batch-extract lessons from session notes — saving your primary model's tokens.
 
 ## Before / After
 
@@ -163,8 +149,19 @@ claude mcp add -s user hive \
 | `HIVE_OPENROUTER_PAID_MODEL` | `qwen/qwen3-coder` | Paid tier model |
 | `HIVE_OPENROUTER_BUDGET` | `1.0` | Monthly budget cap (USD) |
 | `HIVE_VAULT_SCOPES` | `{"projects": "10_projects", "meta": "00_meta"}` | JSON mapping of scope names to vault subdirectories |
+| `HIVE_LOG_PATH` | `~/.local/share/hive/hive.log` | Persistent debug log (1MB rotating, 1 backup) |
 
-See [full configuration reference](https://mlorentedev.github.io/hive/configuration/) for all 15 environment variables.
+See [full configuration reference](https://mlorentedev.github.io/hive/configuration/) for all 16 environment variables including advanced tuning.
+
+### Debug Logging
+
+Hive writes warnings and errors to a persistent log file for post-mortem debugging:
+
+```
+~/.local/share/hive/hive.log
+```
+
+Check this file when tools return unexpected results or the server fails silently. The log rotates at 1MB with one backup file. Override the path with `HIVE_LOG_PATH`.
 
 ## Recommended Workflow
 
@@ -238,16 +235,17 @@ Without these instructions, your assistant uses Hive inconsistently. With them, 
 ```
 MCP Host (Claude Code, Gemini CLI, Codex CLI, Cursor, ...)
     └── hive-vault (MCP server, stdio)
-            ├── Vault Tools (16) ── Obsidian vault (Markdown + YAML frontmatter)
-            │     query, search, smart_search, list_files, patch,
-            │     update, create, capture_lesson, extract_lessons,
-            │     summarize, validate, session_briefing, recent,
-            │     usage, health, list_projects
+            ├── Vault Tools (7) ── Obsidian vault (Markdown + YAML frontmatter)
+            │     query, search, list, health, write, patch,
+            │     capture_lesson
             │
-            └── Worker Tools (3) ── Task delegation + routing:
+            ├── Session Tools (1) ── Adaptive context assembly
+            │     session_briefing
+            │
+            └── Worker Tools (2) ── Task delegation + routing:
                   delegate_task        1. Ollama (local, free)
-                  list_models          2. OpenRouter free tier
-                  worker_status        3. OpenRouter paid ($1/mo cap)
+                  worker_status        2. OpenRouter free tier
+                                       3. OpenRouter paid ($1/mo cap)
                                        4. Reject → host handles it
 ```
 
@@ -259,7 +257,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, code standards, and PR workflo
 git clone https://github.com/mlorentedev/hive.git
 cd hive
 make install   # create venv + install deps
-make check     # lint + typecheck + test (265 tests, 92% coverage)
+make check     # lint + typecheck + test (324 tests, 91% coverage)
 ```
 
 ## License

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -64,9 +64,9 @@ The `--upgrade` flag ensures you always get the latest version from PyPI on each
 
 Once registered, your AI assistant can use Hive tools. Try asking:
 
-> "Use vault_list_projects to see my vault"
+> "Use vault_list to see my vault"
 
-The assistant will call `vault_list_projects()` and list all projects with file counts and available shortcuts.
+The assistant will call `vault_list()` and list all projects with file counts and available shortcuts.
 
 ## Configure Vault Path
 

--- a/site/src/content/docs/guides/benchmarks.md
+++ b/site/src/content/docs/guides/benchmarks.md
@@ -58,7 +58,7 @@ Real vault (493K tokens): 5 project context queries consumed 2,925 tokens total,
 | Tool | S/N ratio | Best for |
 |---|---|---|
 | vault_search | 98.8% | Targeted queries -- minimal noise |
-| vault_smart_search | 98.4% | Ranked search results |
+| vault_search (ranked) | 98.4% | Ranked search results |
 | vault_query | 87-90% | Full section reads |
 | session_briefing | 78.5% | Cold start context assembly |
 

--- a/site/src/content/docs/guides/prompts.md
+++ b/site/src/content/docs/guides/prompts.md
@@ -15,7 +15,7 @@ End-of-session review that extracts lessons and appends them to the vault.
 1. Review work completed in the current session
 2. Identify patterns, mistakes, and insights
 3. Format as structured lessons
-4. Use `vault_update` to append to the project's `90-lessons.md`
+4. Use `vault_write` to append to the project's `90-lessons.md`
 
 **Usage**: Ask your assistant to "run a retrospective for my-project" at the end of a work session.
 
@@ -55,7 +55,7 @@ Estimate token savings from hive MCP tools in the current session.
 **Parameters**: none
 
 **Protocol**:
-1. Call `vault_usage` to get tool call statistics
+1. Call `vault_health(include_usage=True)` to get tool call statistics
 2. Estimate tokens that would have been consumed by static loading
 3. Calculate savings percentage
 4. Report results

--- a/site/src/content/docs/guides/troubleshooting.md
+++ b/site/src/content/docs/guides/troubleshooting.md
@@ -61,9 +61,9 @@ MCP servers do **not** inherit your shell's environment variables. Every env var
 
 **Fix:** Exit and restart your AI assistant session (e.g., restart Claude Code, start a new Gemini CLI session).
 
-## vault_list_projects Returns Empty
+## vault_list Returns Empty
 
-**Symptom:** `vault_list_projects` shows no projects.
+**Symptom:** `vault_list` shows no projects.
 
 **Cause:** Either `VAULT_PATH` doesn't point to the right directory, or your vault layout doesn't match the configured scopes.
 
@@ -87,7 +87,7 @@ See [Vault Structure](/hive/guides/vault-structure/) for layout details.
 - Typo in the project name (it must match the directory name exactly)
 - The scope directory itself doesn't exist
 
-**Fix:** Run `vault_list_projects` to see what Hive can find. If your project isn't listed, check your `HIVE_VAULT_SCOPES` configuration.
+**Fix:** Run `vault_list` to see what Hive can find. If your project isn't listed, check your `HIVE_VAULT_SCOPES` configuration.
 
 ## Gemini CLI: MCP Registration Syntax
 
@@ -113,9 +113,9 @@ gemini mcp add -s user \
 - `-s user` installs at user scope (persists across projects)
 - Environment variable values are expanded immediately (not stored as references)
 
-## vault_update Rejects My Content
+## vault_write Rejects My Content
 
-**Symptom:** `vault_update` with `operation="replace"` returns a validation error.
+**Symptom:** `vault_write` with `operation="replace"` returns a validation error.
 
 **Cause:** When replacing an entire file, Hive validates that YAML frontmatter includes required fields: `id`, `type`, and `status`.
 
@@ -143,11 +143,30 @@ Or use `operation="append"` to add content without replacing frontmatter.
 
 Both use WAL mode for performance. If sizes seem excessive, you can safely delete them — Hive recreates them automatically. Budget tracking resets on deletion.
 
+## Checking the Debug Log
+
+Hive writes warnings and errors to a persistent log file for post-mortem debugging:
+
+```
+~/.local/share/hive/hive.log
+```
+
+Check this file when tools return unexpected results or the server fails silently. The log rotates at 1MB with one backup file (`hive.log.1`).
+
+To change the log location:
+
+```bash
+claude mcp add -s user hive \
+  -e HIVE_LOG_PATH=/path/to/custom.log \
+  -- uvx --upgrade hive-vault
+```
+
 ## Getting Help
 
 If your issue isn't listed here:
 
 1. Run `vault_health` to check vault connectivity and file counts
 2. Run `worker_status` to check provider connectivity and budget
-3. Check the [Configuration](/hive/configuration/) page for all environment variables
-4. Open an issue at [github.com/mlorentedev/hive](https://github.com/mlorentedev/hive/issues)
+3. Check `~/.local/share/hive/hive.log` for error details
+4. Check the [Configuration](/hive/configuration/) page for all environment variables
+5. Open an issue at [github.com/mlorentedev/hive](https://github.com/mlorentedev/hive/issues)

--- a/site/src/content/docs/guides/use-cases.md
+++ b/site/src/content/docs/guides/use-cases.md
@@ -42,7 +42,7 @@ When you need the most relevant results, not just keyword matches:
 > "Find the most relevant docs about deployment"
 
 ```python
-vault_smart_search(query="deployment", max_results=5)
+vault_search(query="deployment", ranked=True, max_results=5)
 ```
 
 Results are ranked by: active > draft > archived, recent > old, and match density. The most useful documents surface first.
@@ -54,7 +54,7 @@ After solving a tricky bug or making an architecture decision:
 > "Append this lesson to the vault: Always use WAL mode for SQLite in async contexts"
 
 ```python
-vault_update(
+vault_write(
     project="my-project",
     section="lessons",
     operation="append",
@@ -71,10 +71,11 @@ Start a new ADR, runbook, or any document:
 > "Create an ADR for choosing PostgreSQL over MySQL"
 
 ```python
-vault_create(
+vault_write(
     project="my-project",
     path="30-architecture/adr-005-postgresql.md",
     content="# ADR-005: PostgreSQL over MySQL\n\n## Context\n...",
+    operation="create",
     doc_type="adr"
 )
 ```
@@ -91,7 +92,7 @@ When you discover something important mid-task, capture it immediately without b
 capture_lesson(
     project="my-project",
     title="YAML frontmatter validation",
-    context="Writing a vault_update tool that modifies project files",
+    context="Writing a vault_write tool that modifies project files",
     problem="Missing required fields (id, type, status) cause silent failures in downstream tools like vault_search and session_briefing",
     solution="Always validate frontmatter before vault writes — reject if required fields are missing",
     tags=["yaml", "vault", "validation"]
@@ -109,7 +110,7 @@ After a long debugging session or architecture discussion, extract multiple less
 > "Extract lessons from these session notes about the database migration"
 
 ```python
-extract_lessons(
+capture_lesson(
     project="my-project",
     text="We discovered the migration failed because...[paste session notes]...",
     min_confidence=0.7,
@@ -119,9 +120,9 @@ extract_lessons(
 
 This sends the text to a worker model (Ollama or OpenRouter) which identifies decisions, bug root causes, and pattern choices — then writes them to `90-lessons.md`. Your primary model saves tokens by not processing the raw text itself.
 
-**When to use `capture_lesson` vs `extract_lessons`:**
-- `capture_lesson`: You know the exact lesson — structured input, single lesson
-- `extract_lessons`: You have raw text and want the worker to find lessons — batch extraction
+**When to use inline vs batch:**
+- **Inline** (`capture_lesson` with title/problem/solution): You know the exact lesson — structured input, single lesson
+- **Batch** (`capture_lesson` with `text=...`): You have raw text and want the worker to find lessons — batch extraction
 
 ## Delegating Trivial Tasks
 
@@ -169,7 +170,7 @@ Find broken frontmatter, stale docs, and dead links before they cause problems:
 > "Validate my vault for issues"
 
 ```python
-vault_validate(project="my-project")
+vault_health(project="my-project", checks=["frontmatter", "stale", "links"])
 ```
 
 Returns categorized issues: missing frontmatter fields, files that haven't been updated in 180+ days, and `[[wikilinks]]` pointing to nonexistent files. Run it after shipping a feature to catch documentation that drifted from reality.
@@ -177,7 +178,7 @@ Returns categorized issues: missing frontmatter fields, files that haven't been 
 You can also target specific checks:
 
 ```python
-vault_validate(checks=["stale"])  # Only flag stale files across all projects
+vault_health(checks=["stale"])  # Only flag stale files across all projects
 ```
 
 ## Monitoring Token Savings
@@ -186,7 +187,7 @@ Curious how much Hive is saving you?
 
 > "Run a benchmark"
 
-The `benchmark` prompt checks `vault_usage` and estimates how many tokens would have been consumed by static context loading vs. on-demand queries.
+The `benchmark` prompt checks `vault_health(include_usage=True)` and estimates how many tokens would have been consumed by static context loading vs. on-demand queries.
 
 ## Checking Recent Vault Changes
 
@@ -195,7 +196,7 @@ See what's been updated in your vault recently:
 > "Show vault changes from the last 7 days"
 
 ```python
-vault_recent(since_days=7, project="my-project")
+vault_search(since_days=7, project="my-project")
 ```
 
 Combines git history with frontmatter dates to surface all recent activity.

--- a/site/src/content/docs/guides/vault-structure.md
+++ b/site/src/content/docs/guides/vault-structure.md
@@ -100,7 +100,7 @@ vault_query(project="my-app", path="notes/2026-03-01.md")
 
 ## Frontmatter
 
-Hive uses YAML frontmatter for metadata. Required fields for `vault_update` with `operation="replace"`:
+Hive uses YAML frontmatter for metadata. Required fields for `vault_write` with `operation="replace"`:
 
 ```yaml
 ---
@@ -112,14 +112,14 @@ tags: [python, architecture]
 ---
 ```
 
-`vault_create` auto-generates frontmatter — you only need to provide the body content.
+`vault_write(operation="create")` auto-generates frontmatter — you only need to provide the body content.
 
 ## Git Integration
 
-All write operations (`vault_update`, `vault_create`, `vault_patch`, `capture_lesson`) auto-commit to git. This ensures:
+All write operations (`vault_write`, `vault_patch`, `capture_lesson`) auto-commit to git. This ensures:
 
 - Full history of changes
-- `vault_recent` can find recently modified files
+- `vault_search(since_days=N)` can find recently modified files
 - No manual git management needed
 
 Your vault directory must be a git repository. If it isn't, run `git init` in your vault root.

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,8 +25,8 @@ Hive replaces static context with **on-demand vault queries** via the [Model Con
 ## Features
 
 <CardGrid>
-  <Card title="17 Tools" icon="puzzle">
-    Query, search, patch, and list vault content. Delegate tasks to cheaper models. Track usage and budget.
+  <Card title="10 Tools" icon="puzzle">
+    Query, search, write, patch, and list vault content. Delegate tasks to cheaper models. Track health and budget.
   </Card>
   <Card title="5 Resources" icon="document">
     MCP resources for projects, health metrics, context, tasks, and lessons — directly consumable by AI clients.

--- a/site/src/content/docs/reference/architecture.md
+++ b/site/src/content/docs/reference/architecture.md
@@ -17,7 +17,7 @@ description: System architecture and module map.
 │                                                  │
 │  ┌─────────────┐  ┌────────────┐  ┌──────────┐  │
 │  │ Vault Tools  │  │Worker Tools│  │Resources │  │
-│  │ (16 tools)   │  │ (3 tools)  │  │(5 URIs)  │  │
+│  │ (7 tools)    │  │ (2 tools)  │  │(5 URIs)  │  │
 │  └──────┬──────┘  └─────┬──────┘  └──────────┘  │
 │         │               │                        │
 │  ┌──────▼──────┐  ┌─────▼──────┐                 │
@@ -57,7 +57,7 @@ Vault and worker functionality are served from a single FastMCP instance. This s
 
 ### Git Auto-Commit
 
-All vault writes auto-commit to git. This provides full history and enables `vault_recent` to detect changes via `git log`.
+All vault writes auto-commit to git. This provides full history and enables `vault_search(since_days=N)` to detect changes via `git log`.
 
 ### Budget Controls
 

--- a/site/src/content/docs/reference/resources.md
+++ b/site/src/content/docs/reference/resources.md
@@ -61,5 +61,5 @@ Tools are **actions** — they accept parameters, support filtering, and can wri
 |---|---|
 | Load project context | `hive://projects/{project}/context` resource |
 | Search across vault | `vault_search` tool |
-| Update a file | `vault_update` tool |
-| List projects | `hive://projects` resource OR `vault_list_projects` tool |
+| Update a file | `vault_write` tool |
+| List projects | `hive://projects` resource OR `vault_list` tool |

--- a/site/src/content/docs/tools/vault.md
+++ b/site/src/content/docs/tools/vault.md
@@ -1,17 +1,27 @@
 ---
 title: Vault Tools
-description: 16 tools for querying, searching, and managing your Obsidian vault.
+description: 7 tools for querying, searching, and managing your Obsidian vault.
 ---
 
-## vault_list_projects
+## vault_list
 
-List all projects in the Obsidian vault.
+List projects or browse files within a project.
 
 ```python
-vault_list_projects()
+# List all projects
+vault_list()
+
+# Browse files in a project
+vault_list(project="my-project")
+
+# Browse a subdirectory
+vault_list(project="my-project", path="30-architecture")
+
+# Glob pattern filtering
+vault_list(project="my-project", pattern="adr-*")
 ```
 
-Returns project names, file counts, and available section shortcuts.
+Without `project`, lists all vault projects with file counts and shortcuts. With `project`, lists files and directories (directories first, then files). With `pattern`, recursively finds all matching files.
 
 ## vault_query
 
@@ -39,9 +49,10 @@ Use `project="_meta"` to access `00_meta/` (cross-project patterns).
 
 ## vault_search
 
-Full-text search across the vault.
+Full-text search across the vault with optional ranking and recent-changes mode.
 
 ```python
+# Standard keyword search
 vault_search(
     query="authentication",
     max_lines=100,
@@ -50,88 +61,82 @@ vault_search(
     tag_filter="",      # filter by frontmatter tag
     use_regex=False     # treat query as a regular expression
 )
+
+# Ranked search (relevance scoring)
+vault_search(query="deployment", ranked=True, max_results=5)
+
+# Recent changes (last N days)
+vault_search(since_days=7, project="my-project")
 ```
 
-Returns matching lines grouped by file, with metadata headers.
+**Standard mode:** Returns matching lines grouped by file, with metadata headers. When `use_regex=True`, the query is compiled as a Python regular expression (case-insensitive).
 
-When `use_regex=True`, the query is compiled as a Python regular expression (case-insensitive). Invalid regex patterns return an error message.
+**Ranked mode** (`ranked=True`): Scores results by status weight (active > draft > archived), recency, and match density. Returns top results with metadata and matching lines.
+
+**Recent mode** (`since_days > 0`): Combines git history with frontmatter `created` dates to find files changed in the last N days. Optional `project` filter.
 
 ## vault_health
 
-Health metrics for all vault projects.
+Health metrics, drift detection, and usage statistics.
 
 ```python
+# Health report for all projects
 vault_health()
+
+# Validate a specific project
+vault_health(project="my-project", checks=["frontmatter", "stale", "links"], max_issues=50)
+
+# Include usage statistics
+vault_health(include_usage=True, usage_days=30)
 ```
 
-Reports per-project: file count, total lines, stale files (>180 days by default, configurable via `HIVE_STALE_THRESHOLD_DAYS`), section coverage.
+**Health report** (default): Per-project file count, total lines, stale files (>180 days, configurable via `HIVE_STALE_THRESHOLD_DAYS`), section coverage.
 
-## vault_validate
-
-Drift detector — validate vault files for common issues.
-
-```python
-vault_validate(project="my-project", checks=["frontmatter", "stale", "links"], max_issues=50)
-```
-
-| Parameter | Default | Description |
-|---|---|---|
-| `project` | `""` (all) | Project to validate. Empty scans all projects |
-| `checks` | `[]` (all) | Which checks to run: `frontmatter`, `stale`, `links` |
-| `max_issues` | `50` | Maximum issues to report |
-
-**Checks:**
+**Validation** (`checks` parameter): Drift detector for common issues:
 - **frontmatter**: Missing or malformed YAML frontmatter, missing required fields (id, type, status), unparseable dates
 - **stale**: Active files not modified in `HIVE_STALE_THRESHOLD_DAYS` (default 180)
 - **links**: Broken `[[wikilinks]]` pointing to nonexistent files
 
 Issues are categorized as `[error]` or `[warning]` with file path and description.
 
-## vault_update
+**Usage stats** (`include_usage=True`): Tool call counts by tool and project, with estimated token savings.
 
-Write to an existing vault file with validation.
+## vault_write
+
+Create, append, or replace vault files with validation and auto git commit.
 
 ```python
-vault_update(
+# Append to an existing file
+vault_write(
     project="my-project",
     section="lessons",
-    operation="append",   # append | replace
-    content="New lesson learned..."
+    content="New lesson learned...",
+    operation="append"      # default
 )
-```
 
-- **append**: adds content to the end
-- **replace**: requires valid YAML frontmatter in the new content
-- Auto-commits to git after successful write
+# Replace an entire file (requires valid frontmatter)
+vault_write(
+    project="my-project",
+    section="context",
+    content="---\nid: my-project\ntype: project\nstatus: active\n---\n\nNew content.",
+    operation="replace"
+)
 
-## vault_create
-
-Create a new file with auto-generated frontmatter.
-
-```python
-vault_create(
+# Create a new file with auto-generated frontmatter
+vault_write(
     project="my-project",
     path="30-architecture/adr-005.md",
-    content="# ADR-005: ...",
-    doc_type="adr"    # used in generated frontmatter
+    content="# ADR-005: PostgreSQL\n\n## Context\n...",
+    operation="create",
+    doc_type="adr"          # used in generated frontmatter
 )
 ```
 
-Generates YAML frontmatter with `id`, `type`, `status: draft`, `created: today`. Auto-commits to git.
+- **append**: Adds content to the end of an existing file
+- **replace**: Replaces the entire file. Requires valid YAML frontmatter with `id`, `type`, `status`
+- **create**: Creates a new file. Auto-generates frontmatter with `id`, `type`, `status: draft`, `created: today`
 
-## vault_list_files
-
-List files and directories in a vault project.
-
-```python
-vault_list_files(
-    project="my-project",
-    path="",           # subdirectory (relative to project root)
-    pattern=""         # glob pattern for recursive filtering (e.g. 'adr-*', '*.md')
-)
-```
-
-Without `pattern`, lists the immediate contents of the directory (directories first, then files). With `pattern`, recursively finds all matching files.
+All operations auto-commit to git.
 
 ## vault_patch
 
@@ -150,9 +155,10 @@ Replaces exactly one occurrence of `old_text` with `new_text`. Rejects ambiguous
 
 ## capture_lesson
 
-Capture a lesson learned inline during a session.
+Capture lessons inline or batch-extract from text using a worker.
 
 ```python
+# Inline capture (structured, single lesson)
 capture_lesson(
     project="my-project",
     title="Root cause was stale cache",
@@ -161,90 +167,18 @@ capture_lesson(
     solution="Clear Redis cache after config changes",
     tags=["deploy", "cache"]    # optional
 )
-```
 
-Appends a structured entry to `90-lessons.md` with date, context, problem, and solution. Creates the file with frontmatter if it doesn't exist. Deduplicates by title. Auto-commits to git.
-
-**When to use:** Immediately after discovering a bug root cause, architectural insight, or debugging trick — don't wait until session end.
-
-## extract_lessons
-
-Batch-extract lessons from raw text using a worker model.
-
-```python
-extract_lessons(
+# Batch extraction (worker-powered, multiple lessons)
+capture_lesson(
     project="my-project",
     text="We found that the cache was stale after deploy...",
-    min_confidence=0.7,   # 0.0-1.0, filter low-confidence extractions
-    max_lessons=5          # cap on lessons extracted
+    min_confidence=0.7,
+    max_lessons=5
 )
 ```
 
-Sends the text to a worker model (Ollama/OpenRouter) which extracts structured lessons (title, context, problem, solution, tags, confidence). Lessons above the confidence threshold are written to `90-lessons.md` with deduplication.
+**Inline mode** (no `text`): Appends a structured entry to `90-lessons.md` with date, context, problem, and solution. Creates the file with frontmatter if it doesn't exist. Deduplicates by title. Auto-commits to git.
 
-**Why use this instead of `capture_lesson`?** `capture_lesson` requires you to structure each lesson manually. `extract_lessons` sends raw text to a cheaper model that does the structuring — saving your primary model's tokens on bulk extraction.
+**Batch mode** (`text` provided): Sends the text to a worker model (Ollama/OpenRouter) which extracts structured lessons (title, context, problem, solution, tags, confidence). Lessons above the confidence threshold are written to `90-lessons.md` with deduplication.
 
-Returns a summary: which lessons were written, which were skipped (duplicates or low confidence).
-
-## vault_summarize
-
-Smart summarization for vault files.
-
-```python
-vault_summarize(
-    project="my-project",
-    section="context",
-    path="",
-    max_summary_lines=50
-)
-```
-
-- Files under the threshold are returned directly
-- Large files return a delegation prompt for the worker to summarize
-
-## vault_smart_search
-
-Ranked search with relevance scoring.
-
-```python
-vault_smart_search(
-    query="deployment",
-    max_results=10,
-    max_lines=200
-)
-```
-
-Scores results by: status weight (active > draft > archived), recency, and match density. Returns top results with metadata and matching lines.
-
-## session_briefing
-
-One-call context load for starting a session.
-
-```python
-session_briefing(project="my-project")
-```
-
-Returns combined: active tasks, recent lessons, git log (last 10 commits), and health metrics.
-
-## vault_recent
-
-Files changed in the vault recently.
-
-```python
-vault_recent(
-    since_days=7,
-    project=""      # optional filter
-)
-```
-
-Combines git history with frontmatter `created` dates to find recent activity.
-
-## vault_usage
-
-Tool usage analytics for the current session.
-
-```python
-vault_usage(since_days=30)
-```
-
-Returns call counts by tool and project, with estimated token savings.
+**When to use:** Immediately after discovering a bug root cause, architectural insight, or debugging trick — don't wait until session end.

--- a/site/src/content/docs/tools/worker.md
+++ b/site/src/content/docs/tools/worker.md
@@ -1,29 +1,43 @@
 ---
 title: Worker Tools
-description: 3 tools for delegating tasks to cheaper models with automatic routing.
+description: 2 tools for delegating tasks to cheaper models with automatic routing.
 ---
 
 ## delegate_task
 
-Route a task to a cheaper model with automatic tier selection.
+Route a task to a cheaper model, or summarize vault files automatically.
 
 ```python
+# Task delegation
 delegate_task(
     prompt="Explain this regex: ^(?:[a-z0-9]+\.)*[a-z0-9]+$",
     context="",              # optional context to include
     max_cost_per_request=0,  # 0 = free models only
     model=""                 # explicit model override
 )
+
+# Vault file summarization
+delegate_task(
+    project="my-project",
+    section="context",       # or use path="..."
+    max_summary_lines=20     # target summary length
+)
 ```
 
-### Routing Tiers
+### Task Delegation
 
-When no explicit model is specified, tasks are routed through tiers in order:
+When `prompt` is provided, tasks are routed through tiers in order:
 
 1. **Ollama** (local) — Free. Best for trivial tasks. Falls through if unavailable.
 2. **OpenRouter free** — Free tier models (e.g., Qwen3 Coder 480B). Real code work.
 3. **OpenRouter paid** — Only when `max_cost_per_request > 0` and monthly budget allows. Model configurable via `HIVE_OPENROUTER_PAID_MODEL`.
 4. **Reject** — Returns error so the host handles the task directly.
+
+### Vault Summarization
+
+When `project` is provided, reads a vault file:
+- **Small files** (≤50 lines): returned directly with metadata
+- **Large files** (>50 lines): auto-delegated to a worker for summarization. Falls back to raw content if workers are unavailable.
 
 ### Explicit Model Selection
 
@@ -48,22 +62,16 @@ Each response includes a metadata footer:
 [model: qwen2.5-coder:7b | provider: ollama | cost: $0.00 | latency: 2.1s]
 ```
 
-## list_models
-
-List available models across all providers.
-
-```python
-list_models()
-```
-
-Shows configured models for Ollama and OpenRouter, with connectivity status.
-
 ## worker_status
 
-Show worker health and budget information.
+Show worker health, budget, and available models.
 
 ```python
+# Full status with model listing
 worker_status()
+
+# Status without model listing
+worker_status(include_models=False)
 ```
 
 Returns:
@@ -71,3 +79,4 @@ Returns:
 - Ollama connectivity status
 - OpenRouter connectivity status
 - Request counts and cost breakdown
+- Available models across all providers (when `include_models=True`)

--- a/src/hive/relevance.py
+++ b/src/hive/relevance.py
@@ -49,7 +49,7 @@ class RelevanceTracker:
     ) -> None:
         """Record a section access, updating EMA score.
 
-        Write operations (vault_update, vault_create) get a boosted signal.
+        Write operations (vault_write) get a boosted signal.
         """
         signal = self._alpha * (_WRITE_MULTIPLIER if is_write else 1.0)
         row = self._conn.execute(

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -33,7 +33,6 @@ from hive.usage import UsageTracker
 
 _log = logging.getLogger(__name__)
 
-_VALID_OPERATIONS = {"append", "replace"}
 _REJECT_MSG = "The host should handle this task directly."
 
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, idempotentHint=True)
@@ -204,28 +203,6 @@ def _format_response(resp: ClientResponse) -> str:
     return f"{header}\n\n{resp.text}"
 
 
-def _build_delegation_prompt(
-    meta: str, body: str, line_count: int, max_summary_lines: int
-) -> str:
-    """Build a structured prompt for delegating summarization to the worker."""
-    parts = ["## Summarization Request", ""]
-    if meta:
-        parts.append(f"**Metadata:** {meta}")
-    parts.append(f"**Source length:** {line_count} lines")
-    parts.append(f"**Target length:** {max_summary_lines} lines")
-    parts.extend([
-        "",
-        "### Suggested `delegate_task` parameters",
-        f'- task: "Summarize the following document in at most {max_summary_lines} lines, '
-        'preserving key decisions and action items."',
-        "- max_tokens: 2000",
-        "",
-        "### Document body",
-        "",
-        body,
-    ])
-    return "\n".join(parts)
-
 
 def _score_file(match_count: int, fm: Frontmatter | None, today: date) -> float:
     """Score a file for smart search ranking."""
@@ -286,16 +263,18 @@ def create_server(
             "filesystem access. Supports section shortcuts (context, tasks, "
             "roadmap, lessons) and arbitrary paths.\n"
             "- **Finding information:** Use `vault_search` for keyword/regex "
-            "lookup with filters. Use `vault_smart_search` when you need "
-            "results ranked by relevance.\n"
+            "lookup with filters. Add `ranked=True` for relevance-ranked "
+            "results, or `since_days=N` for recent changes.\n"
             "- **Recording lessons:** Call `capture_lesson` when a bug fix, "
             "architectural decision, or useful insight emerges during work. "
-            "Use `extract_lessons` for bulk extraction from large text blocks.\n"
+            "Use `capture_lesson(text=...)` for bulk extraction from large "
+            "text blocks.\n"
             "- **Offloading work:** Use `delegate_task` for summarization, "
-            "boilerplate generation, or analysis that doesn't need the host's "
-            "full capability.\n"
-            "- **Checking vault health:** Call `vault_validate` after modifying "
-            "vault files or periodically to detect drift.\n\n"
+            "boilerplate generation, or analysis. Use "
+            "`delegate_task(project=...)` to summarize vault files.\n"
+            "- **Checking vault health:** Call `vault_health` after modifying "
+            "vault files or periodically to detect drift. Add "
+            "`include_usage=True` for usage statistics.\n\n"
             "Read-only tools are safe to call freely. "
             "Write tools auto-commit to git."
         ),
@@ -307,7 +286,7 @@ def create_server(
         """Log a tool call and return the result unchanged."""
         tracker.log_call(tool, project, len(result.splitlines()))
         if project and section:
-            is_write = tool in {"vault_update", "vault_create"}
+            is_write = tool == "vault_write"
             relevance.record_access(project, section, is_write=is_write)
         return result
 
@@ -353,7 +332,10 @@ def create_server(
                 continue
             created_date = parse_date(fm.created) if fm is not None else None
             if created_date is None:
-                created_date = date.fromtimestamp(f.stat().st_mtime)
+                try:
+                    created_date = date.fromtimestamp(f.stat().st_mtime)
+                except OSError:
+                    continue
             if created_date < threshold:
                 stale.append(f.relative_to(project_dir).as_posix())
         return stale
@@ -374,11 +356,11 @@ def create_server(
             for project_dir in projects:
                 found_any = True
                 md_files = list(project_dir.rglob("*.md"))
-                total_lines = sum(
-                    len(f.read_text(encoding="utf-8").splitlines())
-                    for f in md_files
-                    if _safe_read(f) is not None
-                )
+                total_lines = 0
+                for f in md_files:
+                    content = _safe_read(f)
+                    if content is not None:
+                        total_lines += len(content.splitlines())
                 stale_files = _count_stale(project_dir, stale_threshold)
                 missing = [
                     s for s, fname in SECTION_SHORTCUTS.items()
@@ -405,7 +387,11 @@ def create_server(
         """Read file text, returning None on error."""
         try:
             return f.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        except UnicodeDecodeError:
+            _log.debug("Skipping non-UTF-8 file: %s", f)
+            return None
+        except OSError as exc:
+            _log.warning("Cannot read file %s: %s", f, exc)
             return None
 
     # ── Resources ────────────────────────────────────────────────────────
@@ -481,7 +467,7 @@ def create_server(
 - Show drafts to the user for approval before writing
 
 ### Step 4 — Append to Vault
-- `vault_update(project="{project}", section="lessons", operation="append", content=<lessons>)`
+- `vault_write(project="{project}", section="lessons", operation="append", content=<lessons>)`
 - Never modify or rewrite existing lessons — append only
 
 ### Step 5 — Report
@@ -526,13 +512,13 @@ If the task is NOT delegatable, say so and handle it directly. Stop here.
 - If budget exhausted or no models available, report and stop
 
 ### Step 3 — Context Compression
-- `vault_summarize(paths=<relevant files>)` if the task needs vault context
+- `delegate_task(project=<slug>, path=<file>)` to summarize relevant vault files
 - Strip the task to its essential instruction — remove conversational context
 - Keep prompt under 2000 tokens
 
 ### Step 4 — Delegate
-- `list_models()` to see available models and pick the appropriate tier
-- `delegate_task(prompt=<compressed task>, task_type=<type>)`
+- `worker_status()` to see available models and pick the appropriate tier
+- `delegate_task(prompt=<compressed task>)`
 - One task per call — never batch
 
 ### Step 5 — Evaluate Result
@@ -590,8 +576,8 @@ Vault Sync Plan:
 **Wait for explicit user approval before proceeding.**
 
 ### Step 5 — Apply Updates
-- Context/tasks: `vault_update(operation="replace", ...)` for factual updates
-- Lessons: `vault_update(operation="append", ...)` for new entries only
+- Context/tasks: `vault_write(operation="replace", ...)` for factual updates
+- Lessons: `vault_write(operation="append", ...)` for new entries only
 - Never delete vault content without explicit user request
 
 ### Step 6 — Verify
@@ -604,7 +590,7 @@ Vault Sync Plan:
 - Use `replace` for context and tasks (factual state)
 - Use `append` for lessons (never modify existing)
 - All content in English
-- One vault_update call per section to minimize git commits"""
+- One vault_write call per section to minimize git commits"""
 
     @mcp.prompt
     def benchmark() -> str:
@@ -616,8 +602,8 @@ Vault Sync Plan:
 
 ### Step 1 — Inventory Tool Usage
 Scan this conversation for all hive MCP tool calls:
-- `vault_query` / `vault_search` / `vault_smart_search` / `vault_summarize` calls
-- `delegate_task` / `worker_status` / `list_models` calls
+- `vault_query` / `vault_search` calls
+- `delegate_task` / `worker_status` calls
 - Count each occurrence and note what was queried
 
 ### Step 2 — Estimate On-Demand Cost
@@ -665,9 +651,65 @@ Total estimated savings: ~C tokens
     # ── Tools ───────────────────────────────────────────────────────────
 
     @mcp.tool(annotations=_READ_ONLY)
-    def vault_list_projects() -> str:
-        """List all projects available in the Obsidian vault."""
-        return _track("vault_list_projects", _list_projects_text())
+    def vault_list(
+        project: str = "",
+        path: str = "",
+        pattern: str = "",
+    ) -> str:
+        """List vault projects, or files within a project.
+
+        When called without arguments, lists all available projects.
+        When called with a project, lists files in that project directory.
+
+        Args:
+            project: Project slug. Empty = list all projects.
+            path: Subdirectory within the project. Empty = project root.
+            pattern: Glob pattern to filter files (e.g. 'adr-*', '*.md').
+        """
+        if not project:
+            return _track("vault_list", _list_projects_text())
+
+        resolved = _resolve_project_dir(resolved_path, project, scopes)
+        if resolved is None:
+            return _track("vault_list",
+                          f"Project '{project}' not found in vault.", project)
+        project_dir, _ = resolved
+
+        target = project_dir / path if path else project_dir
+        boundary_error = _check_path_boundary(target, resolved_path)
+        if boundary_error:
+            return _track("vault_list", boundary_error, project)
+        if not target.is_dir():
+            return _track("vault_list",
+                          f"Path '{path}' not found in project '{project}'.",
+                          project)
+
+        lines: list[str] = [
+            f"# Files: {project}/{path}" if path else f"# Files: {project}",
+            "",
+        ]
+
+        max_list_results = 500
+        if pattern:
+            files = sorted(f for f in target.rglob(pattern) if f.is_file())
+            for f in files[:max_list_results]:
+                rel_f = f.relative_to(target)
+                lines.append(f"- {rel_f}")
+            if len(lines) == 2:
+                return _track(
+                    "vault_list",
+                    f"No files matching '{pattern}' in {project}/{path}.",
+                    project,
+                )
+        else:
+            dirs = sorted(d for d in target.iterdir() if d.is_dir())
+            for d in dirs:
+                lines.append(f"- {d.name}/")
+            files = sorted(f for f in target.iterdir() if f.is_file())
+            for f in files:
+                lines.append(f"- {f.name}")
+
+        return _track("vault_list", "\n".join(lines), project, path)
 
     @mcp.tool(annotations=_READ_ONLY)
     def vault_query(
@@ -709,36 +751,172 @@ Total estimated savings: ~C tokens
 
     @mcp.tool(annotations=_READ_ONLY)
     def vault_search(
-        query: str,
+        query: str = "",
         max_lines: int = 500,
         type_filter: str = "",
         status_filter: str = "",
         tag_filter: str = "",
         use_regex: bool = False,
+        ranked: bool = False,
+        max_results: int = 10,
+        since_days: int = 0,
+        project: str = "",
     ) -> str:
-        """Full-text search across the vault. Use for keyword lookup or filtered queries.
+        """Search the vault: full-text, ranked, or recent changes.
 
-        Prefer vault_smart_search when relevance ranking matters.
+        Default mode: flat full-text search across all vault files.
+        Ranked mode (ranked=True): results scored by relevance.
+        Recent mode (since_days>0): files changed in the last N days.
 
         Args:
-            query: Text to search for (case-insensitive). Supports regex when use_regex=True.
+            query: Text to search for (case-insensitive).
             max_lines: Maximum output lines. Default 500.
-            type_filter: Only include files whose frontmatter type matches (e.g. 'adr').
-            status_filter: Only include files whose frontmatter status matches (e.g. 'active').
-            tag_filter: Only include files that have this tag in their frontmatter tags list.
-            use_regex: Treat query as a regular expression. Default False (literal match).
+            type_filter: Only files whose frontmatter type matches.
+            status_filter: Only files whose frontmatter status matches.
+            tag_filter: Only files that have this frontmatter tag.
+            use_regex: Treat query as regex. Default False.
+            ranked: Score results by relevance. Default False.
+            max_results: Max files when ranked. Default 10.
+            since_days: Show recent changes (0 = disabled). Default 0.
+            project: Filter to this project (recent mode only).
         """
+        # ── Recent mode ──
+        if since_days > 0:
+            git_paths = set(_git_recent(resolved_path, since_days))
+            cutoff = date.today() - timedelta(days=since_days)
+            for md_file in resolved_path.rglob("*.md"):
+                content = _safe_read(md_file)
+                if content is None:
+                    continue
+                fm = parse_frontmatter(content)
+                if fm is None:
+                    continue
+                created = parse_date(fm.created)
+                if created is not None and created >= cutoff:
+                    git_paths.add(
+                        md_file.relative_to(resolved_path).as_posix(),
+                    )
+
+            if project:
+                resolved = _resolve_project_dir(
+                    resolved_path, project, scopes,
+                )
+                if resolved is not None:
+                    prefix = (
+                        resolved[0].relative_to(resolved_path).as_posix()
+                        + "/"
+                    )
+                    git_paths = {
+                        p for p in git_paths if p.startswith(prefix)
+                    }
+                else:
+                    git_paths = set()
+
+            if not git_paths:
+                return _track(
+                    "vault_search",
+                    f"No changes found in the last {since_days} days.",
+                    project,
+                )
+
+            lines: list[str] = [
+                f"# Recent Changes (last {since_days} days)", "",
+            ]
+            for rel_path in sorted(git_paths):
+                full = resolved_path / rel_path
+                if not full.exists():
+                    lines.append(f"- {rel_path} (deleted)")
+                    continue
+                try:
+                    content = full.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    lines.append(f"- {rel_path}")
+                    continue
+                fm = parse_frontmatter(content)
+                meta = _format_metadata(fm)
+                if meta:
+                    lines.append(f"- {rel_path} [{meta}]")
+                else:
+                    lines.append(f"- {rel_path}")
+
+            output = "\n".join(lines)
+            return _track(
+                "vault_search", _truncate(output, max_lines), project,
+            )
+
+        # ── Ranked mode ──
+        if ranked:
+            if not query:
+                return _track(
+                    "vault_search", "Query is required for ranked search.",
+                )
+            query_lower = query.lower()
+            today = date.today()
+            scored: list[tuple[float, str, str, list[str]]] = []
+
+            for md_file in sorted(resolved_path.rglob("*.md")):
+                content = _safe_read(md_file)
+                if content is None:
+                    continue
+                matching = [
+                    ln.strip()
+                    for ln in content.splitlines()
+                    if query_lower in ln.lower()
+                ]
+                if not matching:
+                    continue
+                fm = parse_frontmatter(content)
+                score = _score_file(len(matching), fm, today)
+                rel = md_file.relative_to(resolved_path).as_posix()
+                meta = _format_metadata(fm)
+                scored.append((score, rel, meta, matching))
+
+            if not scored:
+                return _track(
+                    "vault_search",
+                    f"No matches found for '{query}'.",
+                )
+
+            scored.sort(key=lambda x: x[0], reverse=True)
+            scored = scored[:max_results]
+
+            results: list[str] = [
+                f"# Ranked Search: '{query}'", "",
+            ]
+            for score, rel, meta, matching in scored:
+                meta_part = f" [{meta}]" if meta else ""
+                results.append(
+                    f"### {rel} (score: {score:.1f}){meta_part}",
+                )
+                for line in matching[:5]:
+                    results.append(f"  - {line}")
+
+            output = "\n".join(results)
+            return _track(
+                "vault_search", _truncate(output, max_lines),
+            )
+
+        # ── Standard search ──
+        if not query:
+            return _track(
+                "vault_search", "Query is required for search.",
+            )
+
         if use_regex:
             if len(query) > 200:
-                return _track("vault_search",
-                              "Regex pattern too long (max 200 chars).")
+                return _track(
+                    "vault_search",
+                    "Regex pattern too long (max 200 chars).",
+                )
             try:
                 pattern = re.compile(query, re.IGNORECASE)
             except re.error as exc:
-                return _track("vault_search",
-                              f"Invalid regex '{query}': {exc}")
+                return _track(
+                    "vault_search",
+                    f"Invalid regex '{query}': {exc}",
+                )
 
-        results: list[str] = []
+        flat_results: list[str] = []
         query_lower = query.lower()
         has_filters = bool(type_filter or status_filter or tag_filter)
 
@@ -761,324 +939,391 @@ Total estimated savings: ~C tokens
 
             if use_regex:
                 matching_lines = [
-                    line.strip() for line in content.splitlines() if pattern.search(line)
+                    line.strip()
+                    for line in content.splitlines()
+                    if pattern.search(line)
                 ]
             else:
                 matching_lines = [
-                    line.strip() for line in content.splitlines()
+                    line.strip()
+                    for line in content.splitlines()
                     if query_lower in line.lower()
                 ]
             if matching_lines:
-                rel = md_file.relative_to(resolved_path)
+                file_rel = md_file.relative_to(resolved_path)
                 meta_str = _format_metadata(fm)
                 meta = f" [{meta_str}]" if meta_str else ""
-                results.append(f"### {rel}{meta}")
+                flat_results.append(f"### {file_rel}{meta}")
                 for line in matching_lines[:5]:
-                    results.append(f"  - {line}")
+                    flat_results.append(f"  - {line}")
 
-        if not results:
-            return _track("vault_search", f"No matches found for '{query}'.")
+        if not flat_results:
+            return _track(
+                "vault_search", f"No matches found for '{query}'.",
+            )
 
-        output = f"# Search: '{query}'\n\n" + "\n".join(results)
+        output = f"# Search: '{query}'\n\n" + "\n".join(flat_results)
         return _track("vault_search", _truncate(output, max_lines))
-
-    @mcp.tool(annotations=_READ_ONLY)
-    def vault_health() -> str:
-        """Return health metrics for all vault projects."""
-        return _track("vault_health", _health_report_text())
 
     all_checks = frozenset({"frontmatter", "stale", "links"})
     wikilink_re = re.compile(r"\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]")
 
     @mcp.tool(annotations=_READ_ONLY)
-    def vault_validate(
+    def vault_health(
         project: str = "",
         checks: list[str] = [],  # noqa: B006
         max_issues: int = 50,
+        include_usage: bool = False,
+        usage_days: int = 30,
     ) -> str:
-        """Detect vault drift — call after bulk edits or periodically for maintenance.
+        """Return vault health metrics, validation, and optional usage analytics.
 
-        Checks for: missing/incomplete frontmatter, stale active files,
-        and broken wikilinks. Returns a list of issues found.
+        Without parameters, returns a health summary for all projects.
+        When checks are specified, runs drift detection (frontmatter, stale, links).
+        When include_usage is True, appends tool usage analytics.
 
         Args:
             project: Project slug to validate. Empty = all projects.
-            checks: Which checks to run. Empty = all. Options: frontmatter, stale, links.
-            max_issues: Maximum issues to report. Default 50.
-        """
-        active_checks = frozenset(checks) & all_checks if checks else all_checks
+            checks: Validation checks to run. Empty = health summary only. Options: frontmatter, stale, links.
+            max_issues: Maximum validation issues to report. Default 50.
+            include_usage: Append vault tool usage analytics. Default False.
+            usage_days: Usage look-back window in days. Default 30.
+        """  # noqa: E501
+        parts: list[str] = []
 
-        # Collect project dirs to scan
-        project_dirs: list[tuple[Path, str]] = []
-        if project:
-            resolved = _resolve_project_dir(resolved_path, project, scopes)
-            if resolved is None:
-                return _track("vault_validate",
-                              f"Project '{project}' not found in vault.", project)
-            project_dirs.append(resolved)
+        if not checks:
+            # Basic health report
+            parts.append(_health_report_text())
         else:
-            for scope_name, dir_name in scopes.items():
-                if scope_name == "meta":
-                    continue
-                scope_dir = resolved_path / dir_name
-                if not scope_dir.is_dir():
-                    continue
-                for d in sorted(scope_dir.iterdir()):
-                    if d.is_dir():
-                        project_dirs.append((d, scope_name))
+            # Validation mode
+            active_checks = frozenset(checks) & all_checks
+            unknown = frozenset(checks) - all_checks
+            if unknown:
+                valid_names = ", ".join(sorted(all_checks))
+                return _track(
+                    "vault_health",
+                    f"Unknown check(s): {', '.join(sorted(unknown))}. "
+                    f"Valid: {valid_names}",
+                    project,
+                )
 
-        if not project_dirs:
-            return _track("vault_validate", "No projects found in vault.")
+            project_dirs: list[tuple[Path, str]] = []
+            if project:
+                resolved = _resolve_project_dir(
+                    resolved_path, project, scopes,
+                )
+                if resolved is None:
+                    return _track(
+                        "vault_health",
+                        f"Project '{project}' not found in vault.",
+                        project,
+                    )
+                project_dirs.append(resolved)
+            else:
+                for scope_name, dir_name in scopes.items():
+                    if scope_name == "meta":
+                        continue
+                    scope_dir = resolved_path / dir_name
+                    if not scope_dir.is_dir():
+                        continue
+                    for d in sorted(scope_dir.iterdir()):
+                        if d.is_dir():
+                            project_dirs.append((d, scope_name))
 
-        # Build index of all known file stems for wikilink resolution
-        all_stems: set[str] = set()
-        if "links" in active_checks:
-            for pd, _ in project_dirs:
-                for f in pd.rglob("*.md"):
-                    all_stems.add(f.stem)
+            if not project_dirs:
+                return _track(
+                    "vault_health", "No projects found in vault.",
+                )
 
-        issues: list[str] = []
-        stale_threshold = date.today() - timedelta(days=stale_days)
+            all_stems: set[str] = set()
+            if "links" in active_checks:
+                for pd, _ in project_dirs:
+                    for f in pd.rglob("*.md"):
+                        all_stems.add(f.stem)
 
-        for project_dir, _scope_name in project_dirs:
-            proj_name = project_dir.name
-            for f in sorted(project_dir.rglob("*.md")):
-                if len(issues) >= max_issues:
-                    break
-                rel = f.relative_to(project_dir).as_posix()
-                content = _safe_read(f)
-                if content is None:
-                    continue
+            issues: list[str] = []
+            stale_threshold = date.today() - timedelta(days=stale_days)
 
-                fm = parse_frontmatter(content)
-
-                # ── frontmatter checks ──
-                if "frontmatter" in active_checks:
-                    if fm is None:
+            for project_dir, _scope_name in project_dirs:
+                proj_name = project_dir.name
+                for f in sorted(project_dir.rglob("*.md")):
+                    if len(issues) >= max_issues:
+                        break
+                    rel = f.relative_to(project_dir).as_posix()
+                    content = _safe_read(f)
+                    if content is None:
                         issues.append(
                             f"[error] {proj_name}/{rel}: "
-                            "Missing or invalid frontmatter"
+                            "File unreadable (I/O or encoding error)",
                         )
                         continue
-                    missing = {"id", "type", "status"} - fm.raw.keys()
-                    if missing:
-                        issues.append(
-                            f"[error] {proj_name}/{rel}: "
-                            f"Frontmatter missing fields: "
-                            f"{', '.join(sorted(missing))}"
-                        )
-                    if fm.created and parse_date(fm.created) is None:
-                        issues.append(
-                            f"[warning] {proj_name}/{rel}: "
-                            f"Unparseable date: '{fm.created}'"
-                        )
 
-                # ── stale checks ──
-                if (
-                    "stale" in active_checks
-                    and fm is not None
-                    and fm.status not in _TERMINAL_STATUSES
-                ):
-                        created_date = parse_date(fm.created) if fm.created else None
-                        if created_date is None:
-                            try:
-                                created_date = date.fromtimestamp(f.stat().st_mtime)
-                            except OSError:
-                                continue
-                        if created_date < stale_threshold:
+                    fm = parse_frontmatter(content)
+
+                    if "frontmatter" in active_checks:
+                        if fm is None:
+                            issues.append(
+                                f"[error] {proj_name}/{rel}: "
+                                "Missing or invalid frontmatter"
+                            )
+                            continue
+                        missing = {"id", "type", "status"} - fm.raw.keys()
+                        if missing:
+                            issues.append(
+                                f"[error] {proj_name}/{rel}: "
+                                f"Frontmatter missing fields: "
+                                f"{', '.join(sorted(missing))}"
+                            )
+                        if fm.created and parse_date(fm.created) is None:
                             issues.append(
                                 f"[warning] {proj_name}/{rel}: "
-                                f"Stale (active since {created_date.isoformat()}, "
-                                f">{stale_days}d)"
+                                f"Unparseable date: '{fm.created}'"
                             )
 
-                # ── link checks ──
-                if "links" in active_checks:
-                    body = extract_body(content)
-                    for m in wikilink_re.finditer(body):
-                        target = m.group(1).strip()
-                        if target not in all_stems:
-                            issues.append(
-                                f"[warning] {proj_name}/{rel}: "
-                                f"Broken link [[{target}]]"
+                    if (
+                        "stale" in active_checks
+                        and fm is not None
+                        and fm.status not in _TERMINAL_STATUSES
+                    ):
+                            created_date = (
+                                parse_date(fm.created)
+                                if fm.created
+                                else None
                             )
-                            if len(issues) >= max_issues:
-                                break
+                            if created_date is None:
+                                try:
+                                    created_date = date.fromtimestamp(
+                                        f.stat().st_mtime,
+                                    )
+                                except OSError:
+                                    continue
+                            if created_date < stale_threshold:
+                                issues.append(
+                                    f"[warning] {proj_name}/{rel}: "
+                                    f"Stale (active since "
+                                    f"{created_date.isoformat()}, "
+                                    f">{stale_days}d)"
+                                )
 
-            if len(issues) >= max_issues:
-                break
+                    if "links" in active_checks:
+                        body = extract_body(content)
+                        for m in wikilink_re.finditer(body):
+                            target = m.group(1).strip()
+                            if target not in all_stems:
+                                issues.append(
+                                    f"[warning] {proj_name}/{rel}: "
+                                    f"Broken link [[{target}]]"
+                                )
+                                if len(issues) >= max_issues:
+                                    break
 
-        # Build output
-        if not issues:
-            scope_label = f" for '{project}'" if project else ""
-            return _track("vault_validate",
-                          f"Vault clean{scope_label}. "
-                          f"0 issues found ({', '.join(sorted(active_checks))}).")
+                if len(issues) >= max_issues:
+                    break
 
-        errors = sum(1 for i in issues if i.startswith("[error]"))
-        warnings = sum(1 for i in issues if i.startswith("[warning]"))
-        header = f"Found {len(issues)} issues ({errors} errors, {warnings} warnings)"
-        if len(issues) >= max_issues:
-            header += f" — truncated at {max_issues}, more may exist"
-        lines = [header, ""]
-        lines.extend(issues)
-        return _track("vault_validate", "\n".join(lines), project)
+            if not issues:
+                scope_label = f" for '{project}'" if project else ""
+                parts.append(
+                    f"Vault clean{scope_label}. "
+                    f"0 issues found "
+                    f"({', '.join(sorted(active_checks))})."
+                )
+            else:
+                errors = sum(
+                    1 for i in issues if i.startswith("[error]")
+                )
+                warnings = sum(
+                    1 for i in issues if i.startswith("[warning]")
+                )
+                header = (
+                    f"Found {len(issues)} issues "
+                    f"({errors} errors, {warnings} warnings)"
+                )
+                if len(issues) >= max_issues:
+                    header += (
+                        f" — truncated at {max_issues}, more may exist"
+                    )
+                validate_lines = [header, ""]
+                validate_lines.extend(issues)
+                parts.append("\n".join(validate_lines))
+
+        if include_usage:
+            stats = tracker.stats(usage_days)
+            if stats["total_calls"] == 0:
+                parts.append(
+                    f"\nNo vault tool calls recorded "
+                    f"in the last {usage_days} days."
+                )
+            else:
+                usage_parts: list[str] = [
+                    f"\n# Vault Usage (last {usage_days} days)",
+                    "",
+                    f"- Total calls: {stats['total_calls']}",
+                    f"- Total response lines: "
+                    f"{stats['total_response_lines']}",
+                    f"- Estimated tokens served: "
+                    f"~{stats['total_response_lines'] * 10}",
+                    "",
+                ]
+                if stats["by_tool"]:
+                    usage_parts.append("## By Tool")
+                    for tool_name, count in stats["by_tool"].items():
+                        usage_parts.append(f"- {tool_name}: {count} calls")
+                    usage_parts.append("")
+                if stats["by_project"]:
+                    usage_parts.append("## By Project")
+                    for proj, count in stats["by_project"].items():
+                        usage_parts.append(f"- {proj}: {count} calls")
+                parts.append("\n".join(usage_parts))
+
+        return _track("vault_health", "\n".join(parts), project)
+
+    _write_operations = frozenset({"append", "replace", "create"})
 
     @mcp.tool(annotations=_WRITE)
-    def vault_update(
+    def vault_write(
         project: str,
-        section: str,
-        operation: str,
         content: str,
+        operation: str = "append",
+        section: str = "",
+        path: str = "",
+        doc_type: str = "",
     ) -> str:
-        """Update a vault project section with auto git commit.
+        """Write to the vault: append, replace a section, or create a new file.
+
+        Modes:
+        - append/replace: Update a project section. Requires section.
+        - create: Create a new file with auto-generated frontmatter. Requires path and doc_type.
 
         Args:
-            project: Project slug (directory under 10_projects/).
-            section: Section shortcut (context, tasks, roadmap, lessons).
-            operation: 'append' to add content at end, 'replace' to overwrite file.
-            content: The markdown content to write.
-        """
-        if operation not in _VALID_OPERATIONS:
-            return _track("vault_update", (
+            project: Project slug or '_meta' for cross-project content.
+            content: Markdown content to write (body only for create mode).
+            operation: 'append', 'replace', or 'create'. Default 'append'.
+            section: Section shortcut (context, tasks, roadmap, lessons). For append/replace.
+            path: Relative path for new file. For create mode.
+            doc_type: Document type for frontmatter. For create mode.
+        """  # noqa: E501
+        if operation not in _write_operations:
+            return _track("vault_write", (
                 f"Invalid operation '{operation}'. "
-                f"Valid operations: {', '.join(sorted(_VALID_OPERATIONS))}"
+                f"Valid: {', '.join(sorted(_write_operations))}"
             ), project)
 
         resolved = _resolve_project_dir(resolved_path, project, scopes)
         if resolved is None:
-            return _track("vault_update",
-                          f"Project '{project}' not found in vault.", project)
+            return _track(
+                "vault_write",
+                f"Project '{project}' not found in vault.",
+                project,
+            )
         project_dir, _ = resolved
+
+        # ── Create mode ──
+        if operation == "create":
+            if not path:
+                return _track(
+                    "vault_write",
+                    "Path is required for create operation.",
+                    project,
+                )
+            if not doc_type:
+                return _track(
+                    "vault_write",
+                    "doc_type is required for create operation.",
+                    project,
+                )
+
+            filepath = project_dir / path
+            boundary_error = _check_path_boundary(filepath, resolved_path)
+            if boundary_error:
+                return _track("vault_write", boundary_error, project)
+            if filepath.exists():
+                return _track(
+                    "vault_write",
+                    f"File already exists: {path}. "
+                    "Use vault_write(operation='replace') to modify.",
+                    project,
+                )
+
+            frontmatter = _make_frontmatter(filepath.stem, doc_type)
+
+            try:
+                filepath.parent.mkdir(parents=True, exist_ok=True)
+                filepath.write_text(
+                    frontmatter + content, encoding="utf-8",
+                )
+            except OSError as exc:
+                return _track(
+                    "vault_write", f"File I/O error: {exc}", project,
+                )
+
+            rel = filepath.relative_to(resolved_path)
+            display = "00_meta" if project == "_meta" else project
+            _git_commit(
+                resolved_path, rel,
+                f"vault: create {display}/{path}",
+            )
+
+            return _track(
+                "vault_write",
+                f"Created {project}/{path} (type: {doc_type}).",
+                project, path,
+            )
+
+        # ── Append / Replace mode ──
+        if not section:
+            return _track(
+                "vault_write",
+                "Section is required for append/replace operations.",
+                project,
+            )
 
         filename = SECTION_SHORTCUTS.get(section)
         if filename is None:
             available = ", ".join(SECTION_SHORTCUTS)
-            return _track("vault_update",
-                          f"Section '{section}' not found. Available: {available}", project)
+            return _track(
+                "vault_write",
+                f"Section '{section}' not found. Available: {available}",
+                project,
+            )
 
         filepath = project_dir / filename
 
         if operation == "replace":
             error = validate_frontmatter(content)
             if error:
-                return _track("vault_update",
-                              f"Frontmatter validation failed: {error}", project)
+                return _track(
+                    "vault_write",
+                    f"Frontmatter validation failed: {error}",
+                    project,
+                )
 
         try:
             if operation == "append":
-                existing = filepath.read_text(encoding="utf-8") if filepath.exists() else ""
-                filepath.write_text(existing + content, encoding="utf-8")
+                existing = (
+                    filepath.read_text(encoding="utf-8")
+                    if filepath.exists()
+                    else ""
+                )
+                filepath.write_text(
+                    existing + content, encoding="utf-8",
+                )
             else:
                 filepath.write_text(content, encoding="utf-8")
         except OSError as exc:
-            return _track("vault_update",
-                          f"File I/O error: {exc}", project)
+            return _track(
+                "vault_write", f"File I/O error: {exc}", project,
+            )
 
         rel = filepath.relative_to(resolved_path)
-        _git_commit(resolved_path, rel, f"vault: update {project}/{section}")
+        _git_commit(
+            resolved_path, rel, f"vault: update {project}/{section}",
+        )
 
-        return _track("vault_update",
-                       f"Updated {project}/{section} ({operation}).",
-                       project, section)
-
-    @mcp.tool(annotations=_WRITE)
-    def vault_create(
-        project: str,
-        path: str,
-        content: str,
-        doc_type: str,
-    ) -> str:
-        """Create a new file in the vault with auto-generated frontmatter.
-
-        Args:
-            project: Project slug or '_meta' for cross-project content.
-            path: Relative path for the new file (e.g. '30-architecture/adr-002.md').
-            content: Markdown body (frontmatter will be auto-generated).
-            doc_type: Document type for frontmatter (adr, lesson, pattern, troubleshooting, etc.).
-        """
-        resolved = _resolve_project_dir(resolved_path, project, scopes)
-        if resolved is None:
-            return _track("vault_create",
-                          f"Project '{project}' not found in vault.", project)
-        project_dir, _ = resolved
-
-        filepath = project_dir / path
-        boundary_error = _check_path_boundary(filepath, resolved_path)
-        if boundary_error:
-            return _track("vault_create", boundary_error, project)
-        if filepath.exists():
-            return _track("vault_create",
-                          f"File already exists: {path}. Use vault_update to modify it.",
-                          project)
-
-        frontmatter = _make_frontmatter(filepath.stem, doc_type)
-
-        try:
-            filepath.parent.mkdir(parents=True, exist_ok=True)
-            filepath.write_text(frontmatter + content, encoding="utf-8")
-        except OSError as exc:
-            return _track("vault_create",
-                          f"File I/O error: {exc}", project)
-
-        rel = filepath.relative_to(resolved_path)
-        display_project = "00_meta" if project == "_meta" else project
-        _git_commit(resolved_path, rel, f"vault: create {display_project}/{path}")
-
-        return _track("vault_create",
-                       f"Created {project}/{path} (type: {doc_type}).",
-                       project, path)
-
-    @mcp.tool(annotations=_READ_ONLY)
-    def vault_list_files(
-        project: str,
-        path: str = "",
-        pattern: str = "",
-    ) -> str:
-        """List files and directories in a vault project.
-
-        Args:
-            project: Project slug or '_meta' for cross-project content.
-            path: Subdirectory to list (relative to project root). Empty = project root.
-            pattern: Glob pattern to filter files (e.g. 'adr-*', '*.md'). Empty = all.
-        """
-        resolved = _resolve_project_dir(resolved_path, project, scopes)
-        if resolved is None:
-            return _track("vault_list_files",
-                          f"Project '{project}' not found in vault.", project)
-        project_dir, _ = resolved
-
-        target = project_dir / path if path else project_dir
-        boundary_error = _check_path_boundary(target, resolved_path)
-        if boundary_error:
-            return _track("vault_list_files", boundary_error, project)
-        if not target.is_dir():
-            return _track("vault_list_files",
-                          f"Path '{path}' not found in project '{project}'.", project)
-
-        lines: list[str] = [f"# Files: {project}/{path}" if path else f"# Files: {project}", ""]
-
-        max_list_results = 500
-        if pattern:
-            # Recursive glob for pattern matching
-            files = sorted(f for f in target.rglob(pattern) if f.is_file())
-            for f in files[:max_list_results]:
-                rel_f = f.relative_to(target)
-                lines.append(f"- {rel_f}")
-            if len(lines) == 2:
-                return _track("vault_list_files",
-                              f"No files matching '{pattern}' in {project}/{path}.",
-                              project)
-        else:
-            # List directories first, then files
-            dirs = sorted(d for d in target.iterdir() if d.is_dir())
-            for d in dirs:
-                lines.append(f"- {d.name}/")
-            files = sorted(f for f in target.iterdir() if f.is_file())
-            for f in files:
-                lines.append(f"- {f.name}")
-
-        return _track("vault_list_files", "\n".join(lines), project, path)
+        return _track(
+            "vault_write",
+            f"Updated {project}/{section} ({operation}).",
+            project, section,
+        )
 
     @mcp.tool(annotations=_WRITE)
     def vault_patch(
@@ -1252,57 +1497,15 @@ Total estimated savings: ~C tokens
 
         return "written", f"Lesson captured: '{title}' → {project}/90-lessons.md"
 
-    @mcp.tool(annotations=_WRITE)
-    def capture_lesson(
-        project: str,
-        title: str,
-        context: str,
-        problem: str,
-        solution: str,
-        tags: list[str] = [],  # noqa: B006
-    ) -> str:
-        """Capture a lesson when a bug fix, decision, or insight worth preserving emerges.
-
-        Appends a structured lesson to the project's 90-lessons.md file.
-        Deduplicates by title to avoid recording the same lesson twice.
-
-        Args:
-            project: Project slug (directory under 10_projects/).
-            title: Short descriptive title for the lesson.
-            context: What you were doing when this came up.
-            problem: What went wrong or what decision was needed.
-            solution: What fixed it or what was decided.
-            tags: Optional list of tags (e.g. ["python", "testing"]).
-        """
-        resolved = _resolve_project_dir(resolved_path, project, scopes)
-        if resolved is None:
-            return _track("capture_lesson",
-                          f"Project '{project}' not found in vault.", project)
-        project_dir, _ = resolved
-
-        status, msg = _write_lesson(project_dir, project, title, context, problem, solution, tags)
-        if status == "error":
-            return _track("capture_lesson", msg, project)
-        if status == "skipped":
-            return _track("capture_lesson", msg, project, "lessons")
-
-        rel = (project_dir / "90-lessons.md").relative_to(resolved_path)
-        _git_commit(resolved_path, rel, f"vault: capture_lesson {project} — {title}")
-
-        return _track("capture_lesson", msg, project, "lessons")
-
     def _parse_lessons_json(raw: str) -> list[dict[str, object]]:
         """Parse JSON from worker response, stripping markdown fences."""
         text = raw.strip()
-        # Strip markdown code fences
         if text.startswith("```"):
             lines = text.splitlines()
-            # Remove first line (```json) and last line (```)
             inner = "\n".join(
                 ln for ln in lines[1:] if not ln.strip().startswith("```")
             )
             text = inner.strip()
-        # Fallback: extract first [...] block
         if not text.startswith("["):
             match = re.search(r"\[.*\]", text, re.DOTALL)
             if match:
@@ -1329,227 +1532,204 @@ Total estimated savings: ~C tokens
     max_extract_input = 8000  # chars, safe for any worker model
 
     @mcp.tool(annotations=_WRITE)
-    async def extract_lessons(
+    async def capture_lesson(
         project: str,
-        text: str,
+        title: str = "",
+        context: str = "",
+        problem: str = "",
+        solution: str = "",
+        tags: list[str] = [],  # noqa: B006
+        text: str = "",
         min_confidence: float = 0.7,
         max_lessons: int = 5,
     ) -> str:
-        """Batch-extract lessons from large text (e.g. session transcripts) via worker.
+        """Capture lessons: inline (structured fields) or batch (raw text via worker).
 
-        Sends text to a cheaper model (Ollama/OpenRouter) which extracts
-        structured lessons, then writes them to the project's 90-lessons.md.
+        Inline mode (default): provide title, context, problem, solution.
+        Batch mode: provide text to extract lessons automatically via worker.
 
         Args:
             project: Project slug (directory under 10_projects/).
-            text: Raw text to extract lessons from (session notes, debug logs, etc.).
-            min_confidence: Minimum confidence threshold (0.0-1.0). Default 0.7.
-            max_lessons: Maximum lessons to extract. Default 5.
+            title: Short descriptive title (inline mode).
+            context: What you were doing (inline mode).
+            problem: What went wrong or what decision was needed (inline mode).
+            solution: What fixed it or what was decided (inline mode).
+            tags: Optional tags (e.g. ["python", "testing"]).
+            text: Raw text to extract lessons from (batch mode).
+            min_confidence: Minimum confidence for batch extraction. Default 0.7.
+            max_lessons: Maximum lessons to extract in batch mode. Default 5.
         """
         resolved = _resolve_project_dir(resolved_path, project, scopes)
         if resolved is None:
-            return _track("extract_lessons",
-                          f"Project '{project}' not found in vault.", project)
+            return _track(
+                "capture_lesson",
+                f"Project '{project}' not found in vault.",
+                project,
+            )
         project_dir, _ = resolved
 
-        # Truncate input to safe length
-        truncated = text[:max_extract_input]
-        # Escape braces so str.format() doesn't choke on user code/JSON
-        safe_text = truncated.replace("{", "{{").replace("}", "}}")
-        prompt = extract_prompt.format(
-            max_lessons=max_lessons,
-            min_confidence=min_confidence,
-            text=safe_text,
+        # ── Batch mode (worker extraction) ──
+        if text:
+            truncated = text[:max_extract_input]
+            safe_text = truncated.replace("{", "{{").replace("}", "}}")
+            prompt = extract_prompt.format(
+                max_lessons=max_lessons,
+                min_confidence=min_confidence,
+                text=safe_text,
+            )
+
+            errors: list[str] = []
+            resp: ClientResponse | None = None
+
+            if await ollama.is_available():
+                resp, err = await _try_worker(prompt, 2000, "ollama")
+                if resp is None:
+                    errors.append(err)
+            else:
+                errors.append("Ollama: offline")
+
+            if resp is None:
+                resp, err = await _try_worker(
+                    prompt, 2000, "openrouter",
+                )
+                if resp is None:
+                    errors.append(err)
+
+            if resp is None:
+                reasons = (
+                    "; ".join(errors)
+                    if errors
+                    else "no workers configured"
+                )
+                return _track(
+                    "capture_lesson",
+                    f"All workers unavailable [{reasons}]. "
+                    "Cannot extract lessons without a worker model.",
+                    project,
+                )
+
+            try:
+                lessons_raw = _parse_lessons_json(resp.text)
+            except (json.JSONDecodeError, ValueError):
+                snippet = resp.text[:200]
+                return _track(
+                    "capture_lesson",
+                    f"Could not parse worker response as JSON: "
+                    f"{snippet}",
+                    project,
+                )
+
+            if not isinstance(lessons_raw, list):
+                return _track(
+                    "capture_lesson",
+                    "Worker returned non-array JSON.",
+                    project,
+                )
+
+            if not lessons_raw:
+                return _track(
+                    "capture_lesson",
+                    "No lessons found in text.",
+                    project,
+                )
+
+            written: list[str] = []
+            skipped: list[str] = []
+            for lesson in lessons_raw[:max_lessons]:
+                if not isinstance(lesson, dict):
+                    continue
+                raw_title = str(lesson.get("title", "")).strip()
+                l_title = raw_title.replace("\n", " ").replace("\r", " ")
+                if not l_title:
+                    continue
+                try:
+                    confidence = float(
+                        str(lesson.get("confidence", 0.5)),
+                    )
+                except (ValueError, TypeError):
+                    confidence = 0.5
+                if confidence < min_confidence:
+                    skipped.append(
+                        f"{l_title} (confidence {confidence:.1f})",
+                    )
+                    continue
+
+                l_ctx = str(lesson.get("context", "")).replace("\n", " ").replace("\r", " ")
+                l_prob = str(lesson.get("problem", "")).replace("\n", " ").replace("\r", " ")
+                l_sol = str(lesson.get("solution", "")).replace("\n", " ").replace("\r", " ")
+                raw_tags = lesson.get("tags", [])
+                l_tags = [
+                    str(t).replace("\n", " ").replace("\r", " ")
+                    for t in raw_tags
+                ] if isinstance(raw_tags, list) else []
+
+                status, msg = _write_lesson(
+                    project_dir, project,
+                    l_title, l_ctx, l_prob, l_sol, l_tags,
+                )
+                if status == "written":
+                    written.append(l_title)
+                elif status == "skipped":
+                    skipped.append(f"{l_title} (duplicate)")
+                elif status == "error":
+                    _log.warning(
+                        "capture_lesson: failed to write '%s': %s",
+                        l_title, msg,
+                    )
+                    skipped.append(f"{l_title} (write error)")
+
+            if written:
+                rel = (
+                    project_dir / "90-lessons.md"
+                ).relative_to(resolved_path)
+                _git_commit(
+                    resolved_path, rel,
+                    f"vault: capture_lesson {project} "
+                    f"— {len(written)} lessons",
+                )
+
+            parts: list[str] = []
+            if written:
+                titles = ", ".join(written)
+                parts.append(
+                    f"Extracted {len(written)} lessons: {titles}",
+                )
+            if skipped:
+                skip_details = ", ".join(skipped)
+                parts.append(f"Skipped {len(skipped)}: {skip_details}")
+            if not written and not skipped:
+                parts.append("No lessons found in text.")
+
+            summary = ". ".join(parts) + "."
+            return _track(
+                "capture_lesson", summary, project, "lessons",
+            )
+
+        # ── Inline mode ──
+        if not title:
+            return _track(
+                "capture_lesson",
+                "Title is required for inline mode. "
+                "Provide text for batch extraction.",
+                project,
+            )
+
+        status, msg = _write_lesson(
+            project_dir, project,
+            title, context, problem, solution, tags,
+        )
+        if status == "error":
+            return _track("capture_lesson", msg, project)
+        if status == "skipped":
+            return _track("capture_lesson", msg, project, "lessons")
+
+        rel = (project_dir / "90-lessons.md").relative_to(resolved_path)
+        _git_commit(
+            resolved_path, rel,
+            f"vault: capture_lesson {project} — {title}",
         )
 
-        # Send to worker via auto-routing
-        errors: list[str] = []
-        resp: ClientResponse | None = None
-
-        if await ollama.is_available():
-            resp, err = await _try_worker(prompt, 2000, "ollama")
-            if resp is None:
-                errors.append(err)
-        else:
-            errors.append("Ollama: offline")
-
-        if resp is None:
-            resp, err = await _try_worker(prompt, 2000, "openrouter")
-            if resp is None:
-                errors.append(err)
-
-        if resp is None:
-            reasons = "; ".join(errors) if errors else "no workers configured"
-            return _track("extract_lessons",
-                          f"All workers unavailable [{reasons}]. "
-                          "Cannot extract lessons without a worker model.",
-                          project)
-
-        # Parse worker response
-        try:
-            lessons_raw = _parse_lessons_json(resp.text)
-        except (json.JSONDecodeError, ValueError):
-            snippet = resp.text[:200]
-            return _track("extract_lessons",
-                          f"Could not parse worker response as JSON: {snippet}",
-                          project)
-
-        if not isinstance(lessons_raw, list):
-            return _track("extract_lessons",
-                          "Worker returned non-array JSON.", project)
-
-        if not lessons_raw:
-            return _track("extract_lessons", "No lessons found in text.", project)
-
-        # Filter, validate, and write
-        written: list[str] = []
-        skipped: list[str] = []
-        for lesson in lessons_raw[:max_lessons]:
-            if not isinstance(lesson, dict):
-                continue
-            raw_title = str(lesson.get("title", "")).strip()
-            title = raw_title.replace("\n", " ").replace("\r", " ")
-            if not title:
-                continue
-            try:
-                confidence = float(str(lesson.get("confidence", 0.5)))
-            except (ValueError, TypeError):
-                confidence = 0.5
-            if confidence < min_confidence:
-                skipped.append(f"{title} (confidence {confidence:.1f})")
-                continue
-
-            l_context = str(lesson.get("context", "")).replace("\n", " ").replace("\r", " ")
-            l_problem = str(lesson.get("problem", "")).replace("\n", " ").replace("\r", " ")
-            l_solution = str(lesson.get("solution", "")).replace("\n", " ").replace("\r", " ")
-            raw_tags = lesson.get("tags", [])
-            l_tags = [
-                str(t).replace("\n", " ").replace("\r", " ")
-                for t in raw_tags
-            ] if isinstance(raw_tags, list) else []
-
-            status, msg = _write_lesson(
-                project_dir, project, title, l_context, l_problem, l_solution, l_tags,
-            )
-            if status == "written":
-                written.append(title)
-            elif status == "skipped":
-                skipped.append(f"{title} (duplicate)")
-            elif status == "error":
-                _log.warning("extract_lessons: failed to write '%s': %s", title, msg)
-                skipped.append(f"{title} (write error)")
-
-        # Single git commit for all lessons
-        if written:
-            rel = (project_dir / "90-lessons.md").relative_to(resolved_path)
-            _git_commit(resolved_path, rel,
-                        f"vault: extract_lessons {project} — {len(written)} lessons")
-
-        # Build summary
-        parts: list[str] = []
-        if written:
-            titles = ", ".join(written)
-            parts.append(f"Extracted {len(written)} lessons: {titles}")
-        if skipped:
-            skip_details = ", ".join(skipped)
-            parts.append(f"Skipped {len(skipped)}: {skip_details}")
-        if not written and not skipped:
-            parts.append("No lessons found in text.")
-
-        summary = ". ".join(parts) + "."
-        return _track("extract_lessons", summary, project, "lessons")
-
-    @mcp.tool(annotations=_READ_ONLY)
-    def vault_summarize(
-        project: str,
-        section: str = "context",
-        path: str = "",
-        max_summary_lines: int = 20,
-    ) -> str:
-        """Get a file summary or a delegation prompt for large files.
-
-        Small files (≤50 lines) are returned directly with metadata.
-        Large files (>50 lines) return a structured prompt to pass to delegate_task.
-
-        Args:
-            project: Project slug or '_meta'.
-            section: Shortcut name. Ignored if path is set.
-            path: Relative path to a .md file. Overrides section.
-            max_summary_lines: Target summary length for delegation prompt.
-        """
-        result = _resolve_file(resolved_path, project, section, path, scopes)
-        if isinstance(result, str):
-            return _track("vault_summarize", result, project)
-        filepath = result
-
-        try:
-            content = filepath.read_text(encoding="utf-8")
-        except OSError as exc:
-            return _track("vault_summarize",
-                          f"File I/O error: {exc}", project)
-        fm = parse_frontmatter(content)
-        body = extract_body(content)
-        line_count = len(content.splitlines())
-        meta = _format_metadata(fm)
-
-        if line_count <= _SUMMARIZE_THRESHOLD:
-            header = f"**Metadata:** {meta}\n\n" if meta else ""
-            return _track("vault_summarize", f"{header}{content}", project)
-
-        return _track("vault_summarize",
-                       _build_delegation_prompt(meta, body, line_count, max_summary_lines),
-                       project)
-
-    @mcp.tool(annotations=_READ_ONLY)
-    def vault_smart_search(
-        query: str,
-        max_results: int = 10,
-        max_lines: int = 500,
-    ) -> str:
-        """Ranked full-text search — use when relevance ordering matters.
-
-        Results are scored by match density, status weight, and recency.
-        Prefer over vault_search when you need the most relevant matches first.
-
-        Args:
-            query: Text to search for (case-insensitive).
-            max_results: Maximum number of files to return. Default 10.
-            max_lines: Maximum output lines. Default 500.
-        """
-        query_lower = query.lower()
-        today = date.today()
-        scored: list[tuple[float, str, str, list[str]]] = []
-
-        for md_file in sorted(resolved_path.rglob("*.md")):
-            content = _safe_read(md_file)
-            if content is None:
-                continue
-
-            matching = [ln.strip() for ln in content.splitlines() if query_lower in ln.lower()]
-            if not matching:
-                continue
-
-            fm = parse_frontmatter(content)
-            score = _score_file(len(matching), fm, today)
-            rel = md_file.relative_to(resolved_path).as_posix()
-            meta = _format_metadata(fm)
-            scored.append((score, rel, meta, matching))
-
-        if not scored:
-            return _track("vault_smart_search", f"No matches found for '{query}'.")
-
-        scored.sort(key=lambda x: x[0], reverse=True)
-        scored = scored[:max_results]
-
-        results: list[str] = [f"# Smart Search: '{query}'", ""]
-        for score, rel, meta, matching in scored:
-            meta_part = f" [{meta}]" if meta else ""
-            results.append(f"### {rel} (score: {score:.1f}){meta_part}")
-            for line in matching[:5]:
-                results.append(f"  - {line}")
-
-        output = "\n".join(results)
-        return _track("vault_smart_search", _truncate(output, max_lines))
+        return _track("capture_lesson", msg, project, "lessons")
 
     @mcp.tool(annotations=_READ_ONLY)
     def session_briefing(project: str) -> str:
@@ -1628,100 +1808,6 @@ Total estimated savings: ~C tokens
 
         return _track("session_briefing", "\n".join(parts), project)
 
-    @mcp.tool(annotations=_READ_ONLY)
-    def vault_recent(since_days: int = 7, project: str = "", max_lines: int = 100) -> str:
-        """Show files changed in the vault in the last N days.
-
-        Combines git history with frontmatter created dates for completeness.
-
-        Args:
-            since_days: Look back window in days. Default 7.
-            project: Filter to this project only. Empty = all projects.
-        """
-        # Source 1: git-tracked changes
-        git_paths = set(_git_recent(resolved_path, since_days))
-
-        # Source 2: frontmatter created dates within window
-        cutoff = date.today() - timedelta(days=since_days)
-        for md_file in resolved_path.rglob("*.md"):
-            content = _safe_read(md_file)
-            if content is None:
-                continue
-            fm = parse_frontmatter(content)
-            if fm is None:
-                continue
-            created = parse_date(fm.created)
-            if created is not None and created >= cutoff:
-                git_paths.add(md_file.relative_to(resolved_path).as_posix())
-
-        # Filter to project if specified
-        if project:
-            resolved = _resolve_project_dir(resolved_path, project, scopes)
-            if resolved is not None:
-                prefix = resolved[0].relative_to(resolved_path).as_posix() + "/"
-                git_paths = {p for p in git_paths if p.startswith(prefix)}
-            else:
-                git_paths = set()
-
-        if not git_paths:
-            return _track("vault_recent",
-                          f"No changes found in the last {since_days} days.", project)
-
-        lines: list[str] = [f"# Recent Changes (last {since_days} days)", ""]
-        for rel_path in sorted(git_paths):
-            full = resolved_path / rel_path
-            if not full.exists():
-                lines.append(f"- {rel_path} (deleted)")
-                continue
-            try:
-                content = full.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError):
-                lines.append(f"- {rel_path}")
-                continue
-            fm = parse_frontmatter(content)
-            meta = _format_metadata(fm)
-            if meta:
-                lines.append(f"- {rel_path} [{meta}]")
-            else:
-                lines.append(f"- {rel_path}")
-
-        output = "\n".join(lines)
-        return _track("vault_recent", _truncate(output, max_lines), project)
-
-    @mcp.tool(annotations=_READ_ONLY)
-    def vault_usage(since_days: int = 30) -> str:
-        """Show vault tool usage analytics.
-
-        Reports call frequency, popular tools, popular projects, and total
-        response lines served — useful for session profiling and benchmarking.
-
-        Args:
-            since_days: Look back window in days. Default 30.
-        """
-        stats = tracker.stats(since_days)
-        if stats["total_calls"] == 0:
-            return f"No vault tool calls recorded in the last {since_days} days."
-
-        parts: list[str] = [f"# Vault Usage (last {since_days} days)", ""]
-        parts.append(f"- Total calls: {stats['total_calls']}")
-        parts.append(f"- Total response lines: {stats['total_response_lines']}")
-        parts.append(
-            f"- Estimated tokens served: ~{stats['total_response_lines'] * 10}"
-        )
-        parts.append("")
-
-        if stats["by_tool"]:
-            parts.append("## By Tool")
-            for tool_name, count in stats["by_tool"].items():
-                parts.append(f"- {tool_name}: {count} calls")
-            parts.append("")
-
-        if stats["by_project"]:
-            parts.append("## By Project")
-            for proj, count in stats["by_project"].items():
-                parts.append(f"- {proj}: {count} calls")
-
-        return "\n".join(parts)
 
     # ── Worker Tools ──────────────────────────────────────────────────
 
@@ -1769,21 +1855,103 @@ Total estimated savings: ~C tokens
 
     @mcp.tool(annotations=_WRITE)
     async def delegate_task(
-        prompt: str,
+        prompt: str = "",
         context: str = "",
         model: str = "auto",
         max_tokens: int = 2000,
         max_cost_per_request: float = 0.0,
+        project: str = "",
+        section: str = "context",
+        path: str = "",
+        max_summary_lines: int = 20,
     ) -> str:
-        """Offload work to a cheaper model — use for summarization, boilerplate, or analysis.
+        """Offload work to a cheaper model or summarize vault files.
+
+        When project is provided, reads a vault file. Small files (≤50 lines)
+        are returned directly. Large files are auto-delegated to a worker for
+        summarization — falls back to raw content if workers are unavailable.
 
         Args:
             prompt: The task description or code to process.
             context: Optional system context for the model.
             model: Routing — 'auto', 'ollama', 'openrouter-free', or a model ID.
             max_tokens: Maximum tokens in the response.
-            max_cost_per_request: Max USD to spend on this request. 0 = free models only.
+            max_cost_per_request: Max USD. 0 = free models only.
+            project: Project slug for vault summarization mode.
+            section: Shortcut name for summarization. Ignored if path is set.
+            path: Relative path to a .md file. Overrides section.
+            max_summary_lines: Target summary length for summarization.
         """
+        # ── Vault summarize mode ──
+        if project:
+            result = _resolve_file(
+                resolved_path, project, section, path, scopes,
+            )
+            if isinstance(result, str):
+                return _track("delegate_task", result, project)
+            filepath = result
+
+            try:
+                file_content = filepath.read_text(encoding="utf-8")
+            except OSError as exc:
+                return _track(
+                    "delegate_task", f"File I/O error: {exc}", project,
+                )
+            fm = parse_frontmatter(file_content)
+            body = extract_body(file_content)
+            line_count = len(file_content.splitlines())
+            meta = _format_metadata(fm)
+            header = f"**Metadata:** {meta}\n\n" if meta else ""
+
+            if line_count <= _SUMMARIZE_THRESHOLD:
+                return _track(
+                    "delegate_task", f"{header}{file_content}", project,
+                )
+
+            # Large file: try auto-delegation (free tiers only)
+            summary_prompt = (
+                f"Summarize the following document in at most "
+                f"{max_summary_lines} lines, preserving key decisions "
+                f"and action items.\n\n{body}"
+            )
+            summary_ctx = f"Document metadata: {meta}" if meta else ""
+            summary_resp: ClientResponse | None = None
+            summary_errors: list[str] = []
+            if await ollama.is_available():
+                summary_resp, err = await _try_worker(
+                    summary_prompt, max_tokens, "ollama", summary_ctx,
+                )
+                if err:
+                    summary_errors.append(err)
+            else:
+                summary_errors.append("Ollama: offline")
+            if summary_resp is None:
+                summary_resp, err = await _try_worker(
+                    summary_prompt, max_tokens, "openrouter", summary_ctx,
+                )
+                if err:
+                    summary_errors.append(err)
+            if summary_resp is not None:
+                return _track(
+                    "delegate_task",
+                    f"{header}{_format_response(summary_resp)}",
+                    project,
+                )
+            # Workers unavailable — return raw content with notice
+            reasons = "; ".join(summary_errors) if summary_errors else "no workers configured"
+            _log.warning("delegate_task summarize fallback for %s: %s", project, reasons)
+            fallback_notice = (
+                f"**Note:** Summarization failed ({reasons}). "
+                "Returning raw content.\n\n"
+            )
+            return _track(
+                "delegate_task", f"{header}{fallback_notice}{file_content}", project,
+            )
+
+        if not prompt:
+            return _track("delegate_task", "Either prompt or project is required.")
+
+        # ── Worker delegation ──
         # Explicit routing
         if model == "ollama":
             resp, err = await _try_worker(prompt, max_tokens, "ollama", context)
@@ -1842,35 +2010,12 @@ Total estimated savings: ~C tokens
         return f"All workers unavailable. [{reasons}]. {_REJECT_MSG}"
 
     @mcp.tool(annotations=_READ_ONLY)
-    async def list_models() -> str:
-        """List available models across all providers."""
-        lines = ["# Available Models", ""]
+    async def worker_status(include_models: bool = True) -> str:
+        """Show worker health: budget, connectivity, available models, and usage stats.
 
-        # Ollama
-        ollama_status = "online" if await ollama.is_available() else "offline / unavailable"
-        lines.append(f"## Ollama ({ollama_status})")
-        if "online" in ollama_status:
-            lines.append(f"- **{ollama.model}** — local, free, no token limit")
-        lines.append("")
-
-        # OpenRouter
-        lines.append("## OpenRouter")
-        if openrouter is not None:
-            try:
-                models = await openrouter.list_models()
-                for m in models:
-                    cost_label = "free" if m.is_free else f"${m.cost_per_million_input:.2f}/M in"
-                    lines.append(f"- **{m.id}** — {m.name}, ctx: {m.context_length}, {cost_label}")
-            except (ConnectionError, RuntimeError) as exc:
-                lines.append(f"- Error fetching models: {exc}")
-        else:
-            lines.append("- No API key configured")
-
-        return "\n".join(lines)
-
-    @mcp.tool(annotations=_READ_ONLY)
-    async def worker_status() -> str:
-        """Show worker health: budget, connectivity, usage stats."""
+        Args:
+            include_models: Include available model list from all providers. Default True.
+        """
         stats = budget.month_stats(settings.openrouter_budget)
         ollama_up = await ollama.is_available()
 
@@ -1895,6 +2040,27 @@ Total estimated savings: ~C tokens
                     f"- **{model_name}**: {model_stats['count']} requests, "
                     f"${model_stats['total_cost']:.4f}, avg {model_stats['avg_latency_ms']}ms"
                 )
+            lines.append("")
+
+        if include_models:
+            lines.append("## Available Models")
+            lines.append("")
+            ollama_status = "online" if ollama_up else "offline / unavailable"
+            lines.append(f"### Ollama ({ollama_status})")
+            if ollama_up:
+                lines.append(f"- **{ollama.model}** — local, free, no token limit")
+            lines.append("")
+            lines.append("### OpenRouter")
+            if openrouter is not None:
+                try:
+                    models = await openrouter.list_models()
+                    for m in models:
+                        cost = "free" if m.is_free else f"${m.cost_per_million_input:.2f}/M in"
+                        lines.append(f"- **{m.id}** — {m.name}, ctx: {m.context_length}, {cost}")
+                except (ConnectionError, RuntimeError) as exc:
+                    lines.append(f"- Error fetching models: {exc}")
+            else:
+                lines.append("- No API key configured")
 
         return "\n".join(lines)
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -327,8 +327,8 @@ class TestSignalToNoise:
              {"query": "paragraph", "max_lines": 100}),
             ("vault_search (500)", "vault_search",
              {"query": "paragraph", "max_lines": 500}),
-            ("vault_smart_search", "vault_smart_search",
-             {"query": "paragraph", "max_lines": 100}),
+            ("vault_search (ranked)", "vault_search",
+             {"query": "paragraph", "ranked": True, "max_lines": 100}),
             ("session_briefing", "session_briefing",
              {"project": "large-project"}),
         ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,7 +22,7 @@ class TestWorkflowListThenQuery:
     async def test_discover_and_read(self, mock_vault: Path) -> None:
         mcp = create_server(vault_path=mock_vault)
 
-        projects = _text(await mcp.call_tool("vault_list_projects", {}))
+        projects = _text(await mcp.call_tool("vault_list", {}))
         assert "testproject" in projects
 
         context = _text(await mcp.call_tool("vault_query", {"project": "testproject"}))
@@ -37,12 +37,13 @@ class TestWorkflowCreateThenQuery:
 
         create_result = _text(
             await mcp.call_tool(
-                "vault_create",
+                "vault_write",
                 {
                     "project": "testproject",
                     "path": "40-runbooks/deploy-guide.md",
                     "content": "# Deploy Guide\n\nStep 1: push to main.\n",
                     "doc_type": "runbook",
+                    "operation": "create",
                 },
             )
         )
@@ -65,7 +66,7 @@ class TestWorkflowUpdateThenSearch:
         mcp = create_server(vault_path=git_vault)
 
         await mcp.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "testproject",
                 "section": "lessons",
@@ -88,12 +89,13 @@ class TestWorkflowHealthAfterChanges:
         health_before = _text(await mcp.call_tool("vault_health", {}))
 
         await mcp.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "testproject",
                 "path": "new-doc.md",
                 "content": "# New Document\n",
                 "doc_type": "lesson",
+                "operation": "create",
             },
         )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,23 +38,23 @@ def vault_mcp(mock_vault: Path) -> FastMCP:
     return create_server(vault_path=mock_vault)
 
 
-# ── vault_list_projects ──────────────────────────────────────────────
+# ── vault_list ──────────────────────────────────────────────
 
 
 class TestVaultListProjects:
     async def test_returns_projects(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool("vault_list_projects", {})
+        result = await vault_mcp.call_tool("vault_list", {})
         assert "testproject" in _text(result)
 
     async def test_empty_vault(self, tmp_path: Path) -> None:
         (tmp_path / "10_projects").mkdir()
         mcp = create_server(vault_path=tmp_path)
-        result = await mcp.call_tool("vault_list_projects", {})
+        result = await mcp.call_tool("vault_list", {})
         assert "No projects found" in _text(result)
 
     async def test_no_projects_dir(self, tmp_path: Path) -> None:
         mcp = create_server(vault_path=tmp_path)
-        result = await mcp.call_tool("vault_list_projects", {})
+        result = await mcp.call_tool("vault_list", {})
         assert "No projects found" in _text(result)
 
     async def test_multiple_projects(self, mock_vault: Path) -> None:
@@ -64,7 +64,7 @@ class TestVaultListProjects:
             "---\nid: another\ntype: project\nstatus: active\n---\n\n# Another\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = await mcp.call_tool("vault_list_projects", {})
+        result = await mcp.call_tool("vault_list", {})
         assert "testproject" in _text(result)
         assert "another" in _text(result)
 
@@ -401,14 +401,14 @@ class TestVaultHealth:
         assert "no-created.md" in _text(result)
 
 
-# ── vault_update (with real YAML frontmatter validation) ─────────────
+# ── vault_write (update operations, with real YAML frontmatter validation) ────
 
 
-class TestVaultUpdate:
+class TestVaultWrite:
     async def test_append_to_existing_file(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "testproject",
                 "section": "lessons",
@@ -423,7 +423,7 @@ class TestVaultUpdate:
     async def test_replace_section_content(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "testproject",
                 "section": "tasks",
@@ -442,7 +442,7 @@ class TestVaultUpdate:
     async def test_replace_rejects_missing_frontmatter(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "testproject",
                 "section": "tasks",
@@ -459,7 +459,7 @@ class TestVaultUpdate:
         """YAML that parses but lacks required fields should be rejected."""
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "testproject",
                 "section": "tasks",
@@ -474,7 +474,7 @@ class TestVaultUpdate:
         """Content starting with --- but containing invalid YAML."""
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "testproject",
                 "section": "tasks",
@@ -489,7 +489,7 @@ class TestVaultUpdate:
 
         mcp = create_server(vault_path=git_vault)
         await mcp.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "testproject",
                 "section": "lessons",
@@ -509,7 +509,7 @@ class TestVaultUpdate:
     async def test_missing_project(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "nonexistent",
                 "section": "tasks",
@@ -522,7 +522,7 @@ class TestVaultUpdate:
     async def test_invalid_operation(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "testproject",
                 "section": "tasks",
@@ -546,7 +546,7 @@ class TestCaptureLesson:
             {
                 "project": "testproject",
                 "title": "Always validate frontmatter",
-                "context": "Writing vault_update tests",
+                "context": "Writing vault_write tests",
                 "problem": "Replace operation accepted invalid YAML",
                 "solution": "Added frontmatter validation before write",
                 "tags": ["testing", "yaml"],
@@ -557,7 +557,7 @@ class TestCaptureLesson:
 
         lessons = (git_vault / "10_projects" / "testproject" / "90-lessons.md").read_text()
         assert "Always validate frontmatter" in lessons
-        assert "Writing vault_update tests" in lessons
+        assert "Writing vault_write tests" in lessons
         assert "Added frontmatter validation before write" in lessons
 
     async def test_capture_formats_with_date(self, git_vault: Path) -> None:
@@ -698,19 +698,20 @@ class TestCaptureLesson:
         assert "capture_lesson" in log.stdout or "lesson" in log.stdout.lower()
 
 
-# ── vault_create ─────────────────────────────────────────────────────
+# ── vault_write (create operations) ──────────────────────────────────
 
 
-class TestVaultCreate:
+class TestVaultWriteCreate:
     async def test_create_new_adr(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "testproject",
                 "path": "30-architecture/adr-002-new.md",
                 "content": "# ADR-002: New Decision\n\nWe decided something new.\n",
                 "doc_type": "adr",
+                "operation": "create",
             },
         )
         text = _text(result)
@@ -726,12 +727,13 @@ class TestVaultCreate:
     async def test_create_lesson(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "testproject",
                 "path": "92-new-lesson.md",
                 "content": "# New Lesson\n\nLearned something.\n",
                 "doc_type": "lesson",
+                "operation": "create",
             },
         )
         assert "created" in _text(result).lower()
@@ -739,12 +741,13 @@ class TestVaultCreate:
     async def test_rejects_existing_file(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "testproject",
                 "path": "00-context.md",
                 "content": "# Overwrite attempt\n",
                 "doc_type": "project",
+                "operation": "create",
             },
         )
         assert "exists" in _text(result).lower()
@@ -752,12 +755,13 @@ class TestVaultCreate:
     async def test_auto_generates_frontmatter(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         await mcp.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "testproject",
                 "path": "50-troubleshooting/error-timeout.md",
                 "content": "# Timeout Error\n\nFix: increase timeout.\n",
                 "doc_type": "troubleshooting",
+                "operation": "create",
             },
         )
         filepath = (
@@ -774,12 +778,13 @@ class TestVaultCreate:
 
         mcp = create_server(vault_path=git_vault)
         await mcp.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "testproject",
                 "path": "new-file.md",
                 "content": "# New\n",
                 "doc_type": "lesson",
+                "operation": "create",
             },
         )
         log = subprocess.run(
@@ -794,12 +799,13 @@ class TestVaultCreate:
     async def test_create_in_meta(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "_meta",
                 "path": "patterns/pattern-new.md",
                 "content": "# New Pattern\n\nDo this always.\n",
                 "doc_type": "pattern",
+                "operation": "create",
             },
         )
         assert "created" in _text(result).lower()
@@ -809,25 +815,26 @@ class TestVaultCreate:
     async def test_missing_project(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "nonexistent",
                 "path": "new.md",
                 "content": "# New\n",
                 "doc_type": "lesson",
+                "operation": "create",
             },
         )
         assert "not found" in _text(result).lower()
 
 
-# ── vault_summarize ──────────────────────────────────────────────────
+# ── delegate_task: vault summarize mode ──────────────────────────────
 
 
-class TestVaultSummarize:
+class TestDelegateTaskSummarize:
     async def test_small_file_returns_content(self, vault_mcp: FastMCP) -> None:
         """Files ≤50 lines return content directly, no delegation prompt."""
         result = await vault_mcp.call_tool(
-            "vault_summarize", {"project": "testproject", "section": "context"}
+            "delegate_task", {"project": "testproject", "section": "context"}
         )
         text = _text(result)
         assert "# Test Project" in text
@@ -835,95 +842,102 @@ class TestVaultSummarize:
 
     async def test_small_file_includes_metadata(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_summarize", {"project": "testproject", "section": "context"}
+            "delegate_task", {"project": "testproject", "section": "context"}
         )
         text = _text(result)
         assert "**Metadata:**" in text
         assert "type=project" in text
 
-    async def test_large_file_returns_delegation_prompt(self, vault_mcp: FastMCP) -> None:
-        """Files >50 lines return a structured delegation prompt."""
+    async def test_large_file_returns_summary_or_content(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        """Files >50 lines: worker summary if available, raw content otherwise."""
         result = await vault_mcp.call_tool(
-            "vault_summarize",
+            "delegate_task",
             {"project": "testproject", "path": "92-large-doc.md"},
         )
         text = _text(result)
-        assert "delegate_task" in text
-        assert "Summarization Request" in text
-        assert "Document body" in text
+        # Worker available → summary; unavailable → raw content with notice
+        assert "Large Document" in text or "Worker Response" in text
+        assert "**Metadata:**" in text
+        # If fallback, notice must be present
+        if "Worker Response" not in text:
+            assert "Summarization failed" in text or "Large Document" in text
 
     async def test_large_file_includes_metadata_in_prompt(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_summarize",
+            "delegate_task",
             {"project": "testproject", "path": "92-large-doc.md"},
         )
         text = _text(result)
         assert "type=lesson" in text
         assert "status=active" in text
 
-    async def test_large_file_includes_body(self, vault_mcp: FastMCP) -> None:
+    async def test_large_file_has_content(self, vault_mcp: FastMCP) -> None:
+        """Large file returns either body content (fallback) or a summary."""
         result = await vault_mcp.call_tool(
-            "vault_summarize",
+            "delegate_task",
             {"project": "testproject", "path": "92-large-doc.md"},
         )
         text = _text(result)
-        assert "Line 1:" in text
-        assert "Line 80:" in text
+        # Raw content has body lines; worker summary has "Worker Response"
+        assert "Line 1:" in text or "Worker Response" in text
 
-    async def test_custom_max_summary_lines(self, vault_mcp: FastMCP) -> None:
+    async def test_max_summary_lines_accepted(self, vault_mcp: FastMCP) -> None:
+        """max_summary_lines is a valid parameter (used when workers are online)."""
         result = await vault_mcp.call_tool(
-            "vault_summarize",
-            {"project": "testproject", "path": "92-large-doc.md", "max_summary_lines": 10},
+            "delegate_task",
+            {"project": "testproject", "path": "92-large-doc.md",
+             "max_summary_lines": 10},
         )
         text = _text(result)
-        assert "10 lines" in text
-
-    async def test_default_max_summary_lines(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_summarize",
-            {"project": "testproject", "path": "92-large-doc.md"},
-        )
-        assert "20 lines" in _text(result)
+        assert "Large Document" in text
 
     async def test_missing_project(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_summarize", {"project": "nonexistent"}
+            "delegate_task", {"project": "nonexistent"}
         )
         assert "not found" in _text(result).lower()
 
     async def test_missing_file(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_summarize", {"project": "testproject", "path": "nope.md"}
+            "delegate_task", {"project": "testproject", "path": "nope.md"}
         )
         assert "not found" in _text(result).lower()
 
     async def test_path_overrides_section(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_summarize",
+            "delegate_task",
             {"project": "testproject", "section": "tasks", "path": "92-large-doc.md"},
         )
         text = _text(result)
-        assert "Large Document" in text or "delegate_task" in text
+        assert "Large Document" in text
 
     async def test_file_without_frontmatter(self, mock_vault: Path) -> None:
         bare = mock_vault / "10_projects" / "testproject" / "bare.md"
         bare.write_text("# Bare\nJust text.\n")
         mcp = create_server(vault_path=mock_vault)
         result = await mcp.call_tool(
-            "vault_summarize", {"project": "testproject", "path": "bare.md"}
+            "delegate_task", {"project": "testproject", "path": "bare.md"}
         )
         text = _text(result)
         assert "# Bare" in text
         assert "**Metadata:**" not in text
 
 
-# ── vault_smart_search ───────────────────────────────────────────────
+# ── vault_search (ranked) ────────────────────────────────────────────
 
 
-class TestVaultSmartSearch:
+class TestVaultSearchRanked:
+    async def test_empty_query_rejected(self, vault_mcp: FastMCP) -> None:
+        result = await vault_mcp.call_tool(
+            "vault_search", {"ranked": True},
+        )
+        assert "Query is required" in _text(result)
+
     async def test_finds_matching_files(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_smart_search", {"query": "Task one"}
+            "vault_search", {"query": "Task one", "ranked": True}
         )
         text = _text(result)
         assert "11-tasks.md" in text
@@ -931,14 +945,14 @@ class TestVaultSmartSearch:
 
     async def test_no_results(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_smart_search", {"query": "xyznonexistent"}
+            "vault_search", {"query": "xyznonexistent", "ranked": True}
         )
         assert "no matches" in _text(result).lower()
 
     async def test_active_ranks_above_terminal(self, vault_mcp: FastMCP) -> None:
         """Active files should score higher than completed/accepted files."""
         result = await vault_mcp.call_tool(
-            "vault_smart_search", {"query": "Lesson"}
+            "vault_search", {"query": "Lesson", "ranked": True}
         )
         text = _text(result)
         lines = text.splitlines()
@@ -962,7 +976,7 @@ class TestVaultSmartSearch:
             "alpha once\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = await mcp.call_tool("vault_smart_search", {"query": "alpha"})
+        result = await mcp.call_tool("vault_search", {"query": "alpha", "ranked": True})
         text = _text(result)
         score_lines = [ln for ln in text.splitlines() if "score:" in ln]
         many_idx = next(i for i, ln in enumerate(score_lines) if "many-matches" in ln)
@@ -971,7 +985,7 @@ class TestVaultSmartSearch:
 
     async def test_shows_metadata_per_result(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_smart_search", {"query": "Test Project"}
+            "vault_search", {"query": "Test Project", "ranked": True}
         )
         text = _text(result)
         assert "type=project" in text
@@ -979,7 +993,7 @@ class TestVaultSmartSearch:
 
     async def test_max_results_limits_output(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_smart_search", {"query": "active", "max_results": 2}
+            "vault_search", {"query": "active", "ranked": True, "max_results": 2}
         )
         text = _text(result)
         score_lines = [ln for ln in text.splitlines() if "score:" in ln]
@@ -987,14 +1001,14 @@ class TestVaultSmartSearch:
 
     async def test_max_lines_truncates(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_smart_search", {"query": "active", "max_lines": 5}
+            "vault_search", {"query": "active", "ranked": True, "max_lines": 5}
         )
         text = _text(result)
         assert "truncated" in text.lower()
 
     async def test_case_insensitive(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_smart_search", {"query": "task ONE"}
+            "vault_search", {"query": "task ONE", "ranked": True}
         )
         assert "11-tasks.md" in _text(result)
 
@@ -1003,7 +1017,7 @@ class TestVaultSmartSearch:
         bare.write_text("# Bare\nSearchable bare content.\n")
         mcp = create_server(vault_path=mock_vault)
         result = await mcp.call_tool(
-            "vault_smart_search", {"query": "Searchable bare"}
+            "vault_search", {"query": "Searchable bare", "ranked": True}
         )
         text = _text(result)
         assert "bare.md" in text
@@ -1017,7 +1031,7 @@ class TestVaultSmartSearch:
             "\n".join(lines) + "\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = await mcp.call_tool("vault_smart_search", {"query": "keyword"})
+        result = await mcp.call_tool("vault_search", {"query": "keyword", "ranked": True})
         text = _text(result)
         # Should show at most 5 matching lines per file
         match_lines = [ln for ln in text.splitlines() if ln.strip().startswith("- keyword")]
@@ -1047,7 +1061,7 @@ class TestPrompts:
         result = await vault_mcp.render_prompt("retrospective", {"project": "hive"})
         text = self._prompt_text(result)
         assert "vault_query" in text
-        assert "vault_update" in text
+        assert "vault_write" in text
         assert "**Context:**" in text
 
     async def test_retrospective_interpolates_project(self, vault_mcp: FastMCP) -> None:
@@ -1081,7 +1095,7 @@ class TestPrompts:
         result = await vault_mcp.render_prompt("vault_sync", {"project": "hive"})
         text = self._prompt_text(result)
         assert "vault_health" in text
-        assert "vault_update" in text
+        assert "vault_write" in text
 
     async def test_vault_sync_interpolates_project(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.render_prompt("vault_sync", {"project": "testproj"})
@@ -1191,12 +1205,12 @@ class TestRelevanceTracking:
         scores = relevance.get_scores("testproject")
         assert "tasks" in scores
 
-    async def test_vault_update_records_write_boost(self, git_vault: Path) -> None:
+    async def test_vault_write_records_write_boost(self, git_vault: Path) -> None:
         from hive.relevance import RelevanceTracker
 
         relevance = RelevanceTracker()
         mcp = create_server(vault_path=git_vault, relevance_tracker=relevance)
-        await mcp.call_tool("vault_update", {
+        await mcp.call_tool("vault_write", {
             "project": "testproject",
             "section": "lessons",
             "operation": "append",
@@ -1280,10 +1294,10 @@ class TestDecayOnBriefing:
         assert score_after < score_before
 
 
-# ── vault_recent ─────────────────────────────────────────────────────
+# ── vault_search (recent) ────────────────────────────────────────────
 
 
-class TestVaultRecent:
+class TestVaultSearchRecent:
     async def test_recent_git_change_appears(self, git_vault: Path) -> None:
         import subprocess
 
@@ -1297,7 +1311,7 @@ class TestVaultRecent:
             cwd=git_vault, capture_output=True, check=True,
         )
         mcp = create_server(vault_path=git_vault)
-        result = await mcp.call_tool("vault_recent", {"since_days": 1})
+        result = await mcp.call_tool("vault_search", {"since_days": 1})
         assert "new-note.md" in _text(result)
 
     async def test_project_filter(self, git_vault: Path) -> None:
@@ -1316,7 +1330,7 @@ class TestVaultRecent:
         )
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_recent", {"since_days": 1, "project": "testproject"}
+            "vault_search", {"since_days": 1, "project": "testproject"}
         )
         text = _text(result)
         assert "other" not in text.lower() or "testproject" in text
@@ -1330,7 +1344,7 @@ class TestVaultRecent:
             f"---\n\n# Today\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = await mcp.call_tool("vault_recent", {"since_days": 1})
+        result = await mcp.call_tool("vault_search", {"since_days": 1})
         assert "today-note.md" in _text(result)
 
     async def test_no_changes_returns_message(self, tmp_path: Path) -> None:
@@ -1338,7 +1352,7 @@ class TestVaultRecent:
         project = tmp_path / "10_projects" / "emptyproj"
         project.mkdir(parents=True)
         mcp = create_server(vault_path=tmp_path)
-        result = await mcp.call_tool("vault_recent", {"since_days": 1})
+        result = await mcp.call_tool("vault_search", {"since_days": 1})
         assert "no changes" in _text(result).lower()
 
     async def test_output_truncated(self, git_vault: Path) -> None:
@@ -1356,38 +1370,47 @@ class TestVaultRecent:
             cwd=git_vault, capture_output=True, check=True,
         )
         mcp = create_server(vault_path=git_vault)
-        result = await mcp.call_tool("vault_recent", {"since_days": 1})
+        result = await mcp.call_tool(
+            "vault_search", {"since_days": 1, "max_lines": 100},
+        )
         assert "truncated" in _text(result).lower()
 
 
-# ── vault_usage ──────────────────────────────────────────────────────
+# ── vault_health (usage) ─────────────────────────────────────────────
 
 
 class TestVaultUsage:
     async def test_tracks_tool_calls(self, vault_mcp: FastMCP) -> None:
         """Tool calls should be recorded in the usage tracker."""
-        await vault_mcp.call_tool("vault_list_projects", {})
+        await vault_mcp.call_tool("vault_list", {})
         await vault_mcp.call_tool("vault_query", {"project": "testproject"})
-        result = await vault_mcp.call_tool("vault_usage", {"since_days": 1})
+        result = await vault_mcp.call_tool(
+            "vault_health", {"include_usage": True, "usage_days": 1},
+        )
         text = _text(result)
-        assert "vault_list_projects" in text
+        assert "vault_list" in text
         assert "vault_query" in text
-        # vault_usage itself is also tracked
         assert "Total calls:" in text
 
     async def test_tracks_project(self, vault_mcp: FastMCP) -> None:
         await vault_mcp.call_tool("vault_query", {"project": "testproject"})
-        result = await vault_mcp.call_tool("vault_usage", {"since_days": 1})
+        result = await vault_mcp.call_tool(
+            "vault_health", {"include_usage": True, "usage_days": 1},
+        )
         assert "testproject" in _text(result)
 
     async def test_empty_usage(self, tmp_path: Path) -> None:
         mcp = create_server(vault_path=tmp_path)
-        result = await mcp.call_tool("vault_usage", {"since_days": 1})
+        result = await mcp.call_tool(
+            "vault_health", {"include_usage": True, "usage_days": 1},
+        )
         assert "no vault tool calls" in _text(result).lower()
 
     async def test_estimates_tokens(self, vault_mcp: FastMCP) -> None:
         await vault_mcp.call_tool("vault_query", {"project": "testproject"})
-        result = await vault_mcp.call_tool("vault_usage", {"since_days": 1})
+        result = await vault_mcp.call_tool(
+            "vault_health", {"include_usage": True, "usage_days": 1},
+        )
         assert "tokens served" in _text(result).lower()
 
 
@@ -1614,48 +1637,11 @@ class TestDelegateTaskRecording:
         assert budget.month_stats(5.0)["request_count"] == 1
 
 
-# ── list_models ─────────────────────────────────────────────────────
-
-
-class TestListModels:
-    """list_models tool combines Ollama + OpenRouter info."""
-
-    @pytest.mark.asyncio
-    async def test_list_models_output(
-        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
-    ) -> None:
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        openrouter.list_models = AsyncMock(  # type: ignore[method-assign]
-            return_value=[
-                ModelInfo(
-                    id="qwen/qwen3-coder:free",
-                    name="Qwen3 Coder",
-                    context_length=65536,
-                    cost_per_million_input=0.0,
-                    cost_per_million_output=0.0,
-                    is_free=True,
-                ),
-            ]
-        )
-        result = _text(await worker.call_tool("list_models", {}))
-        assert "qwen2.5-coder:7b" in result
-        assert "qwen/qwen3-coder:free" in result
-
-    @pytest.mark.asyncio
-    async def test_list_models_ollama_down(
-        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
-    ) -> None:
-        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
-        openrouter.list_models = AsyncMock(return_value=[])  # type: ignore[method-assign]
-        result = _text(await worker.call_tool("list_models", {}))
-        assert "offline" in result.lower() or "unavailable" in result.lower()
-
-
 # ── worker_status ───────────────────────────────────────────────────
 
 
 class TestWorkerStatus:
-    """worker_status tool shows budget + connectivity."""
+    """worker_status tool shows budget, connectivity, and available models."""
 
     @pytest.mark.asyncio
     async def test_status_shows_budget(
@@ -1679,6 +1665,36 @@ class TestWorkerStatus:
         result = _text(await worker.call_tool("worker_status", {}))
         assert "offline" in result.lower() or "unavailable" in result.lower()
 
+    @pytest.mark.asyncio
+    async def test_status_includes_models(
+        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    ) -> None:
+        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        openrouter.list_models = AsyncMock(  # type: ignore[method-assign]
+            return_value=[
+                ModelInfo(
+                    id="qwen/qwen3-coder:free",
+                    name="Qwen3 Coder",
+                    context_length=65536,
+                    cost_per_million_input=0.0,
+                    cost_per_million_output=0.0,
+                    is_free=True,
+                ),
+            ]
+        )
+        result = _text(await worker.call_tool("worker_status", {}))
+        assert "qwen2.5-coder:7b" in result
+        assert "qwen/qwen3-coder:free" in result
+
+    @pytest.mark.asyncio
+    async def test_status_without_models(
+        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    ) -> None:
+        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        result = _text(await worker.call_tool("worker_status", {"include_models": False}))
+        assert "Available Models" not in result
+        assert "Budget" in result
+
 
 # ── Multi-scope vault tests ─────────────────────────────────────────
 
@@ -1688,20 +1704,20 @@ MULTI_SCOPES = {"projects": "10_projects", "meta": "00_meta", "work": "50_work"}
 class TestMultiScopeListProjects:
     async def test_lists_from_all_scopes(self, multi_scope_vault: Path) -> None:
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool("vault_list_projects", {}))
+        result = _text(await mcp.call_tool("vault_list", {}))
         assert "projects/testproject" in result
         assert "work/my-company" in result
 
     async def test_missing_scope_silently_skipped(self, mock_vault: Path) -> None:
         scopes = {**MULTI_SCOPES, "extra": "99_nonexistent"}
         mcp = create_server(vault_path=mock_vault, vault_scopes=scopes)
-        result = _text(await mcp.call_tool("vault_list_projects", {}))
+        result = _text(await mcp.call_tool("vault_list", {}))
         assert "projects/testproject" in result
         assert "99_nonexistent" not in result
 
     async def test_backward_compat(self, mock_vault: Path) -> None:
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool("vault_list_projects", {}))
+        result = _text(await mcp.call_tool("vault_list", {}))
         assert "testproject" in result
 
 
@@ -1763,7 +1779,7 @@ class TestMultiScopeUpdate:
         mcp = create_server(
             vault_path=git_multi_scope_vault, vault_scopes=MULTI_SCOPES,
         )
-        result = _text(await mcp.call_tool("vault_update", {
+        result = _text(await mcp.call_tool("vault_write", {
             "project": "my-company",
             "section": "lessons",
             "operation": "append",
@@ -1776,7 +1792,7 @@ class TestMultiScopeUpdate:
         assert "Always test" in content
 
 
-class TestMultiScopeRecent:
+class TestMultiScopeSearchRecent:
     async def test_project_filter_in_work_scope(
         self, git_multi_scope_vault: Path,
     ) -> None:
@@ -1784,7 +1800,7 @@ class TestMultiScopeRecent:
             vault_path=git_multi_scope_vault, vault_scopes=MULTI_SCOPES,
         )
         result = _text(await mcp.call_tool(
-            "vault_recent", {"project": "my-company", "since_days": 30},
+            "vault_search", {"project": "my-company", "since_days": 30},
         ))
         # Should find files in 50_work/my-company, not return "No changes"
         assert "my-company" in result or "50_work" in result
@@ -1805,19 +1821,22 @@ class TestPathTraversal:
     async def test_create_path_escape_blocked(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = _text(await mcp.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "testproject",
                 "path": "../../../../tmp/evil.md",
                 "content": "pwned",
                 "doc_type": "test",
+                "operation": "create",
             },
         ))
         assert "escapes vault boundary" in result.lower()
 
-    async def test_summarize_path_escape_blocked(self, vault_mcp: FastMCP) -> None:
+    async def test_delegate_summarize_path_escape_blocked(
+        self, vault_mcp: FastMCP,
+    ) -> None:
         result = _text(await vault_mcp.call_tool(
-            "vault_summarize",
+            "delegate_task",
             {"project": "testproject", "path": "../../../../etc/shadow"},
         ))
         assert "escapes vault boundary" in result.lower()
@@ -1827,7 +1846,7 @@ class TestPathTraversal:
     ) -> None:
         """H1: crafted project name must not escape vault boundary."""
         result = _text(await vault_mcp.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "projects:../../etc",
                 "section": "context",
@@ -1841,12 +1860,13 @@ class TestPathTraversal:
         """H2: newlines in doc_type must not inject YAML fields."""
         mcp = create_server(vault_path=git_vault)
         result = _text(await mcp.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "testproject",
                 "path": "injected.md",
                 "content": "body",
                 "doc_type": "adr\nevil_field: true",
+                "operation": "create",
             },
         ))
         assert "created" in result.lower()
@@ -1872,7 +1892,7 @@ class TestPathTraversal:
     async def test_list_files_path_escape_blocked(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
         result = _text(await mcp.call_tool(
-            "vault_list_files",
+            "vault_list",
             {
                 "project": "testproject",
                 "path": "../../../../etc",
@@ -1881,14 +1901,14 @@ class TestPathTraversal:
         assert "escapes vault boundary" in result.lower()
 
     async def test_list_files_glob_capped(self, mock_vault: Path) -> None:
-        """vault_list_files caps results at 500 entries."""
+        """vault_list caps results at 500 entries."""
         project = mock_vault / "10_projects" / "testproject" / "bulk"
         project.mkdir(parents=True, exist_ok=True)
         for i in range(510):
             (project / f"file_{i:04d}.md").write_text(f"# File {i}\n")
         mcp = create_server(vault_path=mock_vault)
         result = _text(await mcp.call_tool(
-            "vault_list_files",
+            "vault_list",
             {"project": "testproject", "path": "bulk", "pattern": "*.md"},
         ))
         # Should contain at most 500 file entries
@@ -2188,7 +2208,7 @@ class TestGitCommitResilience:
 
         with patch("hive.server.subprocess.run", side_effect=RuntimeError("unexpected")):
             result = _text(await mcp.call_tool(
-                "vault_update",
+                "vault_write",
                 {
                     "project": "testproject",
                     "section": "tasks",
@@ -2240,15 +2260,15 @@ class TestGitReadResilience:
 
         assert "session briefing" in result.lower()
 
-    async def test_vault_recent_survives_git_oserror(self, git_vault: Path) -> None:
-        """vault_recent must not crash if git binary is missing."""
+    async def test_vault_search_recent_survives_git_oserror(self, git_vault: Path) -> None:
+        """vault_search (recent mode) must not crash if git binary is missing."""
         from unittest.mock import patch
 
         mcp = create_server(vault_path=git_vault)
 
         with patch("hive.server.subprocess.run", side_effect=OSError("git not found")):
             result = _text(await mcp.call_tool(
-                "vault_recent", {"since_days": 7},
+                "vault_search", {"since_days": 7},
             ))
 
         # Should return gracefully (no changes or empty result)
@@ -2277,14 +2297,14 @@ class TestFileIOResilience:
         finally:
             tasks.chmod(0o644)
 
-    async def test_vault_update_write_permission_error(self, git_vault: Path) -> None:
-        """vault_update returns error on write failure, not crash."""
+    async def test_vault_write_permission_error(self, git_vault: Path) -> None:
+        """vault_write returns error on write failure, not crash."""
         mcp = create_server(vault_path=git_vault)
         tasks = git_vault / "10_projects" / "testproject" / "11-tasks.md"
         tasks.chmod(0o444)
         try:
             result = _text(await mcp.call_tool(
-                "vault_update",
+                "vault_write",
                 {
                     "project": "testproject",
                     "section": "tasks",
@@ -2319,7 +2339,7 @@ class TestSectionFallback:
         assert "Test Project" in result
 
 
-# ── extract_lessons ─────────────────────────────────────────────────
+# ── capture_lesson (batch) ─────────────────────────────────────────────────
 
 
 @pytest.fixture
@@ -2329,7 +2349,7 @@ def worker_vault(
     ollama: OllamaClient,
     openrouter: OpenRouterClient,
 ) -> FastMCP:
-    """Server with git vault + worker deps for extract_lessons tests."""
+    """Server with git vault + worker deps for capture_lesson (batch) tests."""
     return create_server(
         vault_path=git_vault,
         budget_tracker=budget,
@@ -2365,7 +2385,7 @@ _VALID_LESSONS_JSON = json.dumps([
 
 
 class TestExtractLessons:
-    """extract_lessons tool — worker-powered lesson extraction."""
+    """capture_lesson (batch) tool — worker-powered lesson extraction."""
 
     @pytest.mark.asyncio
     async def test_extracts_and_writes_lessons(
@@ -2376,7 +2396,7 @@ class TestExtractLessons:
             return_value=_worker_response(_VALID_LESSONS_JSON),
         )
         result = _text(await worker_vault.call_tool(
-            "extract_lessons",
+            "capture_lesson",
             {"project": "testproject", "text": "We found a crash..."},
         ))
         assert "2" in result  # 2 lessons extracted
@@ -2401,7 +2421,7 @@ class TestExtractLessons:
             return_value=_worker_response(_VALID_LESSONS_JSON),
         )
         result = _text(await worker_vault.call_tool(
-            "extract_lessons",
+            "capture_lesson",
             {"project": "testproject", "text": "session text"},
         ))
         # First lesson skipped (duplicate), second written
@@ -2424,7 +2444,7 @@ class TestExtractLessons:
             return_value=_worker_response(low_conf),
         )
         result = _text(await worker_vault.call_tool(
-            "extract_lessons",
+            "capture_lesson",
             {"project": "testproject", "text": "some text", "min_confidence": 0.7},
         ))
         assert "0" in result or "no lessons" in result.lower()
@@ -2438,7 +2458,7 @@ class TestExtractLessons:
             side_effect=ConnectionError("no workers"),
         )
         result = _text(await worker_vault.call_tool(
-            "extract_lessons",
+            "capture_lesson",
             {"project": "testproject", "text": "some text"},
         ))
         assert "unavailable" in result.lower() or "worker" in result.lower()
@@ -2452,7 +2472,7 @@ class TestExtractLessons:
             return_value=_worker_response("This is not JSON at all, just text."),
         )
         result = _text(await worker_vault.call_tool(
-            "extract_lessons",
+            "capture_lesson",
             {"project": "testproject", "text": "some text"},
         ))
         assert "parse" in result.lower() or "invalid" in result.lower()
@@ -2466,7 +2486,7 @@ class TestExtractLessons:
             return_value=_worker_response("[]"),
         )
         result = _text(await worker_vault.call_tool(
-            "extract_lessons",
+            "capture_lesson",
             {"project": "testproject", "text": "nothing interesting"},
         ))
         assert "no lessons" in result.lower()
@@ -2486,7 +2506,7 @@ class TestExtractLessons:
             return_value=_worker_response(wrapped),
         )
         result = _text(await worker_vault.call_tool(
-            "extract_lessons",
+            "capture_lesson",
             {"project": "testproject", "text": "session notes"},
         ))
         assert "Fence test" in result
@@ -2505,7 +2525,7 @@ class TestExtractLessons:
             return_value=_worker_response(many),
         )
         await worker_vault.call_tool(
-            "extract_lessons",
+            "capture_lesson",
             {"project": "testproject", "text": "big session", "max_lessons": 3},
         )
         lessons = (git_vault / "10_projects" / "testproject" / "90-lessons.md").read_text()
@@ -2531,7 +2551,7 @@ class TestExtractLessons:
             return_value=_worker_response(injected),
         )
         result = _text(await worker_vault.call_tool(
-            "extract_lessons",
+            "capture_lesson",
             {"project": "testproject", "text": "session"},
         ))
         assert "Good title" in result
@@ -2554,7 +2574,7 @@ class TestExtractLessons:
                 return_value=_worker_response(_VALID_LESSONS_JSON),
             )
             result = _text(await worker_vault.call_tool(
-                "extract_lessons",
+                "capture_lesson",
                 {"project": "testproject", "text": "session notes"},
             ))
             assert "write error" in result.lower() or "error" in result.lower()
@@ -2572,7 +2592,7 @@ class TestExtractLessons:
         )
         # Text containing curly braces — would crash without escaping
         result = _text(await worker_vault.call_tool(
-            "extract_lessons",
+            "capture_lesson",
             {"project": "testproject", "text": 'def foo(): return {"key": value}'},
         ))
         assert "Always check return values" in result
@@ -2593,7 +2613,7 @@ class TestExtractLessons:
             return_value=_worker_response(injected_tags),
         )
         result = _text(await worker_vault.call_tool(
-            "extract_lessons",
+            "capture_lesson",
             {"project": "testproject", "text": "session"},
         ))
         assert "Tag injection test" in result
@@ -2603,16 +2623,28 @@ class TestExtractLessons:
             assert not line.startswith("### Fake Lesson")
 
 
-# ── vault_validate ─────────────────────────────────────────────────
+# ── vault_health (validation) ──────────────────────────────────────
 
 
 class TestVaultValidate:
-    """vault_validate tool — drift detection and vault linting."""
+    """vault_health validation mode — drift detection and vault linting."""
+
+    async def test_unknown_check_names_rejected(self, mock_vault: Path) -> None:
+        """Typo in check name returns error instead of false positive."""
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool(
+            "vault_health", {"checks": ["frontmater"]},
+        ))
+        assert "Unknown check" in result
+        assert "frontmatter" in result
 
     async def test_healthy_vault_no_errors(self, mock_vault: Path) -> None:
         """Well-formed vault produces no error-level issues."""
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool("vault_validate", {}))
+        result = _text(await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmatter", "stale", "links"]},
+            ))
         assert "error" not in result.lower() or "0 errors" in result.lower()
 
     async def test_missing_frontmatter_detected(self, mock_vault: Path) -> None:
@@ -2620,7 +2652,10 @@ class TestVaultValidate:
         bad = mock_vault / "10_projects" / "testproject" / "no-frontmatter.md"
         bad.write_text("# Just a heading\n\nNo frontmatter here.\n")
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool("vault_validate", {}))
+        result = _text(await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmatter", "stale", "links"]},
+            ))
         assert "no-frontmatter.md" in result
         assert "frontmatter" in result.lower()
 
@@ -2629,7 +2664,10 @@ class TestVaultValidate:
         bad = mock_vault / "10_projects" / "testproject" / "incomplete.md"
         bad.write_text("---\nid: incomplete\n---\n\n# Missing type and status\n")
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool("vault_validate", {}))
+        result = _text(await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmatter", "stale", "links"]},
+            ))
         assert "incomplete.md" in result
         assert "type" in result.lower() or "status" in result.lower()
 
@@ -2641,7 +2679,10 @@ class TestVaultValidate:
             "---\n\n# Bad date\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool("vault_validate", {}))
+        result = _text(await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmatter", "stale", "links"]},
+            ))
         assert "bad-date.md" in result
         assert "date" in result.lower()
 
@@ -2653,7 +2694,10 @@ class TestVaultValidate:
             "---\n\n# Very old file\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool("vault_validate", {}))
+        result = _text(await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmatter", "stale", "links"]},
+            ))
         assert "ancient.md" in result
         assert "stale" in result.lower()
 
@@ -2665,7 +2709,10 @@ class TestVaultValidate:
             "---\n\n# Old but done\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool("vault_validate", {}))
+        result = _text(await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmatter", "stale", "links"]},
+            ))
         assert "old-done.md" not in result
 
     async def test_broken_wikilink_detected(self, mock_vault: Path) -> None:
@@ -2676,7 +2723,10 @@ class TestVaultValidate:
             "See [[nonexistent-doc]] for details.\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool("vault_validate", {}))
+        result = _text(await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmatter", "stale", "links"]},
+            ))
         assert "nonexistent-doc" in result
         assert "link" in result.lower() or "broken" in result.lower()
 
@@ -2688,7 +2738,10 @@ class TestVaultValidate:
             "See [[adr-001-test]] for details.\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool("vault_validate", {}))
+        result = _text(await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmatter", "stale", "links"]},
+            ))
         assert "adr-001-test" not in result
 
     async def test_project_filter(self, mock_vault: Path) -> None:
@@ -2699,7 +2752,7 @@ class TestVaultValidate:
         (other / "broken.md").write_text("No frontmatter here.\n")
         mcp = create_server(vault_path=mock_vault)
         result = _text(await mcp.call_tool(
-            "vault_validate", {"project": "testproject"},
+            "vault_health", {"project": "testproject"},
         ))
         assert "broken.md" not in result
 
@@ -2715,7 +2768,7 @@ class TestVaultValidate:
         mcp = create_server(vault_path=mock_vault)
         # Only run frontmatter check — stale should not appear
         result = _text(await mcp.call_tool(
-            "vault_validate", {"checks": ["frontmatter"]},
+            "vault_health", {"checks": ["frontmatter"]},
         ))
         assert "no-fm.md" in result
         assert "ancient2.md" not in result
@@ -2727,7 +2780,8 @@ class TestVaultValidate:
             (project / f"bad-{i}.md").write_text("No frontmatter.\n")
         mcp = create_server(vault_path=mock_vault)
         result = _text(await mcp.call_tool(
-            "vault_validate", {"max_issues": 5},
+            "vault_health",
+            {"checks": ["frontmatter"], "max_issues": 5},
         ))
         assert "truncated" in result.lower() or "more" in result.lower()
 
@@ -2735,7 +2789,8 @@ class TestVaultValidate:
         """Unknown project returns error."""
         mcp = create_server(vault_path=mock_vault)
         result = _text(await mcp.call_tool(
-            "vault_validate", {"project": "nonexistent"},
+            "vault_health",
+            {"project": "nonexistent", "checks": ["frontmatter"]},
         ))
         assert "not found" in result.lower()
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -166,7 +166,7 @@ class TestVaultSmoke:
 
     # B1
     async def test_list_projects(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool("vault_list_projects", {}))
+        result = _text(await server.call_tool("vault_list", {}))
         assert "smoketest" in result
 
     # B2
@@ -258,7 +258,7 @@ class TestVaultSmoke:
     # B13
     async def test_update_append(self, server: FastMCP, smoke_vault: Path) -> None:
         result = _text(await server.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "smoketest",
                 "section": "lessons",
@@ -273,7 +273,7 @@ class TestVaultSmoke:
     # B14
     async def test_update_invalid_frontmatter(self, server: FastMCP) -> None:
         result = _text(await server.call_tool(
-            "vault_update",
+            "vault_write",
             {
                 "project": "smoketest",
                 "section": "tasks",
@@ -286,12 +286,13 @@ class TestVaultSmoke:
     # B15
     async def test_create(self, server: FastMCP, smoke_vault: Path) -> None:
         result = _text(await server.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "smoketest",
                 "path": "30-architecture/adr-test.md",
                 "content": "# Test ADR\n",
                 "doc_type": "adr",
+                "operation": "create",
             },
         ))
         assert "created" in result.lower()
@@ -301,12 +302,13 @@ class TestVaultSmoke:
     # B16
     async def test_create_duplicate(self, server: FastMCP) -> None:
         result = _text(await server.call_tool(
-            "vault_create",
+            "vault_write",
             {
                 "project": "smoketest",
                 "path": "30-architecture/adr-001.md",
                 "content": "dup",
                 "doc_type": "adr",
+                "operation": "create",
             },
         ))
         assert "already exists" in result.lower()
@@ -314,7 +316,7 @@ class TestVaultSmoke:
     # B17
     async def test_list_files(self, server: FastMCP) -> None:
         result = _text(await server.call_tool(
-            "vault_list_files", {"project": "smoketest"},
+            "vault_list", {"project": "smoketest"},
         ))
         assert "00-context.md" in result
         assert "30-architecture/" in result
@@ -322,7 +324,7 @@ class TestVaultSmoke:
     # B18
     async def test_list_files_pattern(self, server: FastMCP) -> None:
         result = _text(await server.call_tool(
-            "vault_list_files", {"project": "smoketest", "pattern": "adr-*"},
+            "vault_list", {"project": "smoketest", "pattern": "adr-*"},
         ))
         assert "adr-001.md" in result
 
@@ -394,14 +396,14 @@ class TestVaultSmoke:
     # B23
     async def test_summarize_small_file(self, server: FastMCP) -> None:
         result = _text(await server.call_tool(
-            "vault_summarize", {"project": "smoketest", "section": "context"},
+            "delegate_task", {"project": "smoketest", "section": "context"},
         ))
         assert "Smoke Test Project" in result
 
     # B24
-    async def test_smart_search(self, server: FastMCP) -> None:
+    async def test_ranked_search(self, server: FastMCP) -> None:
         result = _text(await server.call_tool(
-            "vault_smart_search", {"query": "Decision"},
+            "vault_search", {"query": "Decision", "ranked": True},
         ))
         assert "adr-001" in result
 
@@ -413,19 +415,21 @@ class TestVaultSmoke:
         assert "Session Briefing" in result
 
     # B26
-    async def test_vault_recent(self, server: FastMCP) -> None:
+    async def test_vault_search_recent(self, server: FastMCP) -> None:
         result = _text(await server.call_tool(
-            "vault_recent", {"project": "smoketest"},
+            "vault_search", {"project": "smoketest", "since_days": 30},
         ))
         # Should return something (at least the recently created files)
         assert "smoketest" in result.lower() or "recent" in result.lower()
 
     # B27
-    async def test_vault_usage(self, server: FastMCP) -> None:
+    async def test_vault_health_usage(self, server: FastMCP) -> None:
         # Call a tool first to generate usage data
-        await server.call_tool("vault_list_projects", {})
-        result = _text(await server.call_tool("vault_usage", {}))
-        assert "vault_list_projects" in result
+        await server.call_tool("vault_list", {})
+        result = _text(await server.call_tool(
+            "vault_health", {"include_usage": True},
+        ))
+        assert "vault_list" in result
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -480,7 +484,7 @@ class TestEdgeCasesSmoke:
     async def test_empty_vault(self, tmp_path: Path) -> None:
         (tmp_path / "10_projects").mkdir()
         mcp = create_server(vault_path=tmp_path)
-        result = _text(await mcp.call_tool("vault_list_projects", {}))
+        result = _text(await mcp.call_tool("vault_list", {}))
         assert "no projects" in result.lower()
 
     async def test_empty_vault_health(self, tmp_path: Path) -> None:
@@ -627,28 +631,23 @@ class TestAutoRouting:
         assert stats["request_count"] == 1
 
 
-class TestListModelsSmoke:
-    """Real model listing."""
-
-    @skip_no_ollama
-    async def test_list_models_shows_ollama(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool("list_models", {}))
-        assert "online" in result.lower()
-        assert OLLAMA_MODEL in result
-
-    @skip_no_openrouter
-    async def test_list_models_shows_openrouter(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool("list_models", {}))
-        assert "OpenRouter" in result
-
-
 class TestWorkerStatusSmoke:
-    """Real status check."""
+    """Real status + model listing."""
 
     @skip_no_ollama
     async def test_status_shows_ollama_online(self, server: FastMCP) -> None:
         result = _text(await server.call_tool("worker_status", {}))
         assert "online" in result.lower()
+
+    @skip_no_ollama
+    async def test_status_shows_ollama_model(self, server: FastMCP) -> None:
+        result = _text(await server.call_tool("worker_status", {}))
+        assert OLLAMA_MODEL in result
+
+    @skip_no_openrouter
+    async def test_status_shows_openrouter_models(self, server: FastMCP) -> None:
+        result = _text(await server.call_tool("worker_status", {}))
+        assert "OpenRouter" in result
 
     async def test_status_shows_budget(self, server: FastMCP) -> None:
         result = _text(await server.call_tool("worker_status", {}))

--- a/uv.lock
+++ b/uv.lock
@@ -429,7 +429,7 @@ wheels = [
 
 [[package]]
 name = "hive-vault"
-version = "1.7.1"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- **Consolidate 19 tools → 10** to fit within Claude Code's deferred tool display limit (~14 tools). All functionality preserved via mode-switching parameters.
- **Audit fixes** from 3 parallel audits (security, UX, lessons regression):
  - `delegate_task` summarize fallback now reports worker errors instead of silent raw content dump
  - `vault_health` rejects unknown check names instead of silent no-op ("vault clean" false positive)
  - `vault_search(ranked=True)` rejects empty query instead of matching everything
  - `_safe_read` now logs skipped files for traceability
  - `_health_report_text` fixed double-read race condition
  - `_count_stale` protected `stat()` call with try/except
  - Dead code `_VALID_OPERATIONS` removed
  - Stale tool name references cleaned across codebase

### Consolidation Map

| New Tool | Merged From | Mode Switch |
|---|---|---|
| `vault_list` | `vault_list_projects` + `vault_list_files` | `project` param |
| `vault_search` | + `vault_smart_search` + `vault_recent` | `ranked`, `since_days` |
| `vault_health` | + `vault_validate` + `vault_usage` | `checks`, `include_usage` |
| `vault_write` | `vault_create` + `vault_update` | `operation` param |
| `capture_lesson` | + `extract_lessons` | `text` param for batch |
| `delegate_task` | + `vault_summarize` | `project` param for summarize |
| `worker_status` | + `list_models` | `include_models` param |

### Docs Updated

- README: new 10-tool table, architecture diagram, logging docs, config table
- Site: all tool pages, use-cases, troubleshooting, benchmarks, prompts, vault-structure, architecture, resources, getting-started, index
- Tests: 326 passing (2 new), 91% coverage

## Test plan

- [x] `make check` passes (lint + mypy + 326 tests)
- [x] Site builds cleanly (`npx astro build`)
- [x] Security audit: no silent failures in new code paths
- [x] UX audit: no stale tool names in source, tests, or docs
- [x] Lessons regression: all 12 past lessons verified intact
- [x] Zero `anyOf` in JSON schemas (all 10 tools clean)
- [ ] Manual: verify all 10 tools visible in Claude Code deferred tools list after install