### PR TITLE
fix(vault_patch): tolerant matching for read→patch workflow

### DIFF
--- a/docs/plans/2026-03-11-vault-patch-tolerant-matching.md
+++ b/docs/plans/2026-03-11-vault-patch-tolerant-matching.md
@@ -1,0 +1,355 @@
+# vault_patch Tolerant Matching — Implementation Plan
+
+**Goal:** Fix the broken read→patch workflow (Issue #52) by making `vault_patch` match text against the body (post-frontmatter) with whitespace-tolerant fallback, and provide diagnostic error messages on failure.
+
+**Architecture:** Three-pass cascading match — exact on full file (current), exact on body-only, whitespace-normalized on body. A new `_match_and_replace()` helper in `_helpers.py` encapsulates the logic. On total failure, `difflib.SequenceMatcher` provides similarity diagnostics.
+
+**Tech Stack:** Python 3.12+, difflib (stdlib), pytest, mypy --strict
+
+---
+
+### Task 1: Add `_match_and_replace` helper with exact body-only matching
+
+**Files:**
+- Modify: `src/hive/_helpers.py`
+- Test: `tests/test_helpers.py`
+
+**Step 1: Write failing tests**
+
+In `tests/test_helpers.py` (create if needed), add:
+
+```python
+import pytest
+from hive._helpers import _match_and_replace
+
+
+_FM = "---\nid: test\ntype: note\nstatus: active\n---\n\n"
+
+
+class TestMatchAndReplace:
+    """Tests for _match_and_replace cascading logic."""
+
+    def test_exact_match_full_file(self) -> None:
+        """Pass 1: exact match on full content including frontmatter works."""
+        content = _FM + "# Title\n\nHello world\n"
+        result = _match_and_replace(content, "Hello world", "Goodbye world")
+        assert result is not None
+        ok, new_content = result
+        assert ok
+        assert "Goodbye world" in new_content
+        assert new_content.startswith("---")
+
+    def test_exact_match_body_only(self) -> None:
+        """Pass 2: old_text matches body but NOT full file (frontmatter omitted by caller)."""
+        content = _FM + "# Title\n\nHello world\n"
+        # Simulate LLM copying just body text (no frontmatter)
+        old_text = "# Title\n\nHello world\n"
+        result = _match_and_replace(content, old_text, "# Title\n\nGoodbye world\n")
+        assert result is not None
+        ok, new_content = result
+        assert ok
+        assert new_content.startswith("---")
+        assert "Goodbye world" in new_content
+
+    def test_whitespace_normalized_match(self) -> None:
+        """Pass 3: trailing whitespace differences tolerated."""
+        content = _FM + "# Title\n\n| A | B |   \n|---|---|\n| 1 | 2 |  \n"
+        # LLM stripped trailing spaces
+        old_text = "| A | B |\n|---|---|\n| 1 | 2 |"
+        result = _match_and_replace(content, old_text, "| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |")
+        assert result is not None
+        ok, new_content = result
+        assert ok
+        assert "| C |" in new_content
+
+    def test_ambiguous_returns_error(self) -> None:
+        """Ambiguous match (>1 occurrence) returns error tuple."""
+        content = _FM + "word\nword\n"
+        result = _match_and_replace(content, "word", "replacement")
+        assert result is not None
+        ok, msg = result
+        assert not ok
+        assert "ambiguous" in msg.lower()
+
+    def test_not_found_returns_diagnostic(self) -> None:
+        """Total miss returns diagnostic with similarity hint."""
+        content = _FM + "# Title\n\nHello world\n"
+        result = _match_and_replace(content, "completely different text", "replacement")
+        assert result is not None
+        ok, msg = result
+        assert not ok
+        assert "not found" in msg.lower()
+
+    def test_no_frontmatter_file(self) -> None:
+        """Files without frontmatter still work (pass 1 or pass 3)."""
+        content = "# Plain file\n\nHello world\n"
+        result = _match_and_replace(content, "Hello world", "Goodbye world")
+        assert result is not None
+        ok, new_content = result
+        assert ok
+        assert "Goodbye world" in new_content
+
+    def test_similarity_hint_on_close_miss(self) -> None:
+        """When old_text is close but not exact, error includes similarity %."""
+        content = _FM + "Hello world\n"
+        result = _match_and_replace(content, "Hello worlds", "replacement")
+        assert result is not None
+        ok, msg = result
+        assert not ok
+        assert "%" in msg  # similarity percentage shown
+```
+
+**Step 2: Run tests to verify failure**
+
+Run: `make test` or `pytest tests/test_helpers.py::TestMatchAndReplace -v`
+Expected: FAIL — `_match_and_replace` does not exist yet.
+
+**Step 3: Implement `_match_and_replace`**
+
+In `src/hive/_helpers.py`, add:
+
+```python
+import difflib
+
+from hive.frontmatter import extract_body
+
+
+def _match_and_replace(
+    content: str,
+    old_text: str,
+    new_text: str,
+) -> tuple[bool, str]:
+    """Cascading match-and-replace: exact → body-only → whitespace-normalized.
+
+    Returns (True, new_content) on success, (False, error_message) on failure.
+    """
+    # ── Pass 1: Exact match on full content ──
+    count = content.count(old_text)
+    if count == 1:
+        return True, content.replace(old_text, new_text, 1)
+    if count > 1:
+        return False, f"Ambiguous: old_text appears {count} times."
+
+    # ── Pass 2: Exact match on body (post-frontmatter) ──
+    body = extract_body(content)
+    frontmatter = content[: len(content) - len(body)] if body != content else ""
+
+    count = body.count(old_text)
+    if count == 1:
+        return True, frontmatter + body.replace(old_text, new_text, 1)
+    if count > 1:
+        return False, f"Ambiguous: old_text appears {count} times."
+
+    # ── Pass 3: Whitespace-normalized match on body ──
+    def _normalize(text: str) -> str:
+        return "\n".join(line.rstrip() for line in text.splitlines())
+
+    norm_body = _normalize(body)
+    norm_old = _normalize(old_text)
+
+    if norm_old:
+        count = norm_body.count(norm_old)
+        if count == 1:
+            return True, frontmatter + norm_body.replace(norm_old, new_text, 1)
+        if count > 1:
+            return False, f"Ambiguous: old_text appears {count} times (after whitespace normalization)."
+
+    # ── Diagnostic: similarity hint ──
+    best_ratio = 0.0
+    search_in = norm_body if norm_body else body
+    if norm_old and len(norm_old) <= len(search_in):
+        matcher = difflib.SequenceMatcher(None, norm_old, "")
+        # Slide a window roughly the size of old_text across the body
+        window = len(norm_old)
+        lines = search_in.splitlines()
+        old_lines = norm_old.splitlines()
+        n_old = len(old_lines)
+        for i in range(max(1, len(lines) - n_old + 1)):
+            chunk = "\n".join(lines[i : i + n_old])
+            matcher.set_seq2(chunk)
+            ratio = matcher.ratio()
+            if ratio > best_ratio:
+                best_ratio = ratio
+
+    pct = int(best_ratio * 100)
+    hint = f" Best match: {pct}% similar." if pct > 40 else ""
+    return False, f"old_text not found.{hint}"
+```
+
+**Step 4: Run tests to verify pass**
+
+Run: `pytest tests/test_helpers.py::TestMatchAndReplace -v`
+Expected: all 8 tests PASS.
+
+**Step 5: Run full suite + lint**
+
+Run: `make check`
+Expected: lint clean, mypy clean, all tests pass.
+
+---
+
+### Task 2: Wire `_match_and_replace` into `vault_patch`
+
+**Files:**
+- Modify: `src/hive/_vault_write.py`
+- Test: `tests/test_server.py`
+
+**Step 1: Write failing tests for new vault_patch behavior**
+
+Add to `TestVaultPatch` in `tests/test_server.py`:
+
+```python
+async def test_patch_matches_body_without_frontmatter(self, git_vault: Path) -> None:
+    """old_text from body (no frontmatter) matches correctly."""
+    mcp = create_server(vault_path=git_vault)
+    # old_text is body content only — no frontmatter prefix
+    result = _text(await mcp.call_tool(
+        "vault_patch",
+        {
+            "project": "testproject",
+            "path": "11-tasks.md",
+            "old_text": "- [ ] Task one",
+            "new_text": "- [x] Task one (done)",
+        },
+    ))
+    assert "1 patch" in result.lower()
+    content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
+    assert "- [x] Task one (done)" in content
+    # Frontmatter preserved
+    assert content.startswith("---")
+
+async def test_patch_tolerates_trailing_whitespace(self, git_vault: Path) -> None:
+    """Trailing whitespace differences between old_text and file are tolerated."""
+    tasks = git_vault / "10_projects" / "testproject" / "11-tasks.md"
+    # Add trailing spaces to the file
+    raw = tasks.read_text()
+    raw = raw.replace("- [ ] Task one", "- [ ] Task one   ")
+    tasks.write_text(raw)
+    # Commit so git is clean
+    import subprocess
+    subprocess.run(["git", "add", "."], cwd=git_vault, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "ws"], cwd=git_vault, capture_output=True)
+
+    mcp = create_server(vault_path=git_vault)
+    # old_text has NO trailing spaces (LLM stripped them)
+    result = _text(await mcp.call_tool(
+        "vault_patch",
+        {
+            "project": "testproject",
+            "path": "11-tasks.md",
+            "old_text": "- [ ] Task one",
+            "new_text": "- [x] Task one",
+        },
+    ))
+    assert "1 patch" in result.lower()
+
+async def test_patch_not_found_shows_similarity(self, git_vault: Path) -> None:
+    """When old_text is close but wrong, error includes similarity hint."""
+    mcp = create_server(vault_path=git_vault)
+    result = _text(await mcp.call_tool(
+        "vault_patch",
+        {
+            "project": "testproject",
+            "path": "11-tasks.md",
+            "old_text": "- [ ] Task ones",  # typo
+            "new_text": "- [x] Task one",
+        },
+    ))
+    assert "not found" in result.lower()
+    assert "%" in result  # similarity hint
+
+async def test_patch_roundtrip_query_then_patch(self, git_vault: Path) -> None:
+    """The real-world workflow: vault_query output → vault_patch old_text."""
+    mcp = create_server(vault_path=git_vault)
+    # Step 1: Read via vault_query
+    query_result = _text(await mcp.call_tool(
+        "vault_query",
+        {"project": "testproject", "section": "tasks"},
+    ))
+    # Step 2: Extract a line from the query result, use as old_text
+    # vault_query returns full content including frontmatter,
+    # but the LLM might only copy body lines
+    assert "- [ ] Task one" in query_result
+    result = _text(await mcp.call_tool(
+        "vault_patch",
+        {
+            "project": "testproject",
+            "path": "11-tasks.md",
+            "old_text": "- [ ] Task one",
+            "new_text": "- [x] Task one (completed)",
+        },
+    ))
+    assert "1 patch" in result.lower()
+```
+
+**Step 2: Run new tests to verify they fail (the ws one should fail, others may pass already)**
+
+Run: `pytest tests/test_server.py::TestVaultPatch::test_patch_tolerates_trailing_whitespace -v`
+Expected: FAIL — current code does byte-exact match.
+
+**Step 3: Modify `vault_patch` to use `_match_and_replace`**
+
+In `src/hive/_vault_write.py`, replace the match-and-replace loop (lines 252-281) with:
+
+```python
+from hive._helpers import _match_and_replace
+
+# Replace the for-loop that does working.count(old)/working.replace(old, new, 1)
+# with calls to _match_and_replace:
+
+working = content
+for i, patch in enumerate(patch_list, 1):
+    if "old_text" not in patch or "new_text" not in patch:
+        label = f"patch {i}: " if len(patch_list) > 1 else ""
+        return track(
+            ctx, "vault_patch",
+            f"{label}Each patch must have 'old_text' and 'new_text' keys.",
+            project,
+        )
+    ok, result = _match_and_replace(working, patch["old_text"], patch["new_text"])
+    if not ok:
+        label = f"patch {i}: " if len(patch_list) > 1 else ""
+        return track(ctx, "vault_patch", f"{label}{result}", project)
+    working = result
+```
+
+Note: For multi-patch, after the first patch modifies `working`, subsequent patches run against the already-modified content. The frontmatter extraction in `_match_and_replace` handles this correctly because frontmatter is preserved in the working copy.
+
+**Step 4: Run all vault_patch tests**
+
+Run: `pytest tests/test_server.py::TestVaultPatch -v`
+Expected: ALL pass (existing + new).
+
+**Step 5: Run full suite**
+
+Run: `make check`
+Expected: lint + mypy + all tests pass.
+
+---
+
+### Task 3: Verify and commit
+
+**Step 1: Run `make check` to confirm everything is clean**
+
+Run: `make check`
+Expected: lint clean, mypy clean, all tests pass.
+
+**Step 2: Verify the ambiguous-match path is not broken**
+
+The existing tests cover this (`test_single_patch_ambiguous`, `test_multi_patch_ambiguous_aborts_all`). The new `_match_and_replace` preserves the ambiguity check at each pass level. Confirm these still pass in the full run.
+
+**Step 3: Commit**
+
+```bash
+git add src/hive/_helpers.py src/hive/_vault_write.py tests/test_helpers.py tests/test_server.py
+git commit -m "fix(vault_patch): tolerant matching for read→patch workflow (#52)
+
+vault_patch now uses three-pass cascading match:
+1. Exact match on full file (existing behavior)
+2. Exact match on body only (post-frontmatter)
+3. Whitespace-normalized match on body (rstrip per line)
+
+On failure, error message includes similarity % diagnostic.
+
+Closes #52"
+```

--- a/src/hive/_context.py
+++ b/src/hive/_context.py
@@ -28,3 +28,9 @@ class ServerContext:
     stale_days: int
     openrouter_budget: float
     openrouter_paid_model: str
+
+    def close(self) -> None:
+        """Close all database connections held by this context."""
+        self.tracker.close()
+        self.budget.close()
+        self.relevance.close()

--- a/src/hive/_helpers.py
+++ b/src/hive/_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import difflib
 import logging
 import re
 import subprocess
@@ -10,7 +11,7 @@ from typing import TYPE_CHECKING
 
 from mcp.types import ToolAnnotations
 
-from hive.frontmatter import parse_date, parse_frontmatter
+from hive.frontmatter import extract_body, parse_date, parse_frontmatter
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -147,6 +148,75 @@ def _resolve_file(
         return f"'{target}' not found in project '{project}'."
 
     return filepath
+
+
+# ── Match and replace ──────────────────────────────────────────────────
+
+
+def _normalize_ws(text: str) -> str:
+    """Strip trailing whitespace per line."""
+    return "\n".join(line.rstrip() for line in text.splitlines())
+
+
+def _match_and_replace(
+    content: str,
+    old_text: str,
+    new_text: str,
+) -> tuple[bool, str]:
+    """Cascading match-and-replace: exact → body-only → whitespace-normalized.
+
+    Returns ``(True, new_content)`` on success, ``(False, error_message)``
+    on failure.
+    """
+    # ── Pass 1: Exact match on full content ──
+    count = content.count(old_text)
+    if count == 1:
+        return True, content.replace(old_text, new_text, 1)
+    if count > 1:
+        return False, f"Ambiguous: old_text appears {count} times."
+
+    # ── Pass 2: Exact match on body (post-frontmatter) ──
+    body = extract_body(content)
+    frontmatter = content[: len(content) - len(body)] if body != content else ""
+
+    count = body.count(old_text)
+    if count == 1:
+        return True, frontmatter + body.replace(old_text, new_text, 1)
+    if count > 1:
+        return False, f"Ambiguous: old_text appears {count} times."
+
+    # ── Pass 3: Whitespace-normalized match on body ──
+    norm_body = _normalize_ws(body)
+    norm_old = _normalize_ws(old_text)
+
+    if norm_old:
+        count = norm_body.count(norm_old)
+        if count == 1:
+            return True, frontmatter + norm_body.replace(norm_old, new_text, 1)
+        if count > 1:
+            return (
+                False,
+                f"Ambiguous: old_text appears {count} times"
+                " (after whitespace normalization).",
+            )
+
+    # ── Diagnostic: similarity hint ──
+    best_ratio = 0.0
+    search_in = norm_body or body
+    if norm_old:
+        matcher = difflib.SequenceMatcher(None, norm_old, "")
+        lines = search_in.splitlines()
+        n_old = max(len(norm_old.splitlines()), 1)
+        for i in range(max(1, len(lines) - n_old + 2)):
+            chunk = "\n".join(lines[i : i + n_old])
+            matcher.set_seq2(chunk)
+            ratio = matcher.ratio()
+            if ratio > best_ratio:
+                best_ratio = ratio
+
+    pct = int(best_ratio * 100)
+    hint = f" Best match: {pct}% similar." if pct > 40 else ""
+    return False, f"old_text not found.{hint}"
 
 
 # ── Text formatting ────────────────────────────────────────────────────

--- a/src/hive/_vault_read.py
+++ b/src/hive/_vault_read.py
@@ -20,7 +20,7 @@ from hive._helpers import (
     count_stale,
     track,
 )
-from hive.frontmatter import parse_date, parse_frontmatter
+from hive.frontmatter import extract_body, parse_date, parse_frontmatter
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -273,9 +273,10 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
                 content = _safe_read(md_file)
                 if content is None:
                     continue
+                body = extract_body(content)
                 matching = [
                     ln.strip()
-                    for ln in content.splitlines()
+                    for ln in body.splitlines()
                     if query_lower in ln.lower()
                 ]
                 if not matching:
@@ -352,16 +353,17 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
                 if tag_filter and tag_filter not in fm.tags:
                     continue
 
+            body = extract_body(content)
             if use_regex:
                 matching_lines = [
                     line.strip()
-                    for line in content.splitlines()
+                    for line in body.splitlines()
                     if rx_pattern.search(line)
                 ]
             else:
                 matching_lines = [
                     line.strip()
-                    for line in content.splitlines()
+                    for line in body.splitlines()
                     if query_lower in line.lower()
                 ]
             if matching_lines:
@@ -408,8 +410,8 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             task_content = _safe_read(task_result)
             if task_content is not None:
                 ctx.relevance.record_access(project, "tasks")
-                body = _truncate(task_content, 50)
-                sections["tasks"] = f"## Active Tasks\n{body}"
+                task_body = _truncate(extract_body(task_content), 50)
+                sections["tasks"] = f"## Active Tasks\n{task_body}"
 
         # Lessons
         lessons_result = _resolve_file(
@@ -419,8 +421,8 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             lessons_content = _safe_read(lessons_result)
             if lessons_content is not None:
                 ctx.relevance.record_access(project, "lessons")
-                lines = lessons_content.splitlines()
-                tail = lines[-30:] if len(lines) > 30 else lines
+                lesson_lines = extract_body(lessons_content).splitlines()
+                tail = lesson_lines[-30:] if len(lesson_lines) > 30 else lesson_lines
                 sections["lessons"] = "## Recent Lessons\n" + "\n".join(tail)
 
         # Git activity (always shown, not ranked)

--- a/src/hive/_vault_write.py
+++ b/src/hive/_vault_write.py
@@ -10,6 +10,7 @@ from hive._helpers import (
     _check_path_boundary,
     _git_commit,
     _make_frontmatter,
+    _match_and_replace,
     _resolve_project_dir,
     track,
 )
@@ -258,27 +259,15 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                     f"{label}Each patch must have 'old_text' and 'new_text' keys.",
                     project,
                 )
-            old = patch["old_text"]
-            new = patch["new_text"]
-            count = working.count(old)
-
-            if count == 0:
+            ok, result = _match_and_replace(
+                working, patch["old_text"], patch["new_text"],
+            )
+            if not ok:
                 label = f"patch {i}: " if len(patch_list) > 1 else ""
                 return track(
-                    ctx, "vault_patch",
-                    f"{label}old_text not found in file '{path}'.",
-                    project,
+                    ctx, "vault_patch", f"{label}{result}", project,
                 )
-            if count > 1:
-                label = f"patch {i}: " if len(patch_list) > 1 else ""
-                return track(
-                    ctx, "vault_patch",
-                    f"{label}Ambiguous: old_text appears {count} times "
-                    f"in '{path}'. "
-                    "Provide more context to make the match unique.",
-                    project,
-                )
-            working = working.replace(old, new, 1)
+            working = result
 
         try:
             filepath.write_text(working, encoding="utf-8")

--- a/src/hive/budget.py
+++ b/src/hive/budget.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -64,6 +65,14 @@ class BudgetTracker:
     def can_spend(self, budget: float, amount: float) -> bool:
         """Check if spending `amount` would stay within budget."""
         return self.month_remaining(budget) >= amount
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    def __del__(self) -> None:
+        with contextlib.suppress(Exception):
+            self._conn.close()
 
     def month_stats(self, budget: float) -> dict[str, Any]:
         """Aggregate stats for the current month."""

--- a/src/hive/relevance.py
+++ b/src/hive/relevance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import random
 import sqlite3
 from pathlib import Path
@@ -43,6 +44,14 @@ class RelevanceTracker:
         self._alpha = alpha
         self._decay_factor = decay_factor
         self._epsilon = epsilon
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    def __del__(self) -> None:
+        with contextlib.suppress(Exception):
+            self._conn.close()
 
     def record_access(
         self, project: str, section: str, *, is_write: bool = False,

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -377,6 +377,7 @@ Total estimated savings: ~C tokens
     register_workers(mcp, ctx)
 
     mcp._usage_tracker = tracker  # type: ignore[attr-defined]
+    mcp._hive_ctx = ctx  # type: ignore[attr-defined]
 
     return mcp
 

--- a/src/hive/usage.py
+++ b/src/hive/usage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -42,6 +43,14 @@ class UsageTracker:
             (tool, project, response_lines),
         )
         self._conn.commit()
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    def __del__(self) -> None:
+        with contextlib.suppress(Exception):
+            self._conn.close()
 
     def stats(self, since_days: int = 30) -> dict[str, Any]:
         """Aggregate usage stats for the last N days."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,18 @@
 """Shared test fixtures for Hive test suite."""
 
+from __future__ import annotations
+
 import subprocess
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from hive.budget import BudgetTracker
 from hive.clients import OllamaClient, OpenRouterClient
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
 
 
 @pytest.fixture
@@ -154,9 +160,11 @@ def git_vault(mock_vault: Path) -> Path:
 
 
 @pytest.fixture
-def budget() -> BudgetTracker:
+def budget() -> Generator[BudgetTracker, None, None]:
     """In-memory budget tracker for worker tests."""
-    return BudgetTracker(db_path=":memory:")
+    bt = BudgetTracker(db_path=":memory:")
+    yield bt
+    bt.close()
 
 
 @pytest.fixture

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,93 @@
+"""Tests for _match_and_replace cascading logic."""
+
+from __future__ import annotations
+
+from hive._helpers import _match_and_replace
+
+_FM = "---\nid: test\ntype: note\nstatus: active\n---\n\n"
+
+
+class TestMatchAndReplace:
+    """Tests for _match_and_replace cascading logic."""
+
+    def test_exact_match_full_file(self) -> None:
+        """Pass 1: exact match on full content including frontmatter works."""
+        content = _FM + "# Title\n\nHello world\n"
+        ok, new_content = _match_and_replace(content, "Hello world", "Goodbye world")
+        assert ok
+        assert "Goodbye world" in new_content
+        assert new_content.startswith("---")
+
+    def test_exact_match_body_only(self) -> None:
+        """Pass 2: old_text matches body but is ambiguous in full file."""
+        # "active" appears in frontmatter AND body — ambiguous in Pass 1,
+        # but unique in Pass 2 (body-only)
+        content = _FM + "# Title\n\nStatus: active\n"
+        ok, new_content = _match_and_replace(
+            content, "Status: active", "Status: done",
+        )
+        assert ok
+        assert new_content.startswith("---")
+        assert "Status: done" in new_content
+
+    def test_whitespace_normalized_match(self) -> None:
+        """Pass 3: trailing whitespace differences tolerated."""
+        content = _FM + "# Title\n\n| A | B |   \n|---|---|\n| 1 | 2 |  \n"
+        # LLM stripped trailing spaces
+        old_text = "| A | B |\n|---|---|\n| 1 | 2 |"
+        ok, new_content = _match_and_replace(
+            content, old_text, "| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |",
+        )
+        assert ok
+        assert "| C |" in new_content
+
+    def test_ambiguous_returns_error(self) -> None:
+        """Ambiguous match (>1 occurrence) returns error tuple."""
+        content = _FM + "word\nword\n"
+        ok, msg = _match_and_replace(content, "word", "replacement")
+        assert not ok
+        assert "ambiguous" in msg.lower()
+
+    def test_not_found_returns_diagnostic(self) -> None:
+        """Total miss returns diagnostic."""
+        content = _FM + "# Title\n\nHello world\n"
+        ok, msg = _match_and_replace(
+            content, "completely different text", "replacement",
+        )
+        assert not ok
+        assert "not found" in msg.lower()
+
+    def test_no_frontmatter_file(self) -> None:
+        """Files without frontmatter still work (pass 1 or pass 3)."""
+        content = "# Plain file\n\nHello world\n"
+        ok, new_content = _match_and_replace(
+            content, "Hello world", "Goodbye world",
+        )
+        assert ok
+        assert "Goodbye world" in new_content
+
+    def test_similarity_hint_on_close_miss(self) -> None:
+        """When old_text is close but not exact, error includes similarity %."""
+        content = _FM + "Hello world\n"
+        ok, msg = _match_and_replace(content, "Hello worlds", "replacement")
+        assert not ok
+        assert "%" in msg
+
+    def test_frontmatter_preserved_after_body_replace(self) -> None:
+        """Frontmatter is byte-identical after body replacement."""
+        content = _FM + "# Title\n\nOld content\n"
+        ok, new_content = _match_and_replace(
+            content, "Old content", "New content",
+        )
+        assert ok
+        assert new_content.startswith(_FM)
+
+    def test_whitespace_normalized_preserves_frontmatter(self) -> None:
+        """Pass 3 replacement preserves frontmatter."""
+        content = _FM + "Hello world  \n"
+        ok, new_content = _match_and_replace(
+            content, "Hello world", "Goodbye world",
+        )
+        assert ok
+        assert new_content.startswith("---")
+        assert "Goodbye world" in new_content

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,6 +12,7 @@ from hive.clients import ClientResponse, ModelInfo
 from hive.server import create_server
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from pathlib import Path
 
     from fastmcp import FastMCP
@@ -32,10 +33,18 @@ def _resource_text(result: ResourceResult) -> str:
     return str(result.contents[0].content)
 
 
+def _close_server(mcp: FastMCP) -> None:
+    ctx = getattr(mcp, "_hive_ctx", None)
+    if ctx is not None:
+        ctx.close()
+
+
 @pytest.fixture
-def vault_mcp(mock_vault: Path) -> FastMCP:
+def vault_mcp(mock_vault: Path) -> Generator[FastMCP, None, None]:
     """Create a vault server backed by mock_vault."""
-    return create_server(vault_path=mock_vault)
+    mcp = create_server(vault_path=mock_vault)
+    yield mcp
+    _close_server(mcp)
 
 
 # ── vault_list ──────────────────────────────────────────────
@@ -241,7 +250,7 @@ class TestVaultSearch:
         assert "positive" in _text(result).lower()
 
     async def test_searches_across_files(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool("vault_search", {"query": "active"})
+        result = await vault_mcp.call_tool("vault_search", {"query": "Test"})
         text = _text(result)
         assert "00-context.md" in text
         assert "11-tasks.md" in text
@@ -251,7 +260,7 @@ class TestVaultSearch:
         assert "Some lesson" in _text(result)
 
     async def test_max_lines_limits_output(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool("vault_search", {"query": "active", "max_lines": 5})
+        result = await vault_mcp.call_tool("vault_search", {"query": "Test", "max_lines": 5})
         text = _text(result)
         assert "truncated" in text.lower()
         content_lines = text.split("[...")[0].strip().splitlines()
@@ -1053,7 +1062,7 @@ class TestVaultSearchRanked:
 
     async def test_max_lines_truncates(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_search", {"query": "active", "ranked": True, "max_lines": 5}
+            "vault_search", {"query": "Test", "ranked": True, "max_lines": 5}
         )
         text = _text(result)
         assert "truncated" in text.lower()
@@ -2268,6 +2277,113 @@ class TestVaultPatch:
         )
         count_after = int(after.stdout.strip())
         assert count_after == count_before + 1
+
+
+class TestVaultPatchTolerantMatching:
+    """Tests for tolerant matching in vault_patch (Issue #52)."""
+
+    async def test_patch_tolerates_trailing_whitespace(
+        self, git_vault: Path,
+    ) -> None:
+        """Multi-line old_text with trailing whitespace differences."""
+        tasks = git_vault / "10_projects" / "testproject" / "11-tasks.md"
+        # Write a table with trailing spaces on each line
+        raw = tasks.read_text()
+        raw = raw.replace(
+            "- [ ] Task one\n- [x] Task two",
+            "| A | B |   \n|---|---|  \n| 1 | 2 |   ",
+        )
+        tasks.write_text(raw)
+        import subprocess
+        subprocess.run(
+            ["git", "add", "."], cwd=git_vault, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "ws"], cwd=git_vault, capture_output=True,
+        )
+
+        mcp = create_server(vault_path=git_vault)
+        # LLM stripped trailing spaces from multi-line text
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "old_text": "| A | B |\n|---|---|\n| 1 | 2 |",
+                "new_text": "| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |",
+            },
+        ))
+        assert "1 patch" in result.lower()
+
+    async def test_patch_not_found_shows_similarity(
+        self, git_vault: Path,
+    ) -> None:
+        """Close miss includes similarity % in error."""
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "old_text": "- [ ] Task ones",
+                "new_text": "- [x] Task one",
+            },
+        ))
+        assert "not found" in result.lower()
+        assert "%" in result
+
+    async def test_patch_roundtrip_query_then_patch(
+        self, git_vault: Path,
+    ) -> None:
+        """Real workflow: vault_query output used as vault_patch old_text."""
+        mcp = create_server(vault_path=git_vault)
+        query_result = _text(await mcp.call_tool(
+            "vault_query",
+            {"project": "testproject", "section": "tasks"},
+        ))
+        assert "- [ ] Task one" in query_result
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "old_text": "- [ ] Task one",
+                "new_text": "- [x] Task one (completed)",
+            },
+        ))
+        assert "1 patch" in result.lower()
+
+    async def test_patch_body_only_match_when_frontmatter_overlaps(
+        self, git_vault: Path,
+    ) -> None:
+        """old_text matches body uniquely even if ambiguous in full file."""
+        tasks = git_vault / "10_projects" / "testproject" / "11-tasks.md"
+        # "active" is in the frontmatter status AND we add it to body
+        raw = tasks.read_text()
+        raw = raw.replace("- [ ] Task one", "- [ ] active task")
+        tasks.write_text(raw)
+        import subprocess
+        subprocess.run(
+            ["git", "add", "."], cwd=git_vault, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "ov"], cwd=git_vault, capture_output=True,
+        )
+
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool(
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "11-tasks.md",
+                "old_text": "- [ ] active task",
+                "new_text": "- [x] active task (done)",
+            },
+        ))
+        assert "1 patch" in result.lower()
+        content = tasks.read_text()
+        assert content.startswith("---")
+        assert "- [x] active task (done)" in content
 
 
 class TestGitCommitResilience:

