### PR TITLE
chore: add Glama listing badge and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 [![Docs](https://img.shields.io/badge/docs-hive-blue)](https://mlorentedev.github.io/hive/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+<a href="https://glama.ai/mcp/servers/mlorentedev/hive">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/mlorentedev/hive/badge" />
+</a>
+
 <!-- mcp-name: io.github.mlorentedev/hive-vault -->
 
 **Your AI coding assistant forgets everything between sessions. Hive fixes that.**

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["mlorentedev"]
+}


### PR DESCRIPTION
## Summary
- Add `glama.json` with maintainer declaration for Glama MCP directory
- Add Glama badge to README for discoverability

Completes Glama listing requirements from https://glama.ai/mcp/servers/mlorentedev/hive