### PR TITLE
fix(release): keep uv.lock self-reference in sync with project version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,47 @@ jobs:
           release-type: python
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
+      # release-please bumps `pyproject.toml` and `server.json` (via extra-files)
+      # but does not touch `uv.lock`'s self-reference, so the release PR ships
+      # with a stale lock version. Regenerate the lock on the release-please
+      # branch so the merged PR is internally consistent.
+      - name: Capture release-please PR branch
+        if: steps.release.outputs.pr
+        env:
+          PR_DATA: ${{ steps.release.outputs.pr }}
+        run: |
+          branch=$(printf '%s' "$PR_DATA" | jq -r .headBranchName)
+          echo "PR_BRANCH=$branch" >> "$GITHUB_ENV"
+
+      - name: Check out release-please PR branch
+        if: steps.release.outputs.pr
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.PR_BRANCH }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - name: Set up uv
+        if: steps.release.outputs.pr
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        if: steps.release.outputs.pr
+        run: uv python install 3.12
+
+      - name: Sync uv.lock with release version bump
+        if: steps.release.outputs.pr
+        run: |
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "No uv.lock drift to fix."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: sync uv.lock with release version bump"
+          git push origin "$PR_BRANCH"
+
   publish:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'

--- a/uv.lock
+++ b/uv.lock
@@ -430,7 +430,7 @@ wheels = [
 
 [[package]]
 name = "hive-vault"
-version = "1.12.1"
+version = "1.12.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

`release-please` bumps `pyproject.toml` and `server.json` (via `extra-files`) on every release, but never touches `uv.lock`'s self-reference for the editable install. The lock stays anchored at the previous version until someone runs any `uv` command locally — at which point uv regenerates the self-ref and produces an uncommitted diff that has to be discarded.

Symptoms observed on `master` today: `pyproject.toml` says `1.12.6`, `uv.lock` self-ref says `1.12.1` (five releases ago).

## What this PR does

1. Adds four steps to the `release-please` job that run **only when release-please opens or updates a PR** (`if: steps.release.outputs.pr`):
   - Extract the PR branch name via `jq` into `GITHUB_ENV` (also satisfies the workflow-injection lint by routing dynamic data through env vars).
   - `actions/checkout@v4` onto the release-please branch using the same `RELEASE_PLEASE_TOKEN`.
   - Install uv + Python 3.12.
   - Run `uv lock`; if there is a diff, commit and push back to the release-please branch as `github-actions[bot]`.
2. Commits the current drift (`1.12.1 → 1.12.6` in the lock self-ref) so `master` is internally consistent right now, before the workflow change takes effect.

## Why a same-job approach (vs separate workflow)

- Keeps all release-related logic in `release.yml`.
- Uses `steps.release.outputs.pr` directly — no need to listen for `pull_request` events on a name pattern.
- The `if: steps.release.outputs.pr` gate ensures the steps are no-ops when release-please has nothing to do (no commits accumulated since last release).

## Test plan

- [x] `uv lock` locally regenerates the self-ref from 1.12.4 → 1.12.6 without touching any other field.
- [x] Workflow YAML lint locally: the dynamic value is captured into `GITHUB_ENV` before being used in `with:` / `run:` blocks (satisfies the standard workflow-injection pattern).
- [ ] After merge, watch the next release PR — the workflow should add a `chore: sync uv.lock with release version bump` commit on top of release-please's bump, and the resulting merged PR should leave `master` with a coherent lock.