--- a/uv.lock
+++ b/uv.lock
@@ -389,7 +389,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.0.2"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -409,13 +409,14 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/6b/1a7ec89727797fb07ec0928e9070fa2f45e7b35718e1fe01633a34c35e45/fastmcp-3.0.2.tar.gz", hash = "sha256:6bd73b4a3bab773ee6932df5249dcbcd78ed18365ed0aeeb97bb42702a7198d7", size = 17239351, upload-time = "2026-02-22T16:32:28.843Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/70/862026c4589441f86ad3108f05bfb2f781c6b322ad60a982f40b303b47d7/fastmcp-3.1.0.tar.gz", hash = "sha256:e25264794c734b9977502a51466961eeecff92a0c2f3b49c40c070993628d6d0", size = 17347083, upload-time = "2026-03-03T02:43:11.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/5a/f410a9015cfde71adf646dab4ef2feae49f92f34f6050fcfb265eb126b30/fastmcp-3.0.2-py3-none-any.whl", hash = "sha256:f513d80d4b30b54749fe8950116b1aab843f3c293f5cb971fc8665cb48dbb028", size = 606268, upload-time = "2026-02-22T16:32:30.992Z" },
+    { url = "https://files.pythonhosted.org/packages/17/07/516f5b20d88932e5a466c2216b628e5358a71b3a9f522215607c3281de05/fastmcp-3.1.0-py3-none-any.whl", hash = "sha256:b1f73b56fd3b0cb2bd9e2a144fc650d5cc31587ed129d996db7710e464ae8010", size = 633749, upload-time = "2026-03-03T02:43:09.06Z" },
 ]
 
 [[package]]
