### PR TITLE
fix(ci): compare workflow_dispatch boolean input as boolean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       always() &&
       (
         needs.publish.result == 'success' ||
-        (github.event_name == 'workflow_dispatch' && inputs.republish_mcp == 'true')
+        (github.event_name == 'workflow_dispatch' && inputs.republish_mcp)
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

PR #78 added a \`workflow_dispatch\` trigger with a boolean \`republish_mcp\` input, gated by \`inputs.republish_mcp == 'true'\`. GitHub Actions coerces boolean-typed inputs to real booleans rather than strings, so the comparison never matched and the manual republish run (\`gh workflow run release.yml -f republish_mcp=true\`) skipped the \`publish-mcp\` job. Drop the string compare and use the truthy boolean directly.

## Test plan

- [x] CI green on this PR.
- [ ] After merge, retrigger \`gh workflow run release.yml -f republish_mcp=true\` and confirm \`publish-mcp\` actually runs and bumps the registry past v1.4.5.