### PR TITLE
fix: harden vault tools against encoding errors and path traversal

### DIFF
--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -45,12 +45,18 @@ def health_report_text(ctx: ServerContext, filter_project: str = "") -> str:
         scope_dir = ctx.vault / dir_name
         if not scope_dir.is_dir():
             continue
-        projects = sorted(d for d in scope_dir.iterdir() if d.is_dir())
+        try:
+            projects = sorted(d for d in scope_dir.iterdir() if d.is_dir())
+        except OSError:
+            continue
         for project_dir in projects:
             if filter_project and project_dir.name != filter_project:
                 continue
             found_any = True
-            md_files = list(project_dir.rglob("*.md"))
+            try:
+                md_files = list(project_dir.rglob("*.md"))
+            except OSError:
+                md_files = []
             total_lines = 0
             for f in md_files:
                 content = _safe_read(f)

--- a/src/hive/_vault_read.py
+++ b/src/hive/_vault_read.py
@@ -39,14 +39,20 @@ def list_projects_text(ctx: ServerContext) -> str:
         scope_dir = ctx.vault / dir_name
         if not scope_dir.is_dir():
             continue
-        projects = sorted(d for d in scope_dir.iterdir() if d.is_dir())
+        try:
+            projects = sorted(d for d in scope_dir.iterdir() if d.is_dir())
+        except OSError:
+            continue
         for project_dir in projects:
             found_any = True
             sections = [
                 s for s, filename in SECTION_SHORTCUTS.items()
                 if (project_dir / filename).exists()
             ]
-            md_count = len(list(project_dir.rglob("*.md")))
+            try:
+                md_count = len(list(project_dir.rglob("*.md")))
+            except OSError:
+                md_count = 0
             lines.append(
                 f"- **{scope_name}/{project_dir.name}** — {md_count} files, "
                 f"shortcuts: {', '.join(sections) or 'none'}"
@@ -106,7 +112,24 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
 
         max_list_results = 500
         if pattern:
-            files = sorted(f for f in target.rglob(pattern) if f.is_file())
+            if ".." in pattern:
+                return track(
+                    ctx, "vault_list",
+                    "Pattern must not contain '..'.",
+                    project,
+                )
+            try:
+                files = sorted(
+                    f for f in target.rglob(pattern)
+                    if f.is_file()
+                    and _check_path_boundary(f, ctx.vault) is None
+                )
+            except OSError:
+                return track(
+                    ctx, "vault_list",
+                    f"Error reading directory for pattern '{pattern}'.",
+                    project,
+                )
             if not files:
                 return track(
                     ctx, "vault_list",
@@ -117,12 +140,20 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
                 rel_f = f.relative_to(target)
                 lines.append(f"- {rel_f}")
         else:
-            dirs = sorted(d for d in target.iterdir() if d.is_dir())
-            for d in dirs:
-                lines.append(f"- {d.name}/")
-            files = sorted(f for f in target.iterdir() if f.is_file())
-            for f in files:
-                lines.append(f"- {f.name}")
+            try:
+                entries = sorted(target.iterdir())
+            except OSError:
+                return track(
+                    ctx, "vault_list",
+                    f"Error reading directory '{path or project}'.",
+                    project,
+                )
+            for d in entries:
+                if d.is_dir():
+                    lines.append(f"- {d.name}/")
+            for f in entries:
+                if f.is_file():
+                    lines.append(f"- {f.name}")
 
         return track(ctx, "vault_list", "\n".join(lines), project, path)
 
@@ -155,7 +186,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
 
         try:
             content = filepath.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeDecodeError) as exc:
             return track(ctx, "vault_query",
                          f"File I/O error: {exc}", project, resolved_section)
 

--- a/src/hive/_vault_write.py
+++ b/src/hive/_vault_write.py
@@ -162,7 +162,7 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                 )
             else:
                 filepath.write_text(content, encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeDecodeError) as exc:
             return track(
                 ctx, "vault_write", f"File I/O error: {exc}", project,
             )
@@ -254,7 +254,7 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
 
         try:
             content = filepath.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeDecodeError) as exc:
             return track(ctx, "vault_patch",
                          f"File I/O error reading '{path}': {exc}", project)
 

