### PR TITLE
docs: add codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # hive-vault
 
 [![CI](https://github.com/mlorentedev/hive/actions/workflows/ci.yml/badge.svg)](https://github.com/mlorentedev/hive/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/mlorentedev/hive/graph/badge.svg)](https://codecov.io/gh/mlorentedev/hive)
 [![PyPI](https://img.shields.io/pypi/v/hive-vault)](https://pypi.org/project/hive-vault/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://python.org)
 [![Docs](https://img.shields.io/badge/docs-hive-blue)](https://mlorentedev.github.io/hive/)


### PR DESCRIPTION
## Summary

- Adds the codecov badge to the README between the CI and PyPI badges
- Surfaces an existing CI metric: `codecov/codecov-action@v5` already uploads `coverage.xml` on every CI run
- No behavior change, no release trigger

## Test plan

- [x] Local diff verified (1 line added)
- [ ] After merge, confirm badge renders correctly on the GitHub README