### PR TITLE
refactor: extract shared _SqliteTracker base class

### DIFF
--- a/src/hive/_sqlite_tracker.py
+++ b/src/hive/_sqlite_tracker.py
@@ -1,0 +1,38 @@
+"""Shared SQLite tracker base — thread-safe init, WAL mode, schema setup."""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import threading
+from pathlib import Path
+
+
+class _SqliteTracker:
+    """Base class for thread-safe SQLite-backed trackers.
+
+    Subclasses define `_SCHEMA` as a SQL string with one or more
+    CREATE TABLE statements; the base handles connection setup, parent
+    directory creation, WAL mode for on-disk databases, lock allocation,
+    and connection teardown.
+    """
+
+    _SCHEMA: str = ""
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        if db_path != ":memory:":
+            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        if db_path != ":memory:":
+            self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.executescript(self._SCHEMA)
+
+    def close(self) -> None:
+        """Close the database connection."""
+        with self._lock:
+            self._conn.close()
+
+    def __del__(self) -> None:
+        with contextlib.suppress(Exception):
+            self._conn.close()

--- a/src/hive/budget.py
+++ b/src/hive/budget.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
-import contextlib
-import sqlite3
-import threading
-from pathlib import Path
 from typing import Any
 
-_SCHEMA = """\
+from hive._sqlite_tracker import _SqliteTracker
+
+_MONTH_CLAUSE = "WHERE month = strftime('%Y-%m', 'now')"
+
+
+class BudgetTracker(_SqliteTracker):
+    """Track worker request costs against a monthly budget cap."""
+
+    _SCHEMA = """\
 CREATE TABLE IF NOT EXISTS requests (
     id INTEGER PRIMARY KEY,
     timestamp TEXT DEFAULT (datetime('now')),
@@ -20,22 +24,6 @@ CREATE TABLE IF NOT EXISTS requests (
     task_type TEXT DEFAULT 'general'
 );
 """
-
-_MONTH_CLAUSE = "WHERE month = strftime('%Y-%m', 'now')"
-
-
-class BudgetTracker:
-    """Track worker request costs against a monthly budget cap."""
-
-    def __init__(self, db_path: str = ":memory:") -> None:
-        if db_path != ":memory:":
-            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-
-        self._lock = threading.Lock()
-        self._conn = sqlite3.connect(db_path, check_same_thread=False)
-        if db_path != ":memory:":
-            self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.executescript(_SCHEMA)
 
     def record_request(
         self,
@@ -75,15 +63,6 @@ class BudgetTracker:
         """Check if spending `amount` would stay within budget."""
         with self._lock:
             return (budget - self._month_spent()) >= amount
-
-    def close(self) -> None:
-        """Close the database connection."""
-        with self._lock:
-            self._conn.close()
-
-    def __del__(self) -> None:
-        with contextlib.suppress(Exception):
-            self._conn.close()
 
     def month_stats(self, budget: float) -> dict[str, Any]:
         """Aggregate stats for the current month."""

--- a/src/hive/relevance.py
+++ b/src/hive/relevance.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
-import contextlib
 import random
-import sqlite3
-import threading
-from pathlib import Path
 
-_SCHEMA = """\
+from hive._sqlite_tracker import _SqliteTracker
+
+_DEFAULT_ALPHA = 0.3
+_DECAY_FACTOR = 0.9
+_PRUNE_THRESHOLD = 0.001
+_WRITE_MULTIPLIER = 2.0
+_DEFAULT_EPSILON = 0.15
+
+
+class RelevanceTracker(_SqliteTracker):
+    """Track per-section relevance using Exponential Moving Average."""
+
+    _SCHEMA = """\
 CREATE TABLE IF NOT EXISTS section_scores (
     project TEXT NOT NULL,
     section TEXT NOT NULL,
@@ -19,16 +27,6 @@ CREATE TABLE IF NOT EXISTS section_scores (
 );
 """
 
-_DEFAULT_ALPHA = 0.3
-_DECAY_FACTOR = 0.9
-_PRUNE_THRESHOLD = 0.001
-_WRITE_MULTIPLIER = 2.0
-_DEFAULT_EPSILON = 0.15
-
-
-class RelevanceTracker:
-    """Track per-section relevance using Exponential Moving Average."""
-
     def __init__(
         self,
         db_path: str = ":memory:",
@@ -36,25 +34,10 @@ class RelevanceTracker:
         decay_factor: float = _DECAY_FACTOR,
         epsilon: float = _DEFAULT_EPSILON,
     ) -> None:
-        if db_path != ":memory:":
-            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._lock = threading.Lock()
-        self._conn = sqlite3.connect(db_path, check_same_thread=False)
-        if db_path != ":memory:":
-            self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.executescript(_SCHEMA)
+        super().__init__(db_path)
         self._alpha = alpha
         self._decay_factor = decay_factor
         self._epsilon = epsilon
-
-    def close(self) -> None:
-        """Close the database connection."""
-        with self._lock:
-            self._conn.close()
-
-    def __del__(self) -> None:
-        with contextlib.suppress(Exception):
-            self._conn.close()
 
     def record_access(
         self, project: str, section: str, *, is_write: bool = False,

--- a/src/hive/usage.py
+++ b/src/hive/usage.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-import contextlib
-import sqlite3
-import threading
-from pathlib import Path
 from typing import Any
 
-_SCHEMA = """\
+from hive._sqlite_tracker import _SqliteTracker
+
+
+class UsageTracker(_SqliteTracker):
+    """Track vault tool calls for session profiling and analytics."""
+
+    _SCHEMA = """\
 CREATE TABLE IF NOT EXISTS tool_calls (
     id INTEGER PRIMARY KEY,
     timestamp TEXT DEFAULT (datetime('now')),
@@ -18,20 +20,6 @@ CREATE TABLE IF NOT EXISTS tool_calls (
     response_lines INTEGER DEFAULT 0
 );
 """
-
-
-class UsageTracker:
-    """Track vault tool calls for session profiling and analytics."""
-
-    def __init__(self, db_path: str = ":memory:") -> None:
-        if db_path != ":memory:":
-            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-
-        self._lock = threading.Lock()
-        self._conn = sqlite3.connect(db_path, check_same_thread=False)
-        if db_path != ":memory:":
-            self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.executescript(_SCHEMA)
 
     def log_call(
         self,
@@ -46,15 +34,6 @@ class UsageTracker:
                 (tool, project, response_lines),
             )
             self._conn.commit()
-
-    def close(self) -> None:
-        """Close the database connection."""
-        with self._lock:
-            self._conn.close()
-
-    def __del__(self) -> None:
-        with contextlib.suppress(Exception):
-            self._conn.close()
 
     def stats(self, since_days: int = 30) -> dict[str, Any]:
         """Aggregate usage stats for the last N days."""

--- a/uv.lock
+++ b/uv.lock
@@ -430,7 +430,7 @@ wheels = [
 
 [[package]]
 name = "hive-vault"
-version = "1.11.3"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

`BudgetTracker`, `UsageTracker`, and `RelevanceTracker` all duplicated an identical 8-line SQLite init block (parent mkdir, `threading.Lock`, `sqlite3.connect(check_same_thread=False)`, WAL pragma, `executescript`) plus identical `close()` and `__del__()` methods.

Hoist that machinery into `_SqliteTracker` (new module `src/hive/_sqlite_tracker.py`). Subclasses declare `_SCHEMA` as a class attribute and inherit `__init__`/`close`/`__del__`. `RelevanceTracker` keeps its own `__init__` to receive `alpha`/`decay_factor`/`epsilon` but delegates connection setup to `super().__init__(db_path)`.

## Diff

- New: `src/hive/_sqlite_tracker.py` (+38 lines)
- Modified: `budget.py`, `usage.py`, `relevance.py` (net -59 lines)
- Net: **-21 lines**, no behavior change

## Verification

- 416 tests pass unchanged (existing concurrency tests cover the base class indirectly)
- `_sqlite_tracker.py` reaches 100% coverage via existing tests
- ruff + mypy clean

## Test plan

- [x] Existing `TestThreadSafety` tests still pass for all three trackers
- [x] `make check` green, no test changes needed