### PR TITLE
fix: prevent multi-process hangs, crashes, and write-loss

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,92 +1,99 @@
-# Hive Project
+# CLAUDE.md
 
-> Vault-native AI orchestration: unified MCP server extending Claude Code.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Architecture
+> **Hive** — vault-native AI orchestration: a unified MCP server giving AI coding assistants on-demand access to an Obsidian vault plus delegation to local/cheap workers.
 
-- **Hive MCP Server**: On-demand Obsidian vault access + worker delegation to Ollama/Qwen
-- Modular: `server.py` (registration) + `_context.py` (state) + `_helpers.py` (pure functions) + domain modules (`_vault_read`, `_vault_write`, `_vault_health`, `_workers`)
+## Big-picture architecture
 
-See ADR: `~/Projects/knowledge/10_projects/hive/30-architecture/adr-001-orchestration-model.md`
+Hive is an MCP server (stdio transport, FastMCP framework) with three responsibilities:
 
-## Technical Standards
+1. **Vault tools** — query, search, list, write, patch markdown files in an Obsidian vault. All writes auto-commit to git (best-effort; git failure never crashes the server) and validate YAML frontmatter.
+2. **Session tools** — `session_briefing` assembles tasks + lessons + git log + health in one call so an AI client gets ~50 lines of context instead of ~800.
+3. **Worker tools** — `delegate_task` and `capture_lesson` route work down a cost ladder: Ollama (local, free) → OpenRouter free tier → OpenRouter paid (gated by $1/mo SQLite budget) → reject.
 
-| Requirement | Tool/Pattern |
-|---|---|
-| Python | 3.12+ |
-| Type hints | mypy --strict |
-| Dependencies | uv |
-| Formatting | Ruff |
-| Testing | pytest + pytest-cov |
-| MCP framework | FastMCP |
-| HTTP client | httpx (async) |
-
-## Key Paths
+The package layout follows a deliberate split: `server.py` is a thin registration layer only. Each `_vault_*.py` / `_workers.py` module owns one tool family and registers its tools onto the FastMCP instance via a `register_*(mcp, ctx)` function. State lives in `ServerContext` (a dataclass in `_context.py`) and is passed to every handler — there is no module-level mutable state.
 
 | Path | Role |
 |---|---|
-| `src/hive/server.py` | Thin registration layer — resources, prompts, create_server() |
-| `src/hive/_context.py` | ServerContext dataclass — shared state for tool handlers |
-| `src/hive/_helpers.py` | Pure functions — path resolution, formatting, git ops, tracking |
-| `src/hive/_vault_read.py` | vault_list, vault_query, vault_search, session_briefing |
-| `src/hive/_vault_write.py` | vault_write, vault_patch |
-| `src/hive/_vault_health.py` | vault_health, health report builder |
-| `src/hive/_workers.py` | capture_lesson, delegate_task, worker_status |
-| `src/hive/config.py` | Configuration (vault path, Ollama endpoint, OpenRouter key) |
-| `tests/` | pytest suite |
-| `~/Projects/knowledge/` | Obsidian vault (source of truth) |
-
-## Vault Integration
-
-- Vault path: `~/Projects/knowledge/`
-- All vault writes MUST auto-commit to git (best-effort — never crash on git failure)
-- All vault writes MUST validate YAML frontmatter
-- Project vault entry: `~/Projects/knowledge/10_projects/hive/`
-
-## MCP Tool Schema Rules
-
-- **NEVER use `| None` in tool parameter types** — generates `anyOf` in JSON Schema, Claude Code drops these tools
-- Use empty defaults: `str = ""`, `list[T] = []` (`# noqa: B006`), `int = 0`
-- All subprocess calls MUST catch `Exception` (not just specific types)
-- HTTP clients MUST catch `httpx.TimeoutException` (covers ReadTimeout, not just ConnectTimeout)
-
-## Key Modules
-
-| Module | Role |
-|---|---|
+| `src/hive/server.py` | Thin registration layer — `create_server()`, resources, prompts |
+| `src/hive/_context.py` | `ServerContext` dataclass — shared state for all handlers |
+| `src/hive/_helpers.py` | Pure helpers — path resolution, formatting, git ops, tracking |
+| `src/hive/_vault_read.py` | `vault_list`, `vault_query`, `vault_search`, `session_briefing` |
+| `src/hive/_vault_write.py` | `vault_write`, `vault_patch` (both auto-commit to git) |
+| `src/hive/_vault_health.py` | `vault_health` + health report builder |
+| `src/hive/_workers.py` | `capture_lesson`, `delegate_task`, `worker_status` |
+| `src/hive/_compat.py` | MCP cancellation shim — see "Compat shim" below |
+| `src/hive/config.py` | `HiveSettings` (pydantic-settings, `HIVE_*` env vars) |
 | `src/hive/budget.py` | SQLite budget tracker ($1/mo default cap, WAL mode) |
-| `src/hive/clients.py` | Async HTTP clients (Ollama + OpenRouter) |
+| `src/hive/clients.py` | Async HTTP clients (Ollama + OpenRouter, httpx) |
 | `src/hive/relevance.py` | EMA-based section relevance scoring |
-| `src/hive/frontmatter.py` | YAML frontmatter parsing, validation, generation |
+| `src/hive/frontmatter.py` | YAML frontmatter parse/validate/generate |
+| `site/` | Astro + Starlight bilingual (EN/ES) docs site |
 
-## Worker Routing
+### Compat shim (do not delete blindly)
 
