### PR TITLE
fix(vault_health): resolve cross-scope and project-prefixed wikilinks (#94)

### DIFF
--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -39,6 +39,7 @@ _FENCED_CODE_RE = re.compile(
     r"(?ms)^(?P<fence>`{3,}|~{3,})[^\n]*\n.*?^(?P=fence)[^\n]*$",
 )
 _INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+_POSIX_CLASS_RE = re.compile(r"^:[a-z]+:$")
 
 
 def _strip_code(text: str) -> str:
@@ -217,9 +218,33 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
             all_stems: set[str] = set()
             all_paths: set[str] = set()
             if "links" in active_checks:
-                for pd, _ in project_dirs:
-                    for f in pd.rglob("*.md"):
-                        all_stems.add(f.stem)
+                # Index every .md in the vault under all 4 forms Obsidian
+                # accepts: bare stem, vault-rooted full path, vault-rooted
+                # without scope dir, and project-relative. Meta-scope files
+                # also get an `_meta/`-prefixed form (the slug Obsidian/Hive
+                # users type in wikilinks).
+                scope_dir_names = set(ctx.scopes.values())
+                meta_dir_name = ctx.scopes.get("meta")
+                try:
+                    md_files = list(ctx.vault.rglob("*.md"))
+                except OSError:
+                    md_files = []
+                for f in md_files:
+                    if not f.is_file():
+                        continue
+                    all_stems.add(f.stem)
+                    with contextlib.suppress(ValueError):
+                        vault_rel = (
+                            f.relative_to(ctx.vault).with_suffix("").as_posix()
+                        )
+                        all_paths.add(vault_rel)
+                        if "/" in vault_rel:
+                            leading, rest = vault_rel.split("/", 1)
+                            if leading in scope_dir_names:
+                                all_paths.add(rest)
+                                if leading == meta_dir_name:
+                                    all_paths.add(f"_meta/{rest}")
+                    for pd, _ in project_dirs:
                         with contextlib.suppress(ValueError):
                             all_paths.add(
                                 f.relative_to(pd).with_suffix("").as_posix(),
@@ -296,6 +321,8 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                         body = _strip_code(extract_body(content))
                         for m in _WIKILINK_RE.finditer(body):
                             target = m.group(1).strip().rstrip("\\").strip()
+                            if _POSIX_CLASS_RE.match(target):
+                                continue
                             if (
                                 target not in all_stems
                                 and target not in all_paths

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3406,6 +3406,94 @@ class TestVaultValidate:
             f"MEMORY.md must be skipped; got: {result}"
         )
 
+    async def test_meta_scope_wikilink_resolves(
+        self, mock_vault: Path,
+    ) -> None:
+        """`[[pattern-X]]` targeting `00_meta/patterns/pattern-X.md` must
+        resolve. The meta scope is the canonical home for cross-project
+        patterns/templates and must be a valid link target from every project.
+
+        Regression for #94 category 1.
+        """
+        doc = mock_vault / "10_projects" / "testproject" / "with-meta-link.md"
+        doc.write_text(
+            "---\nid: with-meta-link\ntype: note\nstatus: active\n---\n\n"
+            "See [[pattern-tdd]] for context.\n"
+            "Also [[_meta/patterns/pattern-tdd]] (scope-rooted form).\n",
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool(
+            "vault_health",
+            {"project": "testproject", "checks": ["links"]},
+        ))
+        assert "with-meta-link.md" not in result, (
+            f"Wikilink to existing meta-scope target must resolve; "
+            f"got: {result}"
+        )
+
+    async def test_cross_project_vault_rooted_wikilink_resolves(
+        self, mock_vault: Path,
+    ) -> None:
+        """`[[other-project/30-architecture/adr-X]]` must resolve to the
+        existing file under another project in the same scope. This is the
+        standard Obsidian disambiguation form for cross-project references.
+
+        Regression for #94 category 2.
+        """
+        kubelab = mock_vault / "10_projects" / "kubelab"
+        kubelab.mkdir()
+        (kubelab / "00-context.md").write_text(
+            "---\nid: kubelab\ntype: project\nstatus: active\n---\n\n"
+            "# Kubelab\n",
+        )
+        adrs = kubelab / "30-architecture" / "adrs"
+        adrs.mkdir(parents=True)
+        (adrs / "adr-038-orchestrator-architecture.md").write_text(
+            "---\nid: adr-038\ntype: adr\nstatus: accepted\n---\n\n"
+            "# ADR-038\n",
+        )
+
+        doc = mock_vault / "10_projects" / "testproject" / "with-xproj-link.md"
+        doc.write_text(
+            "---\nid: with-xproj-link\ntype: note\nstatus: active\n---\n\n"
+            "Driven by "
+            "[[kubelab/30-architecture/adrs/adr-038-orchestrator-architecture"
+            "|ADR-038]].\n",
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool(
+            "vault_health", {"checks": ["links"]},
+        ))
+        assert "with-xproj-link.md" not in result, (
+            f"Cross-project vault-rooted wikilink must resolve; got: {result}"
+        )
+
+    async def test_posix_class_in_heading_not_flagged(
+        self, mock_vault: Path,
+    ) -> None:
+        """POSIX character classes (`[[:space:]]`, `[[:digit:]]`, etc.) that
+        appear in markdown headings or prose (outside fenced/inline code) must
+        not be reported as broken wikilinks. No valid Obsidian filename matches
+        the shape `:<lowercase>:`.
+
+        Regression for #94 category 3.
+        """
+        doc = mock_vault / "10_projects" / "testproject" / "posix-heading.md"
+        doc.write_text(
+            "---\nid: posix-heading\ntype: note\nstatus: active\n---\n\n"
+            "### \\s is not POSIX — use [[:space:]] in bash regex\n\n"
+            "And the digit class [[:digit:]] is similar.\n",
+        )
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(await mcp.call_tool(
+            "vault_health",
+            {"project": "testproject", "checks": ["links"]},
+        ))
+        assert "posix-heading.md" not in result, (
+            f"POSIX character classes outside code must not be flagged; "
+            f"got: {result}"
+        )
+
 
 # ── _setup_file_logging ─────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #94.

## Summary

`vault_health(checks=[\"links\"])` was producing ~14 false-positive broken-link warnings per real-vault audit, in three categories that PR #70 did not cover. This PR closes all three by building the link-target index in a single pass over the whole vault and storing every wikilink form Obsidian accepts.

## Changes

`src/hive/_vault_health.py`:

- Build `all_stems` / `all_paths` once via `ctx.vault.rglob(\"*.md\")` instead of per-project loops that excluded the meta scope.
- For every `.md` file, index four forms:
  - bare stem — e.g. `pattern-tdd`
  - vault-rooted full path — `10_projects/kubelab/30-architecture/adrs/adr-038`
  - vault-rooted without the scope dir — `kubelab/30-architecture/adrs/adr-038`, `patterns/pattern-tdd`
  - `_meta/`-prefixed slug for files under the meta scope — `_meta/patterns/pattern-tdd`
  - project-relative (unchanged) — `30-architecture/adrs/adr-001-test`
- New `_POSIX_CLASS_RE = ^:[a-z]+:$` filter applied at wikilink match time, so POSIX character classes in headings or prose (e.g. `[[:space:]]`) are no longer flagged. No valid Obsidian filename has that shape.

## Tests

Three regression tests added under `TestVaultValidate` in `tests/test_server.py`, one per category:

- `test_meta_scope_wikilink_resolves`
- `test_cross_project_vault_rooted_wikilink_resolves`
- `test_posix_class_in_heading_not_flagged`

All fail against `master`; all pass on this branch. Existing link tests (`test_wikilink_inside_fenced_code_block_not_flagged`, `test_escaped_pipe_in_wikilink_resolves_target`, `test_subdir_path_wikilink_to_existing_file_not_flagged`) continue to pass — the new global index is a superset of the prior project-relative one.

## Verification

- \`make check\` — ruff clean, mypy --strict clean, 432 pass / 1 skipped, coverage 90% overall (94% on `_vault_health.py`).

## Test plan

- [x] Three new regression tests fail on `master`, pass on this branch.
- [x] No existing tests regress.
- [x] \`make check\` clean.
- [ ] Smoke-verify on the real `knowledge` vault: `vault_health(checks=[\"links\"], max_issues=100)` warning count should drop from ~50 to within ±5 of `obs-cli unresolved` (~32).