### PR TITLE
chore: sync server.json with current version + harden MCP registry publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: Release
 on:
   push:
     branches: [master]
+  workflow_dispatch:
+    inputs:
+      republish_mcp:
+        description: "Re-publish current server.json to the MCP Registry (skip release-please/PyPI)"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write
@@ -11,6 +18,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -45,6 +53,12 @@ jobs:
 
   publish-mcp:
     needs: publish
+    if: |
+      always() &&
+      (
+        needs.publish.result == 'success' ||
+        (github.event_name == 'workflow_dispatch' && inputs.republish_mcp == 'true')
+      )
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -60,4 +74,19 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish || echo "MCP Registry publish skipped (version may already exist)"
+        run: |
+          set +e
+          output=$(./mcp-publisher publish 2>&1)
+          rc=$?
+          echo "$output"
+          if [ $rc -eq 0 ]; then
+            exit 0
+          fi
+          # Tolerate ONLY the specific "duplicate version" error from the
+          # registry — anything else is a real failure.
+          if echo "$output" | grep -q "cannot publish duplicate version"; then
+            echo "::warning::MCP Registry already has this version — nothing to do."
+            exit 0
+          fi
+          echo "::error::mcp-publisher publish failed with an unexpected error."
+          exit $rc

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/mlorentedev/hive",
     "source": "github"
   },
-  "version": "1.4.5",
+  "version": "1.12.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "hive-vault",
-      "version": "1.4.5",
+      "version": "1.12.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- The MCP Registry has been stuck at v1.4.5 since 2026-03-06 because \`server.json\` was never bumped along with the PyPI version. release-please only applies \`extra-files\` updates on each release PR — it does not retroactively patch them, and the file was added to the config *after* it had already drifted.
- Every release since then has tried to publish \`version: "1.4.5"\` to the registry, received \`400 duplicate version\`, and had the failure swallowed by \`|| echo "MCP Registry publish skipped"\`.

## Fix

1. Bump \`server.json\` to \`1.12.2\` in both \`$.version\` and \`$.packages[0].version\`. release-please's existing \`extra-files\` block keeps it in sync from here on.
2. Replace the generic \`|| echo skipped\` with a grep on the exact \`cannot publish duplicate version\` string — any other failure now surfaces as a real workflow error instead of being silently absorbed.
3. Add a \`workflow_dispatch\` trigger with a \`republish_mcp\` input. After this PR merges I'll run it once to push the corrected manifest to the registry without needing to invent a new feature release.

## Test plan

- [x] \`python -m yaml ...\` parses the updated workflow.
- [ ] CI green on this PR (no workflow runs by itself — just lint/test).
- [ ] After merge, run \`gh workflow run release.yml -f republish_mcp=true\` and confirm the MCP Registry advances past 1.4.5.

## Notes

No \`Co-Authored-By\` trailers per project policy. Pure \`chore:\` — no version bump expected from release-please.