-1. Ollama `qwen2.5-coder:7b` (homelab mini PC) → primary, free
-2. OpenRouter `qwen/qwen3-coder:free` → fallback, free tier
-3. OpenRouter paid (Qwen3 Coder) → if `max_cost_per_request > 0` and budget allows
-4. Reject → return error, Claude handles it
+`src/hive/_compat.py` monkey-patches `mcp.shared.session.RequestResponder.__exit__` to swallow the spurious `CancelledError` that anyio re-raises after a cancelled tool call has already responded. Without it, a client sending `notifications/cancelled` kills the stdio receive loop and every subsequent call hangs (hive issue #75). The patch is forward-compatible — it fires only on the exact failure mode and degrades silently if upstream removes the symbol. Delete only after confirming the upstream MCP fix has shipped.
 
-## Documentation Site (i18n)
+### Worker routing order
 
-- Site: `site/` — Astro + Starlight, bilingual (EN/ES)
-- English docs: `site/src/content/docs/` (root locale)
-- Spanish docs: `site/src/content/docs/es/`
-- **Rule**: When adding or modifying any doc page, always update BOTH languages. Create/edit the English version first, then mirror the change in the corresponding `es/` file.
-- Sidebar labels with translations are in `site/astro.config.mjs`
-- Build: `cd site && npm run build`
+`delegate_task` tries clients in this order, falling through on failure or unavailability:
 
-## Verification Commands
+1. **Ollama** `qwen2.5-coder:7b` (local) — free, primary
+2. **OpenRouter** `qwen/qwen3-coder:free` — free tier fallback
+3. **OpenRouter** paid (`qwen/qwen3-coder`) — only if caller passes `max_cost_per_request > 0` AND `BudgetTracker` allows it
+4. **Reject** — surface the error to the client; Claude handles fallback
 
-All commands go through the Makefile:
+## Commands
+
+All routine commands go through the Makefile (uv-based):
 
 ```bash
-make install    # Create venv + install deps
-make lint       # Ruff linter
-make typecheck  # mypy --strict
-make test       # Unit + integration tests (excludes smoke)
-make smoke      # E2E smoke tests (needs Ollama + OPENROUTER_API_KEY)
-make check      # lint + typecheck + test
+make install    # uv venv + uv pip install -e ".[dev]"
+make lint       # ruff check src/ tests/
+make typecheck  # mypy --strict src/
+make test       # pytest with coverage (smoke tests auto-excluded via addopts)
+make smoke      # pytest -m smoke (needs running Ollama + OPENROUTER_API_KEY)
+make check      # lint + typecheck + test — run this before every PR
 make build      # check + uv build
-make run        # Run Hive MCP server locally
-make clean      # Remove build artifacts
+make run        # uv run python -m hive.server (local MCP server over stdio)
+make clean      # remove build/cache artifacts
+make site / site-dev / site-preview  # Astro docs site
 ```
+
+### Running a single test
+
+The Makefile does not expose this — fall back to `uv run pytest` directly:
+
+```bash
+uv run pytest tests/test_server.py                                # one file
+uv run pytest tests/test_server.py::test_vault_query_returns_file # one test
+uv run pytest tests/test_server.py -k "vault_query"               # by keyword
+uv run pytest -m smoke -k worker_status                           # smoke subset
+```
+
+Smoke tests are marked `@pytest.mark.smoke` and excluded by default (`addopts = "-m 'not smoke'"` in `pyproject.toml`); they require a live Ollama at `OLLAMA_ENDPOINT` and an `OPENROUTER_API_KEY`.
+
+## MCP tool schema rules (load-bearing)
+
+These rules are not stylistic — violating them breaks the server in subtle, hard-to-diagnose ways.
+
+- **NEVER use `| None` in MCP tool parameter types.** It generates `anyOf` in the JSON Schema and Claude Code silently drops the tool. Use empty-value defaults instead: `str = ""`, `list[T] = []` (with `# noqa: B006`), `int = 0`.
+- **All `subprocess.run` calls MUST catch broad `Exception`**, not just `CalledProcessError` — git invocations on Windows raise things like `FileNotFoundError` that would otherwise crash a write tool.
+- **All `httpx` calls MUST catch `httpx.TimeoutException`** (the umbrella class). `ConnectTimeout` alone misses `ReadTimeout`, which is what most slow-worker hangs surface as.
+- Vault writes MUST validate YAML frontmatter (`hive.frontmatter`) and MUST attempt a git commit (best-effort, see `_helpers._git_commit`). Never fail a write because git failed.
+
+## Configuration
+
+`HiveSettings` (pydantic-settings) reads `HIVE_*` env vars. Two settings accept an unprefixed alias for ergonomic deploy: `VAULT_PATH` → `vault_path`, `OPENROUTER_API_KEY` → `openrouter_api_key`. Vault default is `~/Projects/knowledge`. Worker DBs default to `~/.local/share/hive/{worker,relevance}.db`.
+
+## Documentation site (i18n)
+
+`site/` is bilingual Astro + Starlight (EN root locale, ES under `src/content/docs/es/`). **Rule:** any doc change must update both languages — edit English first, then mirror to `es/`. Sidebar labels with translations live in `site/astro.config.mjs`.
+
+## PR workflow
+
+- Branch from `master`, Conventional Commits (`feat:` / `fix:` / `docs:` / `chore:` …) — these drive release-please.
+- `make check` must pass; CI runs on Python 3.12 and 3.13.
+- Squash merge. Merging Conventional-Commit PRs to `master` triggers a release-please PR; merging that PR cuts a GitHub Release and publishes to PyPI (trusted publishing).
+- Coding style: type hints everywhere (`mypy --strict`), Ruff formatting, functions < 40 lines, nesting < 4 levels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=2.0.0",
+    "filelock>=3.13",
     "httpx>=0.27.0",
     "pydantic-settings>=2.0",
     "pyyaml>=6.0",

--- a/src/hive/_compat.py
+++ b/src/hive/_compat.py
@@ -1,26 +1,29 @@
 """Compatibility shims for upstream MCP library bugs.
 
-This module monkey-patches ``mcp.shared.session.RequestResponder.__exit__``
-to swallow the spurious ``CancelledError`` that the anyio cancel scope
-re-raises after we have already responded to a cancelled request.
+This module monkey-patches two methods on
+``mcp.shared.session.RequestResponder`` to keep the stdio receive loop
+alive across two related cancellation races:
 
-Without the patch, when a client sends ``notifications/cancelled`` for an
-in-flight tool call, the cancellation propagates out of the responder
-context manager and kills the receive loop's ``anyio.create_task_group()``.
-The process stays alive but stops reading stdin — every subsequent call
-hangs, the client sees ``MCP error -32000: Connection closed``, and the
-only recovery is restarting the conversation.
+1. **``__exit__``** — swallow the spurious ``CancelledError`` that the
+   anyio cancel scope re-raises after we have already responded to a
+   cancelled request (hive issue #75).
+2. **``respond``** — when a handler finishes *after* the client has
+   already sent ``notifications/cancelled`` (so ``_completed`` is True),
+   the original assertion ``assert not self._completed`` fires inside
+   ``_handle_request``, propagates to the receive loop's
+   ``anyio.create_task_group()``, and kills the server with
+   ``AssertionError('Request already responded to')``. Subsequent calls
+   from any session sharing the process get ``Connection closed``. The
+   patched version short-circuits silently with a debug log.
 
-See hive issue #75. The patch is designed to be forward-compatible:
+Without either patch, a slow tool call that the client cancels mid-flight
+poisons the transport — the process either stops reading stdin or exits
+with the assertion. Recovery requires restarting Claude Code.
 
-* It only fires when the responder has already marked itself completed
-  AND the leaking exception is anyio's ``CancelledError`` class — i.e.
-  the exact failure mode of the upstream bug. If upstream fixes the bug,
-  the trigger never fires and the patch is inert.
-* If a future ``mcp`` release removes ``RequestResponder`` or changes its
-  attributes, ``apply()`` logs a warning and returns without touching
-  anything — Hive degrades to the pre-patch behaviour, never crashes.
-* When the upstream fix lands, this file can simply be deleted.
+Both patches are self-gated to the exact failure mode (responder already
+``_completed``) so if upstream fixes the bug the patch becomes inert.
+If ``RequestResponder`` is renamed/removed in a future ``mcp`` release,
+``apply()`` logs a warning and returns without touching anything.
 """
 
 from __future__ import annotations
@@ -69,6 +72,24 @@ def _make_patched_exit(original_exit: Any) -> Any:  # noqa: ARG001 (kept for sym
     return _patched_exit
 
 
+def _make_patched_respond(original_respond: Any) -> Any:
+    async def _patched_respond(self: Any, response: Any) -> None:
+        if not self._entered:
+            raise RuntimeError(
+                "RequestResponder must be used as a context manager",
+            )
+        if self._completed:
+            _log.debug(
+                "Suppressed respond() on already-completed responder %s "
+                "(handler finished after client cancellation)",
+                self.request_id,
+            )
+            return
+        await original_respond(self, response)
+
+    return _patched_respond
+
+
 def apply() -> None:
     """Apply the cancellation-safety patch to ``RequestResponder.__exit__``.
 
@@ -102,5 +123,21 @@ def apply() -> None:
 
     original_exit = RequestResponder.__exit__
     RequestResponder.__exit__ = _make_patched_exit(original_exit)  # type: ignore[method-assign]
+
+    if hasattr(RequestResponder, "respond"):
+        original_respond = RequestResponder.respond
+        RequestResponder.respond = _make_patched_respond(  # type: ignore[method-assign]
+            original_respond,
+        )
+        _log.debug(
+            "Applied RequestResponder.respond patch (respond-after-cancel)",
+        )
+    else:
+        _log.warning(
+            "RequestResponder has no respond — respond-after-cancel patch "
+            "skipped. Server may crash with AssertionError if a handler "
+            "completes after a client cancellation.",
+        )
+
     setattr(RequestResponder, _PATCH_APPLIED_ATTR, True)
     _log.debug("Applied RequestResponder.__exit__ cancellation patch (issue #75)")

--- a/src/hive/_diagnostics.py
+++ b/src/hive/_diagnostics.py
@@ -39,28 +39,29 @@ class LifecycleMiddleware(Middleware):
     ) -> Any:
         method = context.method or "<unknown>"
         request_id = _extract_request_id(context)
+        tool = _extract_tool_name(context)
         start = time.monotonic()
         try:
             result = await call_next(context)
         except asyncio.CancelledError:
             elapsed_ms = (time.monotonic() - start) * 1000
             _log.info(
-                "mcp cancelled method=%s id=%s elapsed_ms=%.0f",
-                method, request_id, elapsed_ms,
+                "mcp cancelled method=%s tool=%s id=%s elapsed_ms=%.0f",
+                method, tool, request_id, elapsed_ms,
             )
             raise
         except Exception as exc:
             elapsed_ms = (time.monotonic() - start) * 1000
             _log.warning(
-                "mcp error method=%s id=%s elapsed_ms=%.0f exc=%r",
-                method, request_id, elapsed_ms, exc,
+                "mcp error method=%s tool=%s id=%s elapsed_ms=%.0f exc=%r",
+                method, tool, request_id, elapsed_ms, exc,
             )
             raise
         else:
             elapsed_ms = (time.monotonic() - start) * 1000
             _log.info(
-                "mcp ok method=%s id=%s elapsed_ms=%.0f",
-                method, request_id, elapsed_ms,
+                "mcp ok method=%s tool=%s id=%s elapsed_ms=%.0f",
+                method, tool, request_id, elapsed_ms,
             )
             return result
 
@@ -74,3 +75,11 @@ def _extract_request_id(context: MiddlewareContext[Any]) -> str:
         return "-"
     rid = getattr(request_context, "request_id", None)
     return str(rid) if rid is not None else "-"
+
+
+def _extract_tool_name(context: MiddlewareContext[Any]) -> str:
+    """Return the tool name for tools/call, else '-'."""
+    if context.method != "tools/call":
+        return "-"
+    name = getattr(context.message, "name", None)
+    return str(name) if name else "-"

--- a/src/hive/_helpers.py
+++ b/src/hive/_helpers.py
@@ -14,12 +14,13 @@ from contextlib import asynccontextmanager
 from datetime import date
 from typing import TYPE_CHECKING
 
+import filelock
 from mcp.types import ToolAnnotations
 
 from hive.frontmatter import extract_body, parse_date, parse_frontmatter
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Callable
     from pathlib import Path
 
     from hive._context import ServerContext
@@ -392,6 +393,33 @@ _GIT_LOCK = threading.Lock()
 _LOCK_TIMEOUT = 30  # seconds — matches subprocess timeout
 
 
+_GIT_FILELOCKS: dict[str, filelock.BaseFileLock] = {}
+_GIT_FILELOCKS_GUARD = threading.Lock()
+
+
+def _git_filelock(vault_path: Path) -> filelock.BaseFileLock:
+    """Inter-process lock file under the vault's .git dir.
+
+    Serializes write critical sections across separate hive processes
+    (the threading lock only covers a single process). The lock file
+    lives alongside git's own ``index.lock`` so it travels with the
+    repo and is naturally ignored by git itself.
+
+    Returns a process-singleton ``FileLock`` instance per vault path so
+    nested ``acquire()`` calls from the same thread re-enter cleanly:
+    ``vault_write`` takes the lock around the read-modify-write, then
+    calls ``_git_commit`` which would otherwise deadlock waiting on its
+    own outer hold.
+    """
+    key = str(vault_path / ".git" / "hive.lock")
+    with _GIT_FILELOCKS_GUARD:
+        lock = _GIT_FILELOCKS.get(key)
+        if lock is None:
+            lock = filelock.FileLock(key)
+            _GIT_FILELOCKS[key] = lock
+    return lock
+
+
 @asynccontextmanager
 async def tool_span(
     tool_name: str, timeout_seconds: float,
@@ -416,6 +444,71 @@ async def tool_span(
         _log.debug("%s completed in %.1fs", tool_name, elapsed)
 
 
+async def run_sync_tool(
+    tool_name: str,
+    timeout_seconds: float,
+    fn: Callable[..., str],
+    *args: object,
+    **kwargs: object,
+) -> str:
+    """Run a sync tool body in a worker thread with a wall-clock timeout.
+
+    ``asyncio.timeout`` cancels the awaiting coroutine but cannot interrupt
+    the underlying thread — see lesson 2026-03-13. This helper still uses
+    it because the goal is to give the client a fast response (and unblock
+    the MCP receive loop) even when the sync work is stuck on a lock or
+    subprocess; the thread eventually returns and its late ``respond()``
+    call is silenced by the ``_compat`` shim.
+
+    Returns a user-visible error string on timeout instead of propagating
+    so the MCP client sees a normal tool response.
+    """
+    try:
+        async with tool_span(tool_name, timeout_seconds):
+            return await asyncio.to_thread(fn, *args, **kwargs)
+    except TimeoutError:
+        return (
+            f"{tool_name} timed out after {timeout_seconds:.0f}s. "
+            "Server may be under load or a lock is contended; retry shortly."
+        )
+
+
+def wrap_sync_tool(
+    ctx: ServerContext, tool_name: str,
+) -> Callable[[Callable[..., str]], Callable[..., object]]:
+    """Decorator: convert a sync MCP tool handler into async-with-timeout.
+
+    Applied between ``@mcp.tool`` and the sync handler so the body keeps
+    its original ``def`` form (no indentation churn) while gaining a
+    wall-clock timeout and thread-pool execution. The wrapper preserves
+    the original signature, annotations, name, and docstring so
+    FastMCP's schema introspection still sees the correct shape.
+
+    Usage::
+
+        @mcp.tool(annotations=_READ_ONLY)
+        @wrap_sync_tool(ctx, "vault_list")
+        def vault_list(project: str = "", ...) -> str:
+            ...
+    """
+    import functools
+    import inspect
+
+    def decorator(fn: Callable[..., str]) -> Callable[..., object]:
+        sig = inspect.signature(fn)
+
+        @functools.wraps(fn)
+        async def wrapper(*args: object, **kwargs: object) -> str:
+            return await run_sync_tool(
+                tool_name, ctx.tool_timeout, fn, *args, **kwargs,
+            )
+
+        wrapper.__signature__ = sig  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator
+
+
 def _git_commit(vault_path: Path, rel_path: Path, message: str) -> None:
     """Stage a file and commit it in the vault git repo.
 
@@ -423,34 +516,49 @@ def _git_commit(vault_path: Path, rel_path: Path, message: str) -> None:
     propagated, so a git problem cannot crash the MCP server or prevent
     the tool response from reaching the client.
 
-    Serialized via ``_GIT_LOCK`` to prevent concurrent git-add/commit
-    from interleaving and corrupting the index.
+    Serialized at two levels: ``_GIT_LOCK`` (threading) serializes
+    concurrent calls inside a single hive process; the filelock under
+    ``vault/.git/hive.lock`` serializes concurrent calls across separate
+    hive processes (one per MCP client session). Without the filelock,
+    two hive subprocesses could race on git's own ``.git/index.lock``
+    and time out (see hive.log history: 5+ ``git commit timed out``
+    warnings from concurrent sessions).
     """
     safe_msg = message.replace("\n", " ").replace("\r", " ")
     if not _GIT_LOCK.acquire(timeout=_LOCK_TIMEOUT):
-        _log.warning("git commit skipped for %s: lock timeout (%ds)", rel_path, _LOCK_TIMEOUT)
+        _log.warning(
+            "git commit skipped for %s: thread lock timeout (%ds)",
+            rel_path, _LOCK_TIMEOUT,
+        )
         return
     try:
-        subprocess.run(
-            ["git", "add", str(rel_path)],
-            cwd=vault_path,
-            capture_output=True,
-            check=True,
-            timeout=30,
-        )
-        subprocess.run(
-            ["git", "commit", "-m", safe_msg],
-            cwd=vault_path,
-            capture_output=True,
-            check=True,
-            timeout=30,
-        )
-    except subprocess.CalledProcessError as exc:
-        _log.warning("git commit failed for %s: %s", rel_path, exc)
-    except subprocess.TimeoutExpired as exc:
-        _log.warning("git commit timed out for %s: %s", rel_path, exc)
-    except Exception as exc:
-        _log.warning("git commit unexpected error for %s: %s", rel_path, exc)
+        try:
+            with _git_filelock(vault_path).acquire(timeout=_LOCK_TIMEOUT):
+                subprocess.run(
+                    ["git", "add", str(rel_path)],
+                    cwd=vault_path,
+                    capture_output=True,
+                    check=True,
+                    timeout=30,
+                )
+                subprocess.run(
+                    ["git", "commit", "-m", safe_msg],
+                    cwd=vault_path,
+                    capture_output=True,
+                    check=True,
+                    timeout=30,
+                )
+        except filelock.Timeout:
+            _log.warning(
+                "git commit skipped for %s: inter-process lock timeout (%ds)",
+                rel_path, _LOCK_TIMEOUT,
+            )
+        except subprocess.CalledProcessError as exc:
+            _log.warning("git commit failed for %s: %s", rel_path, exc)
+        except subprocess.TimeoutExpired as exc:
+            _log.warning("git commit timed out for %s: %s", rel_path, exc)
+        except Exception as exc:
+            _log.warning("git commit unexpected error for %s: %s", rel_path, exc)
     finally:
         _GIT_LOCK.release()
 

--- a/src/hive/_sqlite_tracker.py
+++ b/src/hive/_sqlite_tracker.py
@@ -7,6 +7,8 @@ import sqlite3
 import threading
 from pathlib import Path
 
+_BUSY_TIMEOUT_SECONDS = 10  # connect-level + PRAGMA busy_timeout
+
 
 class _SqliteTracker:
     """Base class for thread-safe SQLite-backed trackers.
@@ -15,6 +17,12 @@ class _SqliteTracker:
     CREATE TABLE statements; the base handles connection setup, parent
     directory creation, WAL mode for on-disk databases, lock allocation,
     and connection teardown.
+
+    The connect-level ``timeout`` and the ``PRAGMA busy_timeout`` are
+    both set to 10s so that two hive processes writing to the same
+    on-disk DB (one per MCP client session) wait for each other
+    instead of failing fast with ``OperationalError: database is locked``.
+    WAL mode keeps readers non-blocking while writes serialize.
     """
 
     _SCHEMA: str = ""
@@ -23,9 +31,16 @@ class _SqliteTracker:
         if db_path != ":memory:":
             Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.Lock()
-        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn = sqlite3.connect(
+            db_path,
+            check_same_thread=False,
+            timeout=_BUSY_TIMEOUT_SECONDS,
+        )
         if db_path != ":memory:":
             self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute(
+                f"PRAGMA busy_timeout={_BUSY_TIMEOUT_SECONDS * 1000}",
+            )
         self._conn.executescript(self._SCHEMA)
 
     def close(self) -> None:

--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -16,6 +16,7 @@ from hive._helpers import (
     count_stale,
     project_not_found,
     track,
+    wrap_sync_tool,
 )
 from hive.frontmatter import (
     _TERMINAL_STATUSES,
@@ -146,6 +147,7 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
     """Register vault health tools on the MCP server."""
 
     @mcp.tool(annotations=_READ_ONLY)
+    @wrap_sync_tool(ctx, "vault_health")
     def vault_health(
         project: str = "",
         checks: list[str] = [],  # noqa: B006

--- a/src/hive/_vault_read.py
+++ b/src/hive/_vault_read.py
@@ -21,6 +21,7 @@ from hive._helpers import (
     count_stale,
     project_not_found,
     track,
+    wrap_sync_tool,
 )
 from hive.frontmatter import extract_body, parse_date, parse_frontmatter
 
@@ -67,6 +68,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
     """Register vault read tools on the MCP server."""
 
     @mcp.tool(annotations=_READ_ONLY)
+    @wrap_sync_tool(ctx, "vault_list")
     def vault_list(
         project: str = "",
         path: str = "",
@@ -159,6 +161,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         return track(ctx, "vault_list", "\n".join(lines), project, path)
 
     @mcp.tool(annotations=_READ_ONLY)
+    @wrap_sync_tool(ctx, "vault_query")
     def vault_query(
         project: str,
         section: str = "context",
@@ -201,6 +204,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
                      project, resolved_section)
 
     @mcp.tool(annotations=_READ_ONLY)
+    @wrap_sync_tool(ctx, "vault_search")
     def vault_search(
         query: str = "",
         max_lines: int = 500,
@@ -450,6 +454,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         return track(ctx, "vault_search", _truncate(output, max_lines))
 
     @mcp.tool(annotations=_READ_ONLY)
+    @wrap_sync_tool(ctx, "session_briefing")
     def session_briefing(project: str) -> str:
         """Call at the start of every new session to load project context.
 

--- a/src/hive/_vault_write.py
+++ b/src/hive/_vault_write.py
@@ -5,18 +5,22 @@ from __future__ import annotations
 import threading
 from typing import TYPE_CHECKING
 
+import filelock
+
 from hive._helpers import (
     _LOCK_TIMEOUT,
     _WRITE,
     SECTION_SHORTCUTS,
     _check_path_boundary,
     _git_commit,
+    _git_filelock,
     _make_frontmatter,
     _match_and_replace,
     _resolve_project_dir,
     _vault_guard,
     project_not_found,
     track,
+    wrap_sync_tool,
 )
 from hive.frontmatter import validate_frontmatter
 
@@ -33,6 +37,7 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
     """Register vault write tools on the MCP server."""
 
     @mcp.tool(annotations=_WRITE)
+    @wrap_sync_tool(ctx, "vault_write")
     def vault_write(
         project: str,
         content: str,
@@ -103,30 +108,39 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                     project,
                 )
             try:
-                if filepath.exists():
+                try:
+                    with _git_filelock(ctx.vault).acquire(timeout=_LOCK_TIMEOUT):
+                        if filepath.exists():
+                            return track(
+                                ctx, "vault_write",
+                                f"File already exists: {path}. "
+                                "Use vault_write(operation='replace') to modify.",
+                                project,
+                            )
+
+                        try:
+                            filepath.parent.mkdir(parents=True, exist_ok=True)
+                            filepath.write_text(
+                                frontmatter + content, encoding="utf-8",
+                            )
+                        except OSError as exc:
+                            return track(
+                                ctx, "vault_write",
+                                f"File I/O error: {exc}", project,
+                            )
+
+                        rel = filepath.relative_to(ctx.vault)
+                        display = "00_meta" if project == "_meta" else project
+                        _git_commit(
+                            ctx.vault, rel,
+                            f"vault: create {display}/{path}",
+                        )
+                except filelock.Timeout:
                     return track(
                         ctx, "vault_write",
-                        f"File already exists: {path}. "
-                        "Use vault_write(operation='replace') to modify.",
+                        "Server busy — inter-process lock timeout. Retry shortly.",
                         project,
                     )
-
-                try:
-                    filepath.parent.mkdir(parents=True, exist_ok=True)
-                    filepath.write_text(
-                        frontmatter + content, encoding="utf-8",
-                    )
-                except OSError as exc:
-                    return track(
-                        ctx, "vault_write", f"File I/O error: {exc}", project,
-                    )
-
-                rel = filepath.relative_to(ctx.vault)
-                display = "00_meta" if project == "_meta" else project
-                _git_commit(
-                    ctx.vault, rel,
-                    f"vault: create {display}/{path}",
-                )
             finally:
                 _WRITE_LOCK.release()
 
@@ -172,26 +186,35 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
             )
         try:
             try:
-                if operation == "append":
-                    existing = (
-                        filepath.read_text(encoding="utf-8")
-                        if filepath.exists()
-                        else ""
-                    )
-                    filepath.write_text(
-                        existing + content, encoding="utf-8",
-                    )
-                else:
-                    filepath.write_text(content, encoding="utf-8")
-            except (OSError, UnicodeDecodeError) as exc:
-                return track(
-                    ctx, "vault_write", f"File I/O error: {exc}", project,
-                )
+                with _git_filelock(ctx.vault).acquire(timeout=_LOCK_TIMEOUT):
+                    try:
+                        if operation == "append":
+                            existing = (
+                                filepath.read_text(encoding="utf-8")
+                                if filepath.exists()
+                                else ""
+                            )
+                            filepath.write_text(
+                                existing + content, encoding="utf-8",
+                            )
+                        else:
+                            filepath.write_text(content, encoding="utf-8")
+                    except (OSError, UnicodeDecodeError) as exc:
+                        return track(
+                            ctx, "vault_write",
+                            f"File I/O error: {exc}", project,
+                        )
 
-            rel = filepath.relative_to(ctx.vault)
-            _git_commit(
-                ctx.vault, rel, f"vault: update {project}/{section}",
-            )
+                    rel = filepath.relative_to(ctx.vault)
+                    _git_commit(
+                        ctx.vault, rel, f"vault: update {project}/{section}",
+                    )
+            except filelock.Timeout:
+                return track(
+                    ctx, "vault_write",
+                    "Server busy — inter-process lock timeout. Retry shortly.",
+                    project,
+                )
         finally:
             _WRITE_LOCK.release()
 