@@ -429,7 +430,7 @@ wheels = [
 
 [[package]]
 name = "hive-vault"
-version = "1.8.0"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -1292,27 +1293,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.4"
+version = "0.15.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/31/d6e536cdebb6568ae75a7f00e4b4819ae0ad2640c3604c305a0428680b0c/ruff-0.15.4.tar.gz", hash = "sha256:3412195319e42d634470cc97aa9803d07e9d5c9223b99bcb1518f0c725f26ae1", size = 4569550, upload-time = "2026-02-26T20:04:14.959Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9b/840e0039e65fcf12758adf684d2289024d6140cde9268cc59887dc55189c/ruff-0.15.5.tar.gz", hash = "sha256:7c3601d3b6d76dce18c5c824fc8d06f4eef33d6df0c21ec7799510cde0f159a2", size = 4574214, upload-time = "2026-03-05T20:06:34.946Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/82/c11a03cfec3a4d26a0ea1e571f0f44be5993b923f905eeddfc397c13d360/ruff-0.15.4-py3-none-linux_armv6l.whl", hash = "sha256:a1810931c41606c686bae8b5b9a8072adac2f611bb433c0ba476acba17a332e0", size = 10453333, upload-time = "2026-02-26T20:04:20.093Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/5d/6a1f271f6e31dffb31855996493641edc3eef8077b883eaf007a2f1c2976/ruff-0.15.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5a1632c66672b8b4d3e1d1782859e98d6e0b4e70829530666644286600a33992", size = 10853356, upload-time = "2026-02-26T20:04:05.808Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/d8/0fab9f8842b83b1a9c2bf81b85063f65e93fb512e60effa95b0be49bfc54/ruff-0.15.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a4386ba2cd6c0f4ff75252845906acc7c7c8e1ac567b7bc3d373686ac8c222ba", size = 10187434, upload-time = "2026-02-26T20:03:54.656Z" },
-    { url = "https://files.pythonhosted.org/packages/85/cc/cc220fd9394eff5db8d94dec199eec56dd6c9f3651d8869d024867a91030/ruff-0.15.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2496488bdfd3732747558b6f95ae427ff066d1fcd054daf75f5a50674411e75", size = 10535456, upload-time = "2026-02-26T20:03:52.738Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/0f/bced38fa5cf24373ec767713c8e4cadc90247f3863605fb030e597878661/ruff-0.15.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3f1c4893841ff2d54cbda1b2860fa3260173df5ddd7b95d370186f8a5e66a4ac", size = 10287772, upload-time = "2026-02-26T20:04:08.138Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/90/58a1802d84fed15f8f281925b21ab3cecd813bde52a8ca033a4de8ab0e7a/ruff-0.15.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:820b8766bd65503b6c30aaa6331e8ef3a6e564f7999c844e9a547c40179e440a", size = 11049051, upload-time = "2026-02-26T20:04:03.53Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ac/b7ad36703c35f3866584564dc15f12f91cb1a26a897dc2fd13d7cb3ae1af/ruff-0.15.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9fb74bab47139c1751f900f857fa503987253c3ef89129b24ed375e72873e85", size = 11890494, upload-time = "2026-02-26T20:04:10.497Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3d/3eb2f47a39a8b0da99faf9c54d3eb24720add1e886a5309d4d1be73a6380/ruff-0.15.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f80c98765949c518142b3a50a5db89343aa90f2c2bf7799de9986498ae6176db", size = 11326221, upload-time = "2026-02-26T20:04:12.84Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/90/bf134f4c1e5243e62690e09d63c55df948a74084c8ac3e48a88468314da6/ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:451a2e224151729b3b6c9ffb36aed9091b2996fe4bdbd11f47e27d8f2e8888ec", size = 11168459, upload-time = "2026-02-26T20:04:00.969Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e5/a64d27688789b06b5d55162aafc32059bb8c989c61a5139a36e1368285eb/ruff-0.15.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a8f157f2e583c513c4f5f896163a93198297371f34c04220daf40d133fdd4f7f", size = 11104366, upload-time = "2026-02-26T20:03:48.099Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/f6/32d1dcb66a2559763fc3027bdd65836cad9eb09d90f2ed6a63d8e9252b02/ruff-0.15.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:917cc68503357021f541e69b35361c99387cdbbf99bd0ea4aa6f28ca99ff5338", size = 10510887, upload-time = "2026-02-26T20:03:45.771Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/92/22d1ced50971c5b6433aed166fcef8c9343f567a94cf2b9d9089f6aa80fe/ruff-0.15.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e9737c8161da79fd7cfec19f1e35620375bd8b2a50c3e77fa3d2c16f574105cc", size = 10285939, upload-time = "2026-02-26T20:04:22.42Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/f4/7c20aec3143837641a02509a4668fb146a642fd1211846634edc17eb5563/ruff-0.15.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:291258c917539e18f6ba40482fe31d6f5ac023994ee11d7bdafd716f2aab8a68", size = 10765471, upload-time = "2026-02-26T20:03:58.924Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/09/6d2f7586f09a16120aebdff8f64d962d7c4348313c77ebb29c566cefc357/ruff-0.15.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3f83c45911da6f2cd5936c436cf86b9f09f09165f033a99dcf7477e34041cbc3", size = 11263382, upload-time = "2026-02-26T20:04:24.424Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/47/20/5369c3ce21588c708bcbe517a8fbe1a8dfdb5dfd5137e14790b1da71612c/ruff-0.15.5-py3-none-linux_armv6l.whl", hash = "sha256:4ae44c42281f42e3b06b988e442d344a5b9b72450ff3c892e30d11b29a96a57c", size = 10478185, upload-time = "2026-03-05T20:06:29.093Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ed/e81dd668547da281e5dce710cf0bc60193f8d3d43833e8241d006720e42b/ruff-0.15.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6edd3792d408ebcf61adabc01822da687579a1a023f297618ac27a5b51ef0080", size = 10859201, upload-time = "2026-03-05T20:06:32.632Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:89f463f7c8205a9f8dea9d658d59eff49db05f88f89cc3047fb1a02d9f344010", size = 10184752, upload-time = "2026-03-05T20:06:40.312Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0e/ba49e2c3fa0395b3152bad634c7432f7edfc509c133b8f4529053ff024fb/ruff-0.15.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba786a8295c6574c1116704cf0b9e6563de3432ac888d8f83685654fe528fd65", size = 10534857, upload-time = "2026-03-05T20:06:19.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/71/39234440f27a226475a0659561adb0d784b4d247dfe7f43ffc12dd02e288/ruff-0.15.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd4b801e57955fe9f02b31d20375ab3a5c4415f2e5105b79fb94cf2642c91440", size = 10309120, upload-time = "2026-03-05T20:06:00.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/4140aa86a93df032156982b726f4952aaec4a883bb98cb6ef73c347da253/ruff-0.15.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:391f7c73388f3d8c11b794dbbc2959a5b5afe66642c142a6effa90b45f6f5204", size = 11047428, upload-time = "2026-03-05T20:05:51.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f7/4953e7e3287676f78fbe85e3a0ca414c5ca81237b7575bdadc00229ac240/ruff-0.15.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8dc18f30302e379fe1e998548b0f5e9f4dff907f52f73ad6da419ea9c19d66c8", size = 11914251, upload-time = "2026-03-05T20:06:22.887Z" },
+    { url = "https://files.pythonhosted.org/packages/77/46/0f7c865c10cf896ccf5a939c3e84e1cfaeed608ff5249584799a74d33835/ruff-0.15.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc6e7f90087e2d27f98dc34ed1b3ab7c8f0d273cc5431415454e22c0bd2a681", size = 11333801, upload-time = "2026-03-05T20:05:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/01/a10fe54b653061585e655f5286c2662ebddb68831ed3eaebfb0eb08c0a16/ruff-0.15.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1cb7169f53c1ddb06e71a9aebd7e98fc0fea936b39afb36d8e86d36ecc2636a", size = 11206821, upload-time = "2026-03-05T20:06:03.441Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0d/2132ceaf20c5e8699aa83da2706ecb5c5dcdf78b453f77edca7fb70f8a93/ruff-0.15.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9b037924500a31ee17389b5c8c4d88874cc6ea8e42f12e9c61a3d754ff72f1ca", size = 11133326, upload-time = "2026-03-05T20:06:25.655Z" },
+    { url = "https://files.pythonhosted.org/packages/72/cb/2e5259a7eb2a0f87c08c0fe5bf5825a1e4b90883a52685524596bfc93072/ruff-0.15.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:65bb414e5b4eadd95a8c1e4804f6772bbe8995889f203a01f77ddf2d790929dd", size = 10510820, upload-time = "2026-03-05T20:06:37.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/20/b67ce78f9e6c59ffbdb5b4503d0090e749b5f2d31b599b554698a80d861c/ruff-0.15.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d20aa469ae3b57033519c559e9bc9cd9e782842e39be05b50e852c7c981fa01d", size = 10302395, upload-time = "2026-03-05T20:05:54.504Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e5/719f1acccd31b720d477751558ed74e9c88134adcc377e5e886af89d3072/ruff-0.15.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:15388dd28c9161cdb8eda68993533acc870aa4e646a0a277aa166de9ad5a8752", size = 10754069, upload-time = "2026-03-05T20:06:06.422Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/d1db14469e32d98f3ca27079dbd30b7b44dbb5317d06ab36718dee3baf03/ruff-0.15.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b30da330cbd03bed0c21420b6b953158f60c74c54c5f4c1dabbdf3a57bf355d2", size = 11304315, upload-time = "2026-03-05T20:06:10.867Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3a/950367aee7c69027f4f422059227b290ed780366b6aecee5de5039d50fa8/ruff-0.15.5-py3-none-win32.whl", hash = "sha256:732e5ee1f98ba5b3679029989a06ca39a950cced52143a0ea82a2102cb592b74", size = 10551676, upload-time = "2026-03-05T20:06:13.705Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/00/bf077a505b4e649bdd3c47ff8ec967735ce2544c8e4a43aba42ee9bf935d/ruff-0.15.5-py3-none-win_amd64.whl", hash = "sha256:821d41c5fa9e19117616c35eaa3f4b75046ec76c65e7ae20a333e9a8696bc7fe", size = 11678972, upload-time = "2026-03-05T20:06:45.379Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/4e/cd76eca6db6115604b7626668e891c9dd03330384082e33662fb0f113614/ruff-0.15.5-py3-none-win_arm64.whl", hash = "sha256:b498d1c60d2fe5c10c45ec3f698901065772730b411f164ae270bb6bfcc4740b", size = 10965572, upload-time = "2026-03-05T20:06:16.984Z" },
 ]
 
 [[package]]
