### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ For Codex CLI, GitHub Copilot, Cursor, Windsurf, and other clients, see [Getting
 
 Then ask your assistant: *"Use vault_list to see my vault"*
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/mlorentedev-hive).
+
 ## Tools
 
 | Tool | What it does |


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/mlorentedev-hive).