--- a/src/hive/_workers.py
+++ b/src/hive/_workers.py
@@ -75,7 +75,7 @@ def _write_lesson(
     if lessons_file.exists():
         try:
             existing = lessons_file.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeDecodeError) as exc:
             return "error", f"File I/O error: {exc}"
 
     if f"] {title}\n" in existing:
@@ -411,7 +411,7 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
 
             try:
                 file_content = filepath.read_text(encoding="utf-8")
-            except OSError as exc:
+            except (OSError, UnicodeDecodeError) as exc:
                 return track(
                     ctx, "delegate_task", f"File I/O error: {exc}", project,
                 )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -142,6 +142,68 @@ class TestVaultListProjects:
         assert "testproject" in _text(result)
         assert "another" in _text(result)
 
+    async def test_glob_pattern_rejects_dotdot(self, vault_mcp: FastMCP) -> None:
+        result = await vault_mcp.call_tool(
+            "vault_list",
+            {"project": "testproject", "pattern": "../../etc/*.md"},
+        )
+        assert "must not contain" in _text(result).lower()
+
+    async def test_glob_pattern_valid(self, vault_mcp: FastMCP) -> None:
+        result = await vault_mcp.call_tool(
+            "vault_list",
+            {"project": "testproject", "pattern": "*.md"},
+        )
+        text = _text(result)
+        assert "00-context.md" in text
+
+
+# ── unicode / encoding errors ────────────────────────────────────────
+
+
+class TestUnicodeDecodeErrors:
+    """Tools return error message instead of crashing on non-UTF-8 files."""
+
+    async def test_vault_query_non_utf8(self, mock_vault: Path) -> None:
+        bad = mock_vault / "10_projects" / "testproject" / "bad.md"
+        bad.write_bytes(b"\xff\xfe invalid utf-8")
+        mcp = create_server(vault_path=mock_vault)
+        result = await mcp.call_tool(
+            "vault_query", {"project": "testproject", "path": "bad.md"},
+        )
+        text = _text(result)
+        assert "error" in text.lower() or "I/O" in text
+
+    async def test_vault_patch_non_utf8(self, git_vault: Path) -> None:
+        bad = git_vault / "10_projects" / "testproject" / "bad.md"
+        bad.write_bytes(b"\xff\xfe invalid utf-8")
+        mcp = create_server(vault_path=git_vault)
+        result = await mcp.call_tool(
+            "vault_patch", {
+                "project": "testproject", "path": "bad.md",
+                "old_text": "a", "new_text": "b",
+            },
+        )
+        text = _text(result)
+        assert "error" in text.lower() or "I/O" in text
+
+    async def test_vault_write_append_non_utf8(
+        self, git_vault: Path,
+    ) -> None:
+        bad = git_vault / "10_projects" / "testproject" / "90-lessons.md"
+        bad.write_bytes(b"\xff\xfe invalid utf-8")
+        mcp = create_server(vault_path=git_vault)
+        result = await mcp.call_tool(
+            "vault_write", {
+                "project": "testproject",
+                "content": "\nnew content\n",
+                "section": "lessons",
+                "operation": "append",
+            },
+        )
+        text = _text(result)
+        assert "error" in text.lower() or "I/O" in text
+
 
 # ── vault_query ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Catch `UnicodeDecodeError` in 5 `read_text()` calls across vault_query, vault_write (append), vault_patch, delegate_task, and _write_lesson — non-UTF-8 files now return a clean error instead of crashing the server
- Reject glob patterns containing `..` in vault_list and validate rglob results against vault boundary to prevent path traversal
- Wrap `iterdir()`/`rglob()` in `OSError` handlers in `list_projects_text`, `vault_list`, and `health_report_text` so permission errors on individual directories are skipped gracefully

## Test plan

- [x] `TestUnicodeDecodeErrors` — 3 tests: vault_query, vault_patch, vault_write with non-UTF-8 files
- [x] `test_glob_pattern_rejects_dotdot` — validates `..` rejection
- [x] `test_glob_pattern_valid` — confirms valid patterns still work
- [x] Full suite: 369 passed, lint clean, mypy clean