### PR TITLE
fix: stop false positives in vault_health link and frontmatter validator

### DIFF
--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import re
 from datetime import date, timedelta
 from typing import TYPE_CHECKING
@@ -31,6 +32,19 @@ if TYPE_CHECKING:
 
 _ALL_CHECKS = frozenset({"frontmatter", "stale", "links"})
 _WIKILINK_RE = re.compile(r"\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]")
+_FENCED_CODE_RE = re.compile(
+    r"(?ms)^(?P<fence>`{3,}|~{3,})[^\n]*\n.*?^(?P=fence)[^\n]*$",
+)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+
+
+def _strip_code(text: str) -> str:
+    """Remove fenced and inline code so wikilink-like syntax inside code
+    (e.g. bash regex `[[:space:]]`, shell `[[ -z "$1" ]]`) is not parsed
+    as a wikilink.
+    """
+    text = _FENCED_CODE_RE.sub("", text)
+    return _INLINE_CODE_RE.sub("", text)
 
 
 def _find_duplicate_names(scope_dir: Path) -> list[tuple[str, list[str]]]:
@@ -200,10 +214,15 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                 )
 
             all_stems: set[str] = set()
+            all_paths: set[str] = set()
             if "links" in active_checks:
                 for pd, _ in project_dirs:
                     for f in pd.rglob("*.md"):
                         all_stems.add(f.stem)
+                        with contextlib.suppress(ValueError):
+                            all_paths.add(
+                                f.relative_to(pd).with_suffix("").as_posix(),
+                            )
 
             issues: list[str] = []
             stale_threshold = date.today() - timedelta(days=ctx.stale_days)
@@ -223,8 +242,11 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                         continue
 
                     fm = parse_frontmatter(content)
+                    in_memory_dir = "memory" in (
+                        f.relative_to(project_dir).parts
+                    )
 
-                    if "frontmatter" in active_checks:
+                    if "frontmatter" in active_checks and not in_memory_dir:
                         if fm is None:
                             issues.append(
                                 f"[error] {proj_name}/{rel}: "
@@ -270,10 +292,13 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                                 )
 
                     if "links" in active_checks:
-                        body = extract_body(content)
+                        body = _strip_code(extract_body(content))
                         for m in _WIKILINK_RE.finditer(body):
-                            target = m.group(1).strip()
-                            if target not in all_stems:
+                            target = m.group(1).strip().rstrip("\\").strip()
+                            if (
+                                target not in all_stems
+                                and target not in all_paths
+                            ):
                                 issues.append(
                                     f"[warning] {proj_name}/{rel}: "
                                     f"Broken link [[{target}]]"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3287,6 +3287,112 @@ class TestVaultValidate:
         ))
         assert "not found" in result.lower()
 
