### PR TITLE
feat(hive): HIVE-109 vault_health server identity + opt-in runtime metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ When a tool call is cancelled mid-flight (slow worker, client timeout), the serv
 | `vault_query` | Load project context, tasks, roadmap, lessons — or any file by path |
 | `vault_search` | Full-text search with metadata filters, regex, ranked results, recent changes, lesson-usage ranking (`rank_by`) |
 | `vault_list` | Browse projects and files with glob filtering |
-| `vault_health` | Health metrics, drift detection, usage stats |
+| `vault_health` | Server identity (version, vault path, backends), health metrics, drift detection, usage stats, opt-in runtime block |
 | `vault_write` | Create, append, or replace vault files. `commit=False` defers the git commit for batching |
 | `vault_patch` | Surgical find-and-replace. `commit=False` defers the git commit for batching |
 | `vault_commit` | Flush pending `commit=False` writes into one git commit |

--- a/site/src/content/docs/es/guides/troubleshooting.md
+++ b/site/src/content/docs/es/guides/troubleshooting.md
@@ -253,7 +253,7 @@ Disponible desde `hive-vault >= 1.14.0`. El clasificador empírico de comportami
 
 Si tu problema no está listado aquí:
 
-1. Ejecuta `vault_health` para comprobar conectividad del vault y recuentos de archivos
+1. Ejecuta `vault_health` para comprobar conectividad del vault y recuentos de archivos — el bloque `## server` al principio reporta la versión en ejecución, python, ruta del vault y presencia de backends, así puedes incluirlo literal en un bug report (no se expone ninguna API key). Añade `include_runtime=True` para uptime, nombres de tools registrados y snapshot del presupuesto OpenRouter.
 2. Ejecuta `worker_status` para comprobar conectividad de proveedores y presupuesto
 3. Revisa `~/.local/share/hive/hive.log` para detalles de errores
 4. Consulta la página de [Configuración](/hive/es/configuration/) para todas las variables de entorno

--- a/site/src/content/docs/es/tools/vault.md
+++ b/site/src/content/docs/es/tools/vault.md
@@ -107,10 +107,10 @@ vault_search(query="timeout", rank_by="hybrid")          # α=0.7 BM25 + 0.3 con
 
 ## vault_health
 
-Métricas de salud, detección de drift y estadísticas de uso.
+Identidad del servidor, métricas de salud, detección de drift y estadísticas de uso.
 
 ```python
-# Reporte de salud de todos los proyectos
+# Reporte de salud de todos los proyectos (siempre incluye el bloque ## server)
 vault_health()
 
 # Validar un proyecto específico
@@ -118,7 +118,23 @@ vault_health(project="mi-proyecto", checks=["frontmatter", "stale", "links"], ma
 
 # Incluir estadísticas de uso
 vault_health(include_usage=True, usage_days=30)
+
+# Incluir metadatos de runtime (uptime, tools registrados, presupuesto OpenRouter)
+vault_health(include_runtime=True)
 ```
+
+**Bloque de identidad** (siempre activo, ~5 líneas): Prepended a cada respuesta correcta para que los hosts MCP y operadores puedan responder *"¿qué versión de hive-vault sirve esta sesión?"* sin salir de la conversación.
+
+```text
+## server
+- version: 1.15.0
+- python: 3.12.10
+- vault_path: /home/me/Projects/knowledge
+- backends: {"ollama": true, "openrouter": false}
+- started_at: 2026-05-21T20:33:20+00:00
+```
+
+Los backends se reportan como booleanos de presencia únicamente — **las API keys nunca se embeben**. `ollama` refleja la probe de disponibilidad cacheada; `openrouter` es true cuando se configuró una API key al arrancar.
 
 **Reporte de salud** (por defecto): Recuento de archivos por proyecto, total de líneas, archivos obsoletos (>180 días, configurable vía `HIVE_STALE_THRESHOLD_DAYS`), cobertura de secciones. También detecta **nombres de directorio duplicados** en scopes jerárquicos y advierte qué ruta resolverá BFS.
 