@@ -202,6 +225,7 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
         )
 
     @mcp.tool(annotations=_WRITE)
+    @wrap_sync_tool(ctx, "vault_patch")
     def vault_patch(
         project: str,
         path: str,
@@ -284,42 +308,61 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                 "Server busy — write lock timeout. Retry shortly.",
                 project,
             )
+        n = 0
         try:
             try:
-                content = filepath.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError) as exc:
-                return track(ctx, "vault_patch",
-                             f"File I/O error reading '{path}': {exc}", project)
+                with _git_filelock(ctx.vault).acquire(timeout=_LOCK_TIMEOUT):
+                    try:
+                        content = filepath.read_text(encoding="utf-8")
+                    except (OSError, UnicodeDecodeError) as exc:
+                        return track(
+                            ctx, "vault_patch",
+                            f"File I/O error reading '{path}': {exc}",
+                            project,
+                        )
 
-            # Validate and apply all patches on a working copy first
-            working = content
-            for i, patch in enumerate(patch_list, 1):
-                if "find" not in patch or "replace" not in patch:
-                    label = f"patch {i}: " if len(patch_list) > 1 else ""
-                    return track(
-                        ctx, "vault_patch",
-                        f"{label}Each patch must have 'find' and 'replace' keys.",
-                        project,
+                    # Validate and apply all patches on a working copy first
+                    working = content
+                    for i, patch in enumerate(patch_list, 1):
+                        if "find" not in patch or "replace" not in patch:
+                            label = f"patch {i}: " if len(patch_list) > 1 else ""
+                            return track(
+                                ctx, "vault_patch",
+                                f"{label}Each patch must have 'find' and "
+                                f"'replace' keys.",
+                                project,
+                            )
+                        ok, result = _match_and_replace(
+                            working, patch["find"], patch["replace"],
+                        )
+                        if not ok:
+                            label = f"patch {i}: " if len(patch_list) > 1 else ""
+                            return track(
+                                ctx, "vault_patch",
+                                f"{label}{result}", project,
+                            )
+                        working = result
+
+                    try:
+                        filepath.write_text(working, encoding="utf-8")
+                    except OSError as exc:
+                        return track(
+                            ctx, "vault_patch",
+                            f"File I/O error writing '{path}': {exc}",
+                            project,
+                        )
+
+                    rel = filepath.relative_to(ctx.vault)
+                    n = len(patch_list)
+                    _git_commit(
+                        ctx.vault, rel, f"vault: patch {project}/{path}",
                     )
-                ok, result = _match_and_replace(
-                    working, patch["find"], patch["replace"],
+            except filelock.Timeout:
+                return track(
+                    ctx, "vault_patch",
+                    "Server busy — inter-process lock timeout. Retry shortly.",
+                    project,
                 )
-                if not ok:
-                    label = f"patch {i}: " if len(patch_list) > 1 else ""
-                    return track(
-                        ctx, "vault_patch", f"{label}{result}", project,
-                    )
-                working = result
-
-            try:
-                filepath.write_text(working, encoding="utf-8")
-            except OSError as exc:
-                return track(ctx, "vault_patch",
-                             f"File I/O error writing '{path}': {exc}", project)
-
-            rel = filepath.relative_to(ctx.vault)
-            n = len(patch_list)
-            _git_commit(ctx.vault, rel, f"vault: patch {project}/{path}")
         finally:
             _WRITE_LOCK.release()
 

--- a/src/hive/_workers.py
+++ b/src/hive/_workers.py
@@ -168,6 +168,12 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
         except (ConnectionError, RuntimeError) as exc:
             label = f"OpenRouter ({model})" if model else provider.capitalize()
             return None, f"{label}: {exc}"
+        except Exception as exc:
+            label = f"OpenRouter ({model})" if model else provider.capitalize()
+            _log.warning(
+                "_try_worker unexpected error for %s: %r", label, exc,
+            )
+            return None, f"{label}: unexpected error ({type(exc).__name__})"
 
     @mcp.tool(annotations=_WRITE)
     async def capture_lesson(

--- a/tests/test_concurrency_fixes.py
+++ b/tests/test_concurrency_fixes.py
@@ -1,0 +1,210 @@
+"""Regression tests for the multi-process hang/crash fixes.
+
+Two distinct bugs are covered:
+
+1. ``RequestResponder.respond`` raised ``AssertionError('Request already
+   responded to')`` when a handler completed *after* the client had
+   already sent ``notifications/cancelled``. The assertion propagated
+   to the stdio receive loop's task group and killed the server with
+   ``CRITICAL hive: hive server exiting``. Patched in ``hive._compat``.
+
+2. ``_git_commit`` serialized only intra-process (``threading.Lock``).
+   Multiple hive subprocesses (one per Claude Code session) competed on
+   the same ``vault/.git/index.lock`` and triggered 30s subprocess
+   timeouts. Fixed by an additional inter-process ``filelock`` under
+   ``vault/.git/hive.lock``.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+import hive._compat as _hive_compat
+from hive._helpers import _git_commit
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ── Bug 2: respond() AssertionError after client cancellation ─────────
+
+
+_hive_compat.apply()
+
+
+class _FakeResponder:
+    """Minimal stand-in matching the attribute surface our patch reads.
+
+    Calling the patched ``respond`` against this object exercises the
+    ``self._completed`` short-circuit added by ``_compat._make_patched_respond``.
+    We don't go through the full ``mcp`` session because the bug is
+    purely in the assertion logic.
+    """
+
+    def __init__(self, *, entered: bool, completed: bool) -> None:
+        self._entered = entered
+        self._completed = completed
+        self.request_id = "test-req-123"
+
+
+class TestRespondPatchPreventsKill:
+    """The patched ``respond`` must not raise when ``_completed`` is True."""
+
+    async def test_respond_after_cancel_swallowed(self) -> None:
+        """Handler finishing after a cancel must not crash with AssertionError."""
+        from mcp.shared.session import RequestResponder
+
+        fake = _FakeResponder(entered=True, completed=True)
+        # The patched respond is bound to the class — call descriptor-style.
+        # Before the patch this would raise AssertionError('Request already
+        # responded to') and kill the receive loop's TaskGroup.
+        await RequestResponder.respond(fake, {"result": "late"})
+
+    async def test_respond_normal_path_still_requires_entered(self) -> None:
+        """If never entered, original RuntimeError still surfaces."""
+        from mcp.shared.session import RequestResponder
+
+        fake = _FakeResponder(entered=False, completed=False)
+        with pytest.raises(RuntimeError, match="context manager"):
+            await RequestResponder.respond(fake, {"result": "x"})
+
+
+# ── Bug 1: inter-process git contention ───────────────────────────────
+
+
+def _init_git_repo(repo: Path) -> None:
+    """Initialize a minimal git repo with an initial commit."""
+    subprocess.run(
+        ["git", "init", "-q"], cwd=repo, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@hive.local"],
+        cwd=repo, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "hive-test"],
+        cwd=repo, check=True, capture_output=True,
+    )
+    seed = repo / "README.md"
+    seed.write_text("seed\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "README.md"], cwd=repo, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "seed"],
+        cwd=repo, check=True, capture_output=True,
+    )
+
+
+def _commit_worker(vault: str, file_name: str) -> str:
+    """Worker process: write a file and commit it via _git_commit."""
+    from pathlib import Path as _Path
+
+    vault_path = _Path(vault)
+    file_path = vault_path / file_name
+    file_path.write_text(f"content for {file_name}\n", encoding="utf-8")
+    _git_commit(vault_path, _Path(file_name), f"add {file_name}")
+    return file_name
+
+
+def _append_to_shared_file_worker(vault: str, shared_file: str, line: str) -> str:
+    """Worker process: append a line to a shared file under the inter-process lock.
+
+    Mimics what ``vault_write`` (operation=append) does end-to-end:
+    take the inter-process filelock, read the file, append, write, commit.
+    Two processes running this against the same file must not lose lines.
+    """
+    from pathlib import Path as _Path
+
+    from hive._helpers import _git_filelock
+
+    vault_path = _Path(vault)
+    file_path = vault_path / shared_file
+    with _git_filelock(vault_path).acquire(timeout=30):
+        existing = (
+            file_path.read_text(encoding="utf-8")
+            if file_path.exists() else ""
+        )
+        file_path.write_text(existing + line + "\n", encoding="utf-8")
+        _git_commit(vault_path, _Path(shared_file), f"append: {line}")
+    return line
+
+
+class TestInterProcessGitContention:
+    """Concurrent ``_git_commit`` from multiple processes must serialize cleanly."""
+
+    def test_concurrent_processes_complete_within_budget(
+        self, tmp_path: Path,
+    ) -> None:
+        """8 concurrent processes committing distinct files must all succeed in <60s.
+
+        Without the inter-process ``filelock``, the second-onwards processes
+        would lose the race for ``.git/index.lock``, each waiting up to 30s
+        for the ``git add`` subprocess timeout to fire.
+        """
+        _init_git_repo(tmp_path)
+
+        # mp.Pool spawns N processes; each calls _commit_worker with a unique file.
+        # All share the same vault path → race on .git/index.lock.
+        file_names = [f"file_{i:02d}.md" for i in range(8)]
+        args = [(str(tmp_path), n) for n in file_names]
+
+        ctx = mp.get_context("spawn")
+        with ctx.Pool(processes=4) as pool:
+            results = pool.starmap_async(_commit_worker, args)
+            # 60s budget — generous but well below the unfixed worst case
+            # (8 procs × 30s git timeout = 240s upper bound without filelock).
+            collected = results.get(timeout=60)
+
+        assert set(collected) == set(file_names)
+
+        # All files should be committed (not just written) — verify via git log.
+        log = subprocess.run(
+            ["git", "log", "--pretty=format:%s"],
+            cwd=tmp_path, check=True, capture_output=True, text=True,
+        ).stdout.splitlines()
+        committed_files = {
+            ln.removeprefix("add ").strip()
+            for ln in log if ln.startswith("add ")
+        }
+        assert committed_files == set(file_names), (
+            f"missing commits: {set(file_names) - committed_files}"
+        )
+
+    def test_concurrent_appends_to_same_file_lose_no_lines(
+        self, tmp_path: Path,
+    ) -> None:
+        """8 processes appending unique lines to one file must all survive.
+
+        This is the bug that previously made parallel ``capture_lesson``
+        calls silently drop lessons: the per-process threading lock
+        serialized the read-modify-write within one process, but two
+        processes both read the same pre-image, both wrote post-images,
+        and the last writer overwrote the first's append.
+        """
+        _init_git_repo(tmp_path)
+        shared = "shared.md"
+        (tmp_path / shared).write_text("# header\n", encoding="utf-8")
+
+        lines = [f"line-{i:02d}" for i in range(8)]
+        args = [(str(tmp_path), shared, ln) for ln in lines]
+
+        ctx = mp.get_context("spawn")
+        with ctx.Pool(processes=4) as pool:
+            collected = pool.starmap_async(
+                _append_to_shared_file_worker, args,
+            ).get(timeout=90)
+
+        assert set(collected) == set(lines)
+
+        final = (tmp_path / shared).read_text(encoding="utf-8").splitlines()
+        present = [ln for ln in lines if ln in final]
+        missing = [ln for ln in lines if ln not in final]
+        assert not missing, (
+            f"write-loss: {len(missing)} of 8 appends lost.\n"
+            f"present={present}\nmissing={missing}\nfinal={final!r}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -420,6 +420,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -434,6 +443,7 @@ version = "1.12.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "filelock" },
     { name = "httpx" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
@@ -452,6 +462,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=2.0.0" },
+    { name = "filelock", specifier = ">=3.13" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
     { name = "pydantic-settings", specifier = ">=2.0" },


### PR DESCRIPTION
## Summary

Three classes of multi-process bug surfaced when multiple Claude Code sessions ran `hive-vault` subprocesses in parallel against a shared vault. All confirmed in production logs from `~/.local/share/hive/hive.log` (39-min hang ending in CRITICAL exit, recurring git commit timeouts, silent capture_lesson loss).

This PR fixes seven distinct bugs and adds a regression suite. **425 pass / 2 skipped / 0 fail** (was 421 / 2 / 0).

See vault note `adr-005-transport-and-scale` for the architecture analysis behind the chosen fixes and the scale ceiling.

## Bugs fixed

| # | Symptom in log | Root cause | Fix |
|---|---|---|---|
| 1 | `CRITICAL hive: hive server exiting: AssertionError('Request already responded to')` | Handler completed AFTER client `notifications/cancelled` -> `respond()` asserted on `_completed=True` and killed `stdio_server`'s TaskGroup | Extended `_compat.py` to patch `respond` as well (distinct from #75 which patches `__exit__`) |
| 2 | `tools/call id=4 elapsed_ms=2339650` (39-min hang) | Vault tools had no timeout; only the 3 worker tools were wrapped with `tool_span` | New `wrap_sync_tool` decorator runs sync handlers in a worker thread under `asyncio.timeout`, returning a user-visible error on overrun. Per lesson 2026-03-13, this unblocks the client even if the thread keeps running |
| 3 | `git commit timed out for X after 30 seconds` (5+ historical) | Multiple hive processes raced on `.git/index.lock` because `_GIT_LOCK` is intra-process only | New inter-process `filelock` at `vault/.git/hive.lock` |
| 4 | Silent capture_lesson loss in parallel sessions (not in log; observed by usage pattern) | `_WRITE_LOCK` is intra-process; two sibling processes both read pre-image, both wrote post-image, last writer wins | Extended the same `filelock` to wrap the **full critical section** of `vault_write` / `vault_patch`, not just the git commit |
| 5 | Occasional `OperationalError: database is locked` | Default 5s SQLite wait too short under multi-process contention | `PRAGMA busy_timeout=10000` + `sqlite3.connect(timeout=10)` |
| 6 | Workers crashing on unexpected exception classes | `_try_worker` only caught `(ConnectionError, RuntimeError)` | Catch-all `except Exception` with log |
| 7 | Log line gave no hint which tool hung | `LifecycleMiddleware` only logged `method=tools/call id=N` | Now logs `tool=<name>` for `tools/call` |

## Regression tests

New file `tests/test_concurrency_fixes.py` (4 tests):

- `test_respond_after_cancel_swallowed` — verifies patched `respond` does not raise.
- `test_respond_normal_path_still_requires_entered` — verifies non-entered case still raises `RuntimeError`.
- `test_concurrent_processes_complete_within_budget` — 8 procs x `_git_commit` on distinct files complete in <60s (unfixed upper bound ~240s).
- `test_concurrent_appends_to_same_file_lose_no_lines` — 8 procs appending to one file, zero losses (guaranteed lossy pre-fix).

## Test plan

- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy strict clean (17 source files)
- [x] `make test` — 425 pass / 2 skipped / 0 fail
- [ ] Validate against a real Claude Code session by pointing `claude mcp add` at the local checkout: `claude mcp add -s user hive -- uv run --directory /path/to/hive hive-vault`
- [ ] After merge and release, observe `~/.local/share/hive/hive.log` for absence of: `git commit timed out`, `CRITICAL hive: hive server exiting`, `elapsed_ms > 60000`.

## Notes

- Adds one runtime dependency: `filelock>=3.13`. Stdlib does not provide cross-platform inter-process file locking.
- All `_compat.py` patches remain self-gated on the exact failure mode; if upstream MCP fixes either bug the patch becomes inert and `_compat.py` can be deleted.
- Second commit is a `docs:` refresh of `.claude/CLAUDE.md` from the same session. Independent but small enough to bundle.