### PR TITLE
docs: document HIVE_LOG_LEVEL env var and refresh counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ MCP Host (Claude Code, Gemini CLI, Codex CLI, Cursor, ...)
 Full documentation at **[mlorentedev.github.io/hive](https://mlorentedev.github.io/hive/)**:
 
 - [Getting Started](https://mlorentedev.github.io/hive/getting-started/) — install for all MCP clients
-- [Configuration](https://mlorentedev.github.io/hive/configuration/) — all 16 environment variables
+- [Configuration](https://mlorentedev.github.io/hive/configuration/) — all 17 environment variables
 - [Vault Structure](https://mlorentedev.github.io/hive/guides/vault-structure/) — how to organize your vault
 - [Use Cases](https://mlorentedev.github.io/hive/guides/use-cases/) — real-world workflows
 - [Architecture](https://mlorentedev.github.io/hive/reference/architecture/) — module map and design decisions
@@ -89,7 +89,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and PR workflow.
 ```bash
 git clone https://github.com/mlorentedev/hive.git && cd hive
 make install   # create venv + install deps
-make check     # lint + typecheck + test (337 tests, 92% coverage)
+make check     # lint + typecheck + test (424 tests, 91% coverage)
 ```
 
 ## License

--- a/site/src/content/docs/configuration.md
+++ b/site/src/content/docs/configuration.md
@@ -26,6 +26,7 @@ All configuration is done through environment variables, passed when registering
 | `HIVE_RELEVANCE_EPSILON` | `0.15` | Exploration ratio for session_briefing (epsilon-greedy) |
 | `HIVE_VAULT_SCOPES` | `{"projects": "10_projects", "meta": "00_meta", "work": "50_work"}` | JSON mapping of scope names to vault subdirectories. Scopes support hierarchical resolution (BFS). |
 | `HIVE_LOG_PATH` | `~/.local/share/hive/hive.log` | File path for persistent debug log (1MB rotating) |
+| `HIVE_LOG_LEVEL` | `INFO` | Log level for the persistent log file. Captures `hive`, `fastmcp` and `mcp` loggers. Set to `DEBUG` for transport-level diagnostics, `WARNING` to suppress lifecycle events. |
 
 ## API Key Resolution
 

--- a/site/src/content/docs/es/configuration.md
+++ b/site/src/content/docs/es/configuration.md
@@ -26,6 +26,7 @@ Toda la configuración se realiza mediante variables de entorno, pasadas al regi
 | `HIVE_RELEVANCE_EPSILON` | `0.15` | Ratio de exploración para session_briefing (epsilon-greedy) |
 | `HIVE_VAULT_SCOPES` | `{"projects": "10_projects", "meta": "00_meta", "work": "50_work"}` | Mapeo JSON de nombres de scope a subdirectorios del vault. Los scopes soportan resolución jerárquica (BFS). |
 | `HIVE_LOG_PATH` | `~/.local/share/hive/hive.log` | Ruta del log persistente de depuración (rotación 1MB) |
+| `HIVE_LOG_LEVEL` | `INFO` | Nivel del log persistente. Captura los loggers `hive`, `fastmcp` y `mcp`. `DEBUG` para diagnóstico a nivel de transporte; `WARNING` para silenciar eventos de ciclo de vida. |
 
 ## Resolución de API Key
 


### PR DESCRIPTION
## Summary

PR #76 added the \`HIVE_LOG_LEVEL\` env var (defaults to \`INFO\`, captures \`hive\`/\`fastmcp\`/\`mcp\` loggers) but only mentioned it inside the transport-disconnect troubleshooting block. Move it into the canonical configuration table (EN + ES) so anyone scanning env-var reference docs finds it.

While there:

- Bump the env-var count in the README link from "16" to "17".
- Refresh the test/coverage figure quoted in the contributor block to the post-#76 reality (\`424 tests, 91% coverage\`).

No code changes.