@@ -130,6 +146,8 @@ vault_health(include_usage=True, usage_days=30)
 Los problemas se categorizan como `[error]` o `[warning]` con ruta del archivo y descripción.
 
 **Estadísticas de uso** (`include_usage=True`): Recuento de llamadas a herramientas por herramienta y proyecto, con ahorro estimado de tokens.
+
+**Bloque de runtime** (`include_runtime=True`, opt-in): Diagnósticos dinámicos al final del reporte — uptime en segundos, número + nombres de tools MCP registrados (sanity check de que ningún módulo falló al registrarse), y snapshot del presupuesto OpenRouter (`spent_usd`, `cap_usd`, `period`). Independiente de `include_usage`; ambos pueden combinarse en una sola llamada.
 
 ## vault_write
 

--- a/site/src/content/docs/guides/troubleshooting.md
+++ b/site/src/content/docs/guides/troubleshooting.md
@@ -253,7 +253,7 @@ Available from `hive-vault >= 1.14.0`. The empirical wire-behavior classifier ra
 
 If your issue isn't listed here:
 
-1. Run `vault_health` to check vault connectivity and file counts
+1. Run `vault_health` to check vault connectivity and file counts — the `## server` identity block at the top reports the running version, python, vault path, and backend presence so you can include them verbatim in a bug report (no API keys are exposed). Add `include_runtime=True` for uptime, registered tool names, and the OpenRouter budget snapshot.
 2. Run `worker_status` to check provider connectivity and budget
 3. Check `~/.local/share/hive/hive.log` for error details
 4. Check the [Configuration](/hive/configuration/) page for all environment variables

--- a/site/src/content/docs/tools/vault.md
+++ b/site/src/content/docs/tools/vault.md
@@ -107,10 +107,10 @@ vault_search(query="timeout", rank_by="hybrid")          # α=0.7 BM25 + 0.3 con
 
 ## vault_health
 
-Health metrics, drift detection, and usage statistics.
+Server identity, health metrics, drift detection, and usage statistics.
 
 ```python
-# Health report for all projects
+# Health report for all projects (always includes the ## server identity block)
 vault_health()
 
 # Validate a specific project
@@ -118,7 +118,23 @@ vault_health(project="my-project", checks=["frontmatter", "stale", "links"], max
 
 # Include usage statistics
 vault_health(include_usage=True, usage_days=30)
+
+# Include runtime metadata (uptime, registered tools, OpenRouter budget)
+vault_health(include_runtime=True)
 ```
+
+**Identity block** (always-on, ~5 lines): Prepended to every successful response so MCP hosts and operators can answer *"which hive-vault version is serving this session?"* without leaving the conversation.
+
+```text
+## server
+- version: 1.15.0
+- python: 3.12.10
+- vault_path: /home/me/Projects/knowledge
+- backends: {"ollama": true, "openrouter": false}
+- started_at: 2026-05-21T20:33:20+00:00
+```
+
+Backends are reported as presence booleans only — **API keys are never embedded**. `ollama` reflects the cached availability probe; `openrouter` is true when an API key was configured at startup.
 
 **Health report** (default): Per-project file count, total lines, stale files (>180 days, configurable via `HIVE_STALE_THRESHOLD_DAYS`), section coverage. Also detects **duplicate directory names** within hierarchical scopes and warns which path BFS will resolve to.
 
@@ -130,6 +146,8 @@ vault_health(include_usage=True, usage_days=30)
 Issues are categorized as `[error]` or `[warning]` with file path and description.
 
 **Usage stats** (`include_usage=True`): Tool call counts by tool and project, with estimated token savings.
+
+**Runtime block** (`include_runtime=True`, opt-in): Dynamic diagnostics layered after the report — uptime in seconds, count + names of MCP tools currently registered (sanity check that no module failed to register), and the OpenRouter budget snapshot (`spent_usd`, `cap_usd`, `period`). Independent of `include_usage`; both can stack in one call.
 
 ## vault_write
 