@@ -1382,6 +1383,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/7c/b5b7d8136f872e3f13b0584e576886de0489d7213a12de6bebf29ff6ebfc/uncalled_for-0.2.0.tar.gz", hash = "sha256:b4f8fdbcec328c5a113807d653e041c5094473dd4afa7c34599ace69ccb7e69f", size = 49488, upload-time = "2026-02-27T17:40:58.137Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/7f/4320d9ce3be404e6310b915c3629fe27bf1e2f438a1a7a3cb0396e32e9a9/uncalled_for-0.2.0-py3-none-any.whl", hash = "sha256:2c0bd338faff5f930918f79e7eb9ff48290df2cb05fcc0b40a7f334e55d4d85f", size = 11351, upload-time = "2026-02-27T17:40:56.804Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Fix #52**: `vault_patch` now uses three-pass cascading match instead of byte-exact matching:
  1. Exact match on full file (existing behavior, no regression)
  2. Exact match on body only (post-frontmatter) — handles cases where `old_text` omits frontmatter
  3. Whitespace-normalized match on body (`rstrip` per line) — handles LLM whitespace drift
  4. On failure: similarity % diagnostic via `difflib.SequenceMatcher`
- **vault_search**: searches body only, no longer returns false hits from frontmatter YAML fields
- **session_briefing**: truncates body only, no longer wastes line budget on frontmatter
- **SQLite ResourceWarnings**: added `close()` + `__del__` to `BudgetTracker`, `UsageTracker`, `RelevanceTracker` — eliminates all 34 test warnings
- **Deps**: fastmcp 3.0.2→3.1.0 (minor, no breaking changes), ruff 0.15.4→0.15.5 (patch)

## Test plan

- [x] 9 unit tests for `_match_and_replace` cascading logic (`tests/test_helpers.py`)
- [x] 4 integration tests for vault_patch tolerant matching (`TestVaultPatchTolerantMatching`)
- [x] All 14 existing vault_patch tests pass (no regressions)
- [x] Search/briefing tests updated to reflect body-only search behavior
- [x] `make check` clean: 350 passed, 0 warnings, 92% coverage, lint + mypy clean

Closes #52