+    async def test_wikilink_inside_fenced_code_block_not_flagged(
+        self, mock_vault: Path,
+    ) -> None:
+        """Bash regex classes (e.g. [[:space:]], [[ -z "$1" ]]) inside fenced
+        code blocks must NOT be parsed as wikilinks. Currently false-positives.
+        """
+        doc = mock_vault / "10_projects" / "testproject" / "shell-snippets.md"
+        doc.write_text(
+            "---\nid: shell-snippets\ntype: note\nstatus: active\n---\n\n"
+            "# Shell snippets\n\n"
+            "```bash\n"
+            'if [[ -z "$1" ]]; then echo "no arg"; fi\n'
+            'echo "$x" | grep "[[:space:]]"\n'
+            "```\n\n"
+            "And a tilde fence:\n\n"
+            "~~~bash\n"
+            '[[ "$x" =~ ^[[:digit:]]+$ ]]\n'
+            "~~~\n",
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool(
+            "vault_health",
+            {"project": "testproject", "checks": ["links"]},
+        ))
+        assert "shell-snippets.md" not in result, (
+            f"Bash regex inside fenced blocks should not produce broken-link "
+            f"warnings; got: {result}"
+        )
+
+    async def test_escaped_pipe_in_wikilink_resolves_target(
+        self, mock_vault: Path,
+    ) -> None:
+        """`[[target\\|alias]]` is Obsidian's escape for pipes inside table cells.
+        The parser must treat `\\|` as an alias separator, not part of the target.
+        """
+        doc = mock_vault / "10_projects" / "testproject" / "with-escaped-pipe.md"
+        doc.write_text(
+            "---\nid: with-escaped-pipe\ntype: note\nstatus: active\n---\n\n"
+            "| Col | Link |\n"
+            "|-----|------|\n"
+            "| ADR | [[adr-001-test\\|the ADR]] |\n",
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool(
+            "vault_health",
+            {"project": "testproject", "checks": ["links"]},
+        ))
+        # The target adr-001-test exists; the escaped pipe must be parsed as
+        # an alias separator, so no broken-link warning should appear.
+        assert "with-escaped-pipe.md" not in result, (
+            f"Escaped-pipe wikilink should resolve to existing target; "
+            f"got: {result}"
+        )
+
+    async def test_subdir_path_wikilink_to_existing_file_not_flagged(
+        self, mock_vault: Path,
+    ) -> None:
+        """`[[30-architecture/adr-001-test|alias]]` should resolve to the
+        existing file `30-architecture/adr-001-test.md`, not be flagged broken.
+        """
+        doc = mock_vault / "10_projects" / "testproject" / "with-subdir-link.md"
+        doc.write_text(
+            "---\nid: with-subdir-link\ntype: note\nstatus: active\n---\n\n"
+            "See [[30-architecture/adr-001-test|the ADR]] for the rationale.\n",
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool(
+            "vault_health",
+            {"project": "testproject", "checks": ["links"]},
+        ))
+        assert "with-subdir-link.md" not in result, (
+            f"Subdir-path wikilink to existing file should not be flagged; "
+            f"got: {result}"
+        )
+
+    async def test_memory_file_skipped_by_frontmatter_check(
+        self, mock_vault: Path,
+    ) -> None:
+        """Files under */memory/ use Claude auto-memory schema
+        (`name`/`description`/`metadata.type`), not the standard vault schema.
+        Frontmatter check must skip them rather than flagging missing
+        id/type/status fields.
+        """
+        mem_dir = mock_vault / "10_projects" / "testproject" / "memory"
+        mem_dir.mkdir()
+        (mem_dir / "feedback_example.md").write_text(
+            "---\nname: feedback-example\n"
+            "description: example feedback memory\n"
+            "metadata:\n  type: feedback\n---\n\n"
+            "Lead with the rule.\n",
+        )
+        (mem_dir / "MEMORY.md").write_text(
+            "# Project Memory\n\nIndex content with no frontmatter.\n",
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool(
+            "vault_health",
+            {"project": "testproject", "checks": ["frontmatter"]},
+        ))
+        assert "memory/feedback_example.md" not in result, (
+            f"Auto-memory schema must be accepted; got: {result}"
+        )
+        assert "memory/MEMORY.md" not in result, (
+            f"MEMORY.md must be skipped; got: {result}"
+        )
+
 
 # ── _setup_file_logging ─────────────────────────────────────────────
 

--- a/uv.lock
+++ b/uv.lock
@@ -430,7 +430,7 @@ wheels = [
 
 [[package]]
 name = "hive-vault"
-version = "1.11.3"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

The `vault_health(checks=[\"links\", \"frontmatter\"])` validator was emitting ~30+ false-positive warnings per audit, drowning the real drift signal. This PR fixes the four parser bugs identified during the 2026-05-10 vault audit.

## Bugs fixed

- **Fenced code blocks not stripped** — bash regex classes like `[[ -z \"\$1\" ]]`, `[[:space:]]`, `[[:digit:]]` inside ``` ``` ``` / `~~~` blocks were being parsed as wikilinks. Now `_strip_code()` removes fenced and inline code before scanning.
- **Escaped pipe `\\|` parsed wrong** — `[[target\\|alias]]` (Obsidian's escape for pipes inside table cells) was extracting `target\\` as the link target. Trailing backslash is now stripped.
- **Subdir-path wikilinks not resolved** — `[[30-architecture/adr-001|alias]]` reported broken even when the target file existed. Now builds an `all_paths` set of project-relative paths alongside the existing `all_stems` set; a wikilink resolves if it matches either.
- **Auto-memory schema flagged** — files under `*/memory/` follow Claude's auto-memory schema (`name`/`description`/`metadata.type`), not the vault schema. Frontmatter check now skips them.

## Verification

- 4 new regression tests in `TestVaultValidate` covering each bug.
- 420 tests pass (was 416), 92% coverage, ruff + mypy clean.
- No behavior change for valid wikilinks or standard frontmatter — only false positives are removed.

## Test plan

- [x] Unit tests for all 4 parser bugs (fenced code, escaped pipe, subdir paths, memory dir)
- [x] Existing link-check tests still pass (broken-link detection, valid-link non-flagging)
- [x] Full suite (`make check`) green