--- a/src/hive/_context.py
+++ b/src/hive/_context.py
@@ -31,6 +31,8 @@ class ServerContext:
     openrouter_budget: float
     openrouter_paid_model: str
     tool_timeout: float
+    started_at_iso: str = ""
+    started_at_monotonic: float = 0.0
 
     def close(self) -> None:
         """Close all database connections held by this context."""

--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import contextlib
 import re
-from datetime import date, timedelta
+import sys
+import time
+from datetime import UTC, date, datetime, timedelta
+from importlib import metadata
 from typing import TYPE_CHECKING
 
 from hive._helpers import (
@@ -40,6 +43,85 @@ _WIKILINK_RE = re.compile(r"\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]")
 _POSIX_CLASS_RE = re.compile(r"^:[a-z]+:$")
 
 
+def _hive_version() -> str:
+    """Return the installed hive-vault version, or a marker for editable installs."""
+    try:
+        return metadata.version("hive-vault")
+    except metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def identity_block_text(ctx: ServerContext) -> str:
+    """Always-on server identity block — issue #109 acceptance criterion 1.
+
+    Renders ~5 lines: version, python, vault_path, backends (presence
+    booleans only — never API keys), started_at. Stable across calls
+    since started_at is captured at server construction.
+    """
+    # Ollama backend: report the cached availability probe. Unprobed →
+    # False (we cannot claim presence we haven't verified). OpenRouter:
+    # presence boolean derived from whether the client was constructed
+    # (which requires an api_key) — the key itself is never embedded.
+    ollama_present = bool(
+        getattr(ctx.ollama, "_availability_cached", None),
+    )
+    openrouter_present = ctx.openrouter is not None
+    backends = (
+        '{"ollama": ' + ("true" if ollama_present else "false")
+        + ', "openrouter": ' + ("true" if openrouter_present else "false")
+        + "}"
+    )
+    return "\n".join([
+        "## server",
+        f"- version: {_hive_version()}",
+        f"- python: {sys.version.split()[0]}",
+        f"- vault_path: {ctx.vault}",
+        f"- backends: {backends}",
+        f"- started_at: {ctx.started_at_iso}",
+        "",
+    ])
+
+
+def _registered_tool_names(mcp: FastMCP) -> list[str]:
+    """Extract sorted tool names from the FastMCP local provider.
+
+    Falls back to [] if the internal structure changes — runtime block
+    must never crash vault_health.
+    """
+    try:
+        components = getattr(mcp.providers[0], "_components", {})
+    except (AttributeError, IndexError):
+        return []
+    names: set[str] = set()
+    for key in components:
+        if not isinstance(key, str) or not key.startswith("tool:"):
+            continue
+        # key shape is `tool:<name>@<scope>` — strip both prefix and suffix.
+        rest = key[len("tool:"):]
+        names.add(rest.split("@", 1)[0])
+    return sorted(names)
+
+
+def runtime_block_text(ctx: ServerContext, mcp: FastMCP) -> str:
+    """Opt-in runtime block — issue #109 acceptance criterion 2."""
+    uptime_s = max(0.0, time.monotonic() - ctx.started_at_monotonic)
+    tools = _registered_tool_names(mcp)
+    period = datetime.now(UTC).strftime("%Y-%m")
+    stats = ctx.budget.month_stats(ctx.openrouter_budget)
+    lines = [
+        "## runtime",
+        f"- uptime_s: {uptime_s:.1f}",
+        f"- tools_registered: {len(tools)} "
+        f"({', '.join(tools) if tools else '<empty>'})",
+        "- openrouter_budget:",
+        f"  - spent_usd: {float(stats['spent']):.4f}",
+        f"  - cap_usd: {ctx.openrouter_budget}",
+        f"  - period: {period}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
 def _find_duplicate_names(scope_dir: Path) -> list[tuple[str, list[str]]]:
     """Find directory names that appear at multiple depths within a scope.
 
@@ -62,9 +144,18 @@ def _find_duplicate_names(scope_dir: Path) -> list[tuple[str, list[str]]]:
 
 
 def health_report_text(ctx: ServerContext, filter_project: str = "") -> str:
-    """Build health report text (shared by resource and tool)."""
+    """Build health report text (shared by resource and tool).
+
+    Always prepends the ``## server`` identity block (issue #109) so the
+    ``hive://health`` resource and ``vault_health()`` tool agree on the
+    static metadata exposed to MCP hosts.
+    """
     stale_threshold = date.today() - timedelta(days=ctx.stale_days)
-    lines = ["# Vault Health Report", ""]
+    lines: list[str] = [
+        "# Vault Health Report",
+        "",
+        identity_block_text(ctx),
+    ]
     found_any = False
 
     for scope_name, dir_name in ctx.scopes.items():
@@ -156,7 +247,7 @@ def health_report_text(ctx: ServerContext, filter_project: str = "") -> str:
         lines.append("")
 
     if not found_any:
-        return "No projects found in vault."
+        lines.append("No projects found in vault.")
     return "\n".join(lines)
 
 
@@ -171,12 +262,17 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
         max_issues: int = 50,
         include_usage: bool = False,
         usage_days: int = 30,
+        include_runtime: bool = False,
     ) -> str:
         """Return vault health metrics, validation, and optional usage analytics.
+
+        Always emits the ``## server`` identity block (version, python,
+        vault path, backend presence, started_at) at the top.
 
         Without parameters, returns a health summary for all projects.
         When checks are specified, runs drift detection (frontmatter, stale, links).
         When include_usage is True, appends tool usage analytics.
+        When include_runtime is True, appends runtime metadata (uptime, tools, budget).
 
         Args:
             project: Project slug to validate. Empty = all projects.
@@ -184,6 +280,7 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
             max_issues: Maximum validation issues to report. Default 50.
             include_usage: Append vault tool usage analytics. Default False.
             usage_days: Usage look-back window in days. Default 30.
+            include_runtime: Append runtime metadata block. Default False.
         """  # noqa: E501
         guard = _vault_guard(ctx)
         if guard:
@@ -194,6 +291,11 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
         if not checks:
             parts.append(health_report_text(ctx, filter_project=project))
         else:
+            # Identity block is part of every successful vault_health
+            # response — prepend before the validation summary so MCP
+            # hosts can read the running server version even when only
+            # checks=[...] is requested.
+            parts.append("# Vault Health Report\n\n" + identity_block_text(ctx))
             active_checks = frozenset(checks) & _ALL_CHECKS
             unknown = frozenset(checks) - _ALL_CHECKS
             if unknown:
@@ -409,5 +511,8 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                     for proj, count in stats["by_project"].items():
                         usage_parts.append(f"- {proj}: {count} calls")
                 parts.append("\n".join(usage_parts))
+
+        if include_runtime:
+            parts.append(runtime_block_text(ctx, mcp))
 
         return track(ctx, "vault_health", "\n".join(parts), project)

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import logging.handlers
+import time
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from hive import _compat as _hive_compat
@@ -84,6 +86,8 @@ def create_server(
         openrouter_budget=settings.openrouter_budget,
         openrouter_paid_model=settings.openrouter_paid_model,
         tool_timeout=settings.tool_timeout,
+        started_at_iso=datetime.now(UTC).isoformat(timespec="seconds"),
+        started_at_monotonic=time.monotonic(),
     )
 
     mcp = FastMCP(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from hive.clients import ClientResponse, ModelInfo
+from hive.clients import ClientResponse, ModelInfo, OpenRouterClient
 from hive.server import create_server
 
 if TYPE_CHECKING:
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from fastmcp.tools import ToolResult
 
     from hive.budget import BudgetTracker
-    from hive.clients import OllamaClient, OpenRouterClient
+    from hive.clients import OllamaClient
 
 
 def _text(result: ToolResult) -> str:
@@ -524,7 +524,10 @@ class TestVaultHealth:
         )
         mcp = create_server(vault_path=tmp_path)
         result = await mcp.call_tool("vault_health", {})
-        assert "stale" not in _text(result).lower()
+        # Assert against the section label, not the bare substring — the
+        # identity block now embeds ``vault_path`` which may legitimately
+        # contain "stale" inside a pytest tmp dir name.
+        assert "stale files" not in _text(result).lower()
 
     async def test_recent_file_not_stale(self, tmp_path: Path) -> None:
         from datetime import date
@@ -537,7 +540,7 @@ class TestVaultHealth:
         )
         mcp = create_server(vault_path=tmp_path)
         result = await mcp.call_tool("vault_health", {})
-        assert "stale" not in _text(result).lower()
+        assert "stale files" not in _text(result).lower()
 
     async def test_stale_fallback_to_mtime(self, tmp_path: Path) -> None:
         import os
@@ -580,7 +583,180 @@ class TestVaultHealth:
 
         _hc.GHOST_RESPONSES.reset()
         result = _text(await vault_mcp.call_tool("vault_health", {}))
-        assert "ghost_responses" not in result
+        # Anchor on the section header so pytest tmp paths that contain
+        # 'ghost_responses' in their dir name cannot collide.
+        assert "## ghost_responses" not in result
+
+
+# ── vault_health (server identity + runtime, issue #109) ─────────────
+
+
+class TestVaultHealthIdentity:
+    """Identity block is always present at the top of vault_health output."""
+
+    async def test_identity_block_present_no_args(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        """Default vault_health() includes the ## server identity block."""
+        result = _text(await vault_mcp.call_tool("vault_health", {}))
+        assert "## server" in result
+        assert "- version:" in result
+        assert "- python:" in result
+        assert "- vault_path:" in result
+        assert "- backends:" in result
+        assert "- started_at:" in result
+
+    async def test_identity_appears_before_project_stats(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        """Identity block is prepended — appears before per-project blocks."""
+        result = _text(await vault_mcp.call_tool("vault_health", {}))
+        idx_server = result.find("## server")
+        idx_project = result.find("testproject")
+        assert idx_server >= 0
+        assert idx_project >= 0
+        assert idx_server < idx_project
+
+    async def test_identity_with_validation_mode(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        """Identity block also appears when checks=[...] is passed."""
+        result = _text(
+            await vault_mcp.call_tool(
+                "vault_health", {"checks": ["frontmatter"]},
+            ),
+        )
+        assert "## server" in result
+        assert "- version:" in result
+
+    async def test_identity_with_empty_vault(self, tmp_path: Path) -> None:
+        """Identity block appears even when the vault has no projects."""
+        (tmp_path / "10_projects").mkdir()
+        mcp = create_server(vault_path=tmp_path)
+        try:
+            result = _text(await mcp.call_tool("vault_health", {}))
+            assert "## server" in result
+            assert "- version:" in result
+        finally:
+            _close_server(mcp)
+
+    async def test_identity_backends_no_api_keys(
+        self, mock_vault: Path,
+    ) -> None:
+        """The identity block never embeds API key material."""
+        secret = "sk-DO-NOT-LEAK-CANARY-12345"
+        mcp = create_server(
+            vault_path=mock_vault,
+            openrouter_client=OpenRouterClient(
+                api_key=secret, default_model="qwen/qwen3-coder:free",
+            ),
+        )
+        try:
+            result = _text(await mcp.call_tool("vault_health", {}))
+            assert secret not in result
+            assert "## server" in result
+            # presence boolean is exposed instead
+            assert "openrouter" in result.lower()
+        finally:
+            _close_server(mcp)
+
+    async def test_identity_total_length_bounded(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        """Acceptance: identity block adds <10 lines to the report."""
+        result = _text(await vault_mcp.call_tool("vault_health", {}))
+        # Lines between '## server' (inclusive) and the next '## ' heading
+        lines = result.splitlines()
+        start = next(
+            (i for i, line in enumerate(lines) if line.startswith("## server")),
+            None,
+        )
+        assert start is not None
+        end = next(
+            (
+                i for i, line in enumerate(lines[start + 1 :], start + 1)
+                if line.startswith("## ")
+            ),
+            len(lines),
+        )
+        assert (end - start) < 10
+
+
+class TestVaultHealthRuntime:
+    """include_runtime=True activates the optional ## runtime block."""
+
+    async def test_runtime_block_omitted_by_default(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        result = _text(await vault_mcp.call_tool("vault_health", {}))
+        assert "## runtime" not in result
+        assert "uptime_s" not in result
+
+    async def test_runtime_block_present_when_opted_in(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        result = _text(
+            await vault_mcp.call_tool(
+                "vault_health", {"include_runtime": True},
+            ),
+        )
+        assert "## runtime" in result
+        assert "uptime_s" in result
+        assert "tools_registered" in result
+        assert "openrouter_budget" in result
+
+    async def test_runtime_lists_registered_tool_names(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        """tools_registered must include the known hive tools."""
+        result = _text(
+            await vault_mcp.call_tool(
+                "vault_health", {"include_runtime": True},
+            ),
+        )
+        for expected in (
+            "vault_query", "vault_search", "vault_health", "vault_list",
+        ):
+            assert expected in result
+
+    async def test_runtime_orthogonal_to_include_usage(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        """include_runtime is independent from include_usage — both can stack."""
+        result = _text(
+            await vault_mcp.call_tool(
+                "vault_health",
+                {"include_runtime": True, "include_usage": True},
+            ),
+        )
+        assert "## runtime" in result
+        # usage block surfaces 'No vault tool calls' or 'Total calls:'
+        assert (
+            "no vault tool calls" in result.lower()
+            or "Total calls:" in result
+        )
+
+    async def test_runtime_budget_does_not_leak_api_key(
+        self, mock_vault: Path,
+    ) -> None:
+        secret = "sk-RUNTIME-NEVER-LEAK-ABCDEF"
+        mcp = create_server(
+            vault_path=mock_vault,
+            openrouter_client=OpenRouterClient(
+                api_key=secret, default_model="qwen/qwen3-coder:free",
+            ),
+        )
+        try:
+            result = _text(
+                await mcp.call_tool(
+                    "vault_health", {"include_runtime": True},
+                ),
+            )
+            assert secret not in result
+            # budget block exposes cap+spent, not credentials
+            assert "openrouter_budget" in result
+        finally:
+            _close_server(mcp)
 
 
 # ── vault_write (update operations, with real YAML frontmatter validation) ────
@@ -3179,7 +3355,11 @@ class TestVaultValidate:
                 "vault_health",
                 {"checks": ["frontmatter", "stale", "links"]},
             ))
-        assert "error" not in result.lower() or "0 errors" in result.lower()
+        # Anchor on the `[error]` issue marker (and the "Vault clean"
+        # all-green message) rather than the bare substring — the
+        # identity block now exposes ``vault_path`` which may contain
+        # "error" inside a pytest tmp dir name (e.g. test_healthy_…0).
+        assert "[error]" not in result or "Vault clean" in result
 
     async def test_missing_frontmatter_detected(self, mock_vault: Path) -> None:
         """File with no frontmatter is flagged."""
@@ -3507,10 +3687,15 @@ class TestVaultValidate:
         Regression for #94 category 3.
         """
         doc = mock_vault / "10_projects" / "testproject" / "posix-heading.md"
+        # Explicit UTF-8 — Path.write_text defaults to platform encoding
+        # (cp1252 on Windows), which encodes em dash as 0x97; _safe_read
+        # then fails to decode as UTF-8 and the file is reported as
+        # unreadable, masking the actual POSIX-class regression check.
         doc.write_text(
             "---\nid: posix-heading\ntype: note\nstatus: active\n---\n\n"
             "### \\s is not POSIX — use [[:space:]] in bash regex\n\n"
             "And the digit class [[:digit:]] is similar.\n",
+            encoding="utf-8",
         )
         mcp = create_server(vault_path=mock_vault)
         result = _text(await mcp.call_tool(


### PR DESCRIPTION
## Summary

- Adds an always-on `## server` identity block (version, python, vault_path, backend presence booleans, started_at) at the top of every `vault_health()` response so MCP hosts and operators can answer *"which hive-vault version is serving this session?"* without leaving the conversation.
- Adds an opt-in `include_runtime=True` flag that layers a `## runtime` block (uptime, registered tool names, OpenRouter budget snapshot) for live debugging. Orthogonal to `include_usage`; both can stack.
- Backends are reported as presence booleans only — **API keys are never embedded**. Regression test asserts this for both blocks with a canary key (`sk-DO-NOT-LEAK-CANARY-12345`).
- `started_at` captured once at `create_server()` time using UTC ISO (human readable) + `time.monotonic()` (uptime survives NTP / DST adjustment).
- Identity is injected into `health_report_text()` so the `hive://health` MCP resource and the `vault_health()` tool agree.

## Acceptance criteria (issue #109)

- [x] `vault_health()` (no args) returns the identity block at the top — total length increase 6 lines, under the <10-line bound
- [x] `vault_health(include_runtime=True)` adds the runtime block, independent of `include_usage`
- [x] `runtime.backends` never includes API keys, only presence booleans (regression test)
- [x] `started_at` is captured once at `create_server()` time, not per-call
- [x] 11 regression tests added (vs ≥3 in spec): `TestVaultHealthIdentity` (6) + `TestVaultHealthRuntime` (5)

## Collateral fixes

Four pre-existing tests substring-checked the full `vault_health` output (`"stale" not in result`, `"error" not in result`, `"ghost_responses" not in result`). The identity block legitimately embeds `vault_path`, which collides with pytest tmp paths like `test_terminal_status_not_stale0`. Anchored on structural markers (`## ghost_responses`, `[error]`, `Stale files`, `Vault clean`) instead.

`test_posix_class_in_heading_not_flagged` was pre-existing red on Windows: `Path.write_text` without an `encoding` argument falls back to cp1252; `_safe_read` expects UTF-8; the em dash silently corrupted the test fixture. Added explicit `encoding="utf-8"`.

## Test plan

- [x] `uv run pytest -q` — **508 passed, 3 skipped, 0 failed** (~5m47s)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — 0 issues in 18 files
- [x] Starlight site build (`npm run build` in `site/`) — 27 pages built, EN + ES versions of `tools/vault.md` + `guides/troubleshooting.md` updated
- [x] Live smoke: `vault_health(include_runtime=True)` returns the expected shape (identity + runtime block, real version `1.14.1`, no leaked credentials)

## Docs updated

- `README.md` — tools table row reflects identity + runtime surface
- `site/src/content/docs/tools/vault.md` (EN) + `site/src/content/docs/es/tools/vault.md` (ES) — full block example + opt-in semantics
- `site/src/content/docs/guides/troubleshooting.md` (EN) + `site/src/content/docs/es/guides/troubleshooting.md` (ES) — "Getting Help" step 1 now mentions the identity block as the canonical version-report surface

## Related issues opened during this work

- **#110** — Design-weakness audit of vault tool latency tail (zombie subprocesses, lock contention, non-preemptive `tool_timeout`). Discovered while syncing the vault for this PR; not closed by this change.
- **#111** — Split from #110 mitigation #6: `tool_span` does not preempt sync work (live evidence: a `capture_lesson` ran 838 seconds against a configured 60s `tool_timeout`).

## Cross-references

- Closes #109
- Refs #110, #111 (follow-ups, not closed here)
- Builds on the `vault_health` surface area established by #104 (HIVE-104 `external_committer` + `ghost_responses` blocks)
