### PR TITLE
feat: add Dockerfile and CI smoke test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.venv/
+.git/
+.github/
+.claude/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+site/
+tests/
+docs/
+*.md
+!README.md
+!pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,16 @@ jobs:
 
       - name: Build
         run: uv build
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t hive-vault:ci .
+
+      - name: Smoke test
+        run: |
+          docker run --rm hive-vault:ci python -c "from hive.server import create_server; print('OK')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim AS builder
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+COPY pyproject.toml uv.lock README.md ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+COPY src/ src/
+RUN uv pip install --no-cache-dir --no-deps . --python .venv/bin/python
+
+
+FROM python:3.12-slim
+
+RUN useradd --create-home --shell /bin/bash hive
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+USER hive
+ENTRYPOINT ["hive-vault"]


### PR DESCRIPTION
## Summary

- Multi-stage Dockerfile (172MB, non-root user, `python:3.12-slim`)
- `.dockerignore` to exclude tests, site, venv, git
- CI `docker` job: builds image + smoke test (runs after `check` passes)

Required for [Glama listing](https://glama.ai/mcp/servers) and [awesome-mcp-servers PR #3004](https://github.com/punkpeye/awesome-mcp-servers/pull/3004).

## Test plan

- [x] `docker build` succeeds locally
- [x] `docker run --rm hive-vault:test python -c "from hive.server import create_server"` passes
- [x] Image size: 172MB
- [ ] CI `docker` job passes