### PR TITLE
refactor: centralize "Project not found" error string

### DIFF
--- a/src/hive/_helpers.py
+++ b/src/hive/_helpers.py
@@ -30,6 +30,11 @@ _log = logging.getLogger(__name__)
 
 _REJECT_MSG = "The host should handle this task directly."
 
+
+def project_not_found(project: str) -> str:
+    """Standard error string for unresolvable project slugs."""
+    return f"Project '{project}' not found in vault."
+
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, idempotentHint=True)
 _WRITE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False)
 
@@ -197,7 +202,7 @@ def _resolve_file(
     """Resolve a vault file from project + section/path. Returns Path or error string."""
     result = _resolve_project_dir(vault, project, scopes)
     if result is None:
-        return f"Project '{project}' not found in vault."
+        return project_not_found(project)
     project_dir, _ = result
 
     if path:

--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -13,6 +13,7 @@ from hive._helpers import (
     _safe_read,
     _vault_guard,
     count_stale,
+    project_not_found,
     track,
 )
 from hive.frontmatter import (
@@ -179,7 +180,7 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                 if resolved is None:
                     return track(
                         ctx, "vault_health",
-                        f"Project '{project}' not found in vault.",
+                        project_not_found(project),
                         project,
                     )
                 project_dirs.append(resolved)

--- a/src/hive/_vault_read.py
+++ b/src/hive/_vault_read.py
@@ -19,6 +19,7 @@ from hive._helpers import (
     _truncate,
     _vault_guard,
     count_stale,
+    project_not_found,
     track,
 )
 from hive.frontmatter import extract_body, parse_date, parse_frontmatter
@@ -91,7 +92,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         resolved = _resolve_project_dir(ctx.vault, project, ctx.scopes)
         if resolved is None:
             return track(ctx, "vault_list",
-                         f"Project '{project}' not found in vault.", project)
+                         project_not_found(project), project)
         project_dir, _ = resolved
 
         from hive._helpers import _check_path_boundary
@@ -465,7 +466,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         resolved = _resolve_project_dir(ctx.vault, project, ctx.scopes)
         if resolved is None:
             return track(ctx, "session_briefing",
-                         f"Project '{project}' not found.", project)
+                         project_not_found(project), project)
         project_dir, _ = resolved
 
         # Decay stale relevance scores at session start

--- a/src/hive/_vault_write.py
+++ b/src/hive/_vault_write.py
@@ -15,6 +15,7 @@ from hive._helpers import (
     _match_and_replace,
     _resolve_project_dir,
     _vault_guard,
+    project_not_found,
     track,
 )
 from hive.frontmatter import validate_frontmatter
@@ -68,7 +69,7 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
         if resolved is None:
             return track(
                 ctx, "vault_write",
-                f"Project '{project}' not found in vault.",
+                project_not_found(project),
                 project,
             )
         project_dir, _ = resolved
@@ -265,7 +266,7 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
         resolved = _resolve_project_dir(ctx.vault, project, ctx.scopes)
         if resolved is None:
             return track(ctx, "vault_patch",
-                         f"Project '{project}' not found in vault.", project)
+                         project_not_found(project), project)
         project_dir, _ = resolved
 
         filepath = project_dir / path

--- a/src/hive/_workers.py
+++ b/src/hive/_workers.py
@@ -20,6 +20,7 @@ from hive._helpers import (
     _resolve_file,
     _resolve_project_dir,
     _vault_guard,
+    project_not_found,
     tool_span,
     track,
 )
@@ -206,7 +207,7 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                 if resolved is None:
                     return track(
                         ctx, "capture_lesson",
-                        f"Project '{project}' not found in vault.",
+                        project_not_found(project),
                         project,
                     )
                 project_dir, _ = resolved

--- a/uv.lock
+++ b/uv.lock
@@ -430,7 +430,7 @@ wheels = [
 
 [[package]]
 name = "hive-vault"
-version = "1.11.3"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Seven call sites across `_vault_read`, `_vault_write`, `_vault_health`, `_workers`, and `_resolve_file` all built the same project-not-found error string by hand:

\`\`\`python
f\"Project '{project}' not found in vault.\"
\`\`\`

One outlier in `session_briefing` dropped the trailing \"in vault.\" for no reason.

Introduce \`project_not_found(project)\` in \`_helpers\` and route all seven sites through it. One place to evolve the message later (e.g. suggest valid slugs).

## Diff

- `_helpers.py`: +1 function (5 lines)
- `_vault_read.py`, `_vault_write.py`, `_vault_health.py`, `_workers.py`: import + call substitution
- Net: **+17 / -8**, no behavior change

## Verification

- 416 tests pass unchanged
- Test assertions all use `\"not found\" in result.lower()` — not pinned to exact phrasing — so unifying the outlier doesn't break anything
- ruff + mypy clean

## Test plan

- [x] All existing not-found tests pass (test_helpers.py, test_server.py, test_smoke.py)
- [x] `make check` green