### PR TITLE
feat(hive): HIVE-115 Phase A defensive — WAL drain + telemetry + tunable lock + docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "fastmcp>=2.0.0",
     "filelock>=3.13",
     "httpx>=0.27.0",
+    "psutil>=5.9.0",
     "pydantic-settings>=2.0",
     "pyyaml>=6.0",
 ]
@@ -32,6 +33,7 @@ dev = [
     "ruff>=0.8.0",
     "mypy>=1.13",
     "types-PyYAML>=6.0",
+    "types-psutil>=5.9.0",
 ]
 
 [project.scripts]

--- a/site/src/content/docs/configuration.md
+++ b/site/src/content/docs/configuration.md
@@ -53,6 +53,8 @@ When a tool call is cancelled mid-flight (slow worker, client timeout), the serv
 | `HIVE_STALE_THRESHOLD_DAYS` | `180` | Days before a vault file is flagged as stale |
 | `HIVE_HTTP_TIMEOUT` | `60.0` | HTTP timeout (seconds) for Ollama and OpenRouter |
 | `HIVE_TOOL_TIMEOUT` | `60.0` | Tool-level timeout (seconds) for async worker tools (capture_lesson, delegate_task, worker_status) |
+| `HIVE_LOCK_TIMEOUT_S` | `30` | Git filelock acquire timeout (seconds). Raise to 60-90 on large vaults or under heavy obsidian-git contention. Validated 1..600. |
+| `HIVE_WAL_CHECKPOINT_INTERVAL_S` | `30.0` | Interval between `PRAGMA wal_checkpoint(PASSIVE)` ticks per hive process. Lower = more aggressive WAL drain. Validated >0..3600. |
 | `HIVE_RELEVANCE_ALPHA` | `0.3` | EMA learning rate for adaptive context scoring |
 | `HIVE_RELEVANCE_DECAY` | `0.9` | Session decay factor for relevance scores |
 | `HIVE_RELEVANCE_EPSILON` | `0.15` | Exploration ratio for session_briefing (epsilon-greedy) |

--- a/site/src/content/docs/es/configuration.md
+++ b/site/src/content/docs/es/configuration.md
@@ -53,6 +53,8 @@ Cuando una llamada a una herramienta se cancela a mitad de ejecución (worker le
 | `HIVE_STALE_THRESHOLD_DAYS` | `180` | Días antes de que un archivo se marque como obsoleto |
 | `HIVE_HTTP_TIMEOUT` | `60.0` | Timeout HTTP (segundos) para Ollama y OpenRouter |
 | `HIVE_TOOL_TIMEOUT` | `60.0` | Timeout a nivel de herramienta (segundos) para tools async de worker (capture_lesson, delegate_task, worker_status) |
+| `HIVE_LOCK_TIMEOUT_S` | `30` | Timeout de adquisición del filelock de git (segundos). Sube a 60-90 en vaults grandes o bajo fuerte contención con obsidian-git. Validado 1..600. |
+| `HIVE_WAL_CHECKPOINT_INTERVAL_S` | `30.0` | Intervalo entre ticks de `PRAGMA wal_checkpoint(PASSIVE)` por proceso hive. Menor = drenaje del WAL más agresivo. Validado >0..3600. |
 | `HIVE_RELEVANCE_ALPHA` | `0.3` | Tasa de aprendizaje EMA para puntuación adaptativa |
 | `HIVE_RELEVANCE_DECAY` | `0.9` | Factor de decaimiento por sesión para puntuaciones de relevancia |
 | `HIVE_RELEVANCE_EPSILON` | `0.15` | Ratio de exploración para session_briefing (epsilon-greedy) |

--- a/site/src/content/docs/es/guides/troubleshooting.md
+++ b/site/src/content/docs/es/guides/troubleshooting.md
@@ -249,11 +249,102 @@ El contador se reinicia cuando el servidor reinicia. Cada evento también se log
 
 Disponible desde `hive-vault >= 1.14.0`. El clasificador empírico de comportamiento del wire corrió 20 iteraciones en Linux y confirmó el escenario (a) — gana el ErrorData — en 20/20 casos; ver ADR-007 Amendment #2 para la retractación completa del plan "raw send" anterior.
 
-## Obtener Ayuda
+## Contención multi-sesión (3-5 sesiones de Claude Code en paralelo)
+
+**Baseline:** Hive se usa habitualmente con 3-5 sesiones de Claude Code abiertas en paralelo contra el mismo vault. Este es el uso diario base, no un caso extremo. El modelo MCP stdio lanza un subproceso `hive-vault` por sesión, así que 4 ventanas = 4 procesos hermanos compartiendo las mismas DBs SQLite (`~/.local/share/hive/*.db`) y el mismo repo git del vault.
+
+Si esos procesos se acumulan, o si además usas [obsidian-git](https://github.com/Vinzent03/obsidian-git) para auto-backups, pueden aparecer tres síntomas:
+
+- **Bloat del fichero WAL.** `~/.local/share/hive/relevance.db-wal` crece 10-100× el tamaño de la DB en reposo porque los lectores concurrentes impiden que SQLite haga checkpoint del WAL.
+- **Congelaciones silenciosas durante escrituras.** Un `vault_write` o `capture_lesson` tarda 10-30 segundos cuando obsidian-git está auto-comprometiendo en segundo plano (su intervalo de 10 minutos retiene `.git/index.lock` durante pull + commit + push).
+- **Procesos hive zombi.** Una ventana de Claude Code crasheó o se forzó a cerrar, pero su hijo `uvx hive-vault` siguió vivo manteniendo file handles abiertos.
+
+### Inspeccionar el estado actual
+
+Ejecuta `vault_health(include_runtime=True)` desde cualquier sesión. El bloque `## runtime` reporta:
+
+```yaml
+- wal_size_bytes: 4137984          # >5 MB sostenido = contención
+- competing_pid_count: 3            # otros PIDs hive-vault (mismo usuario)
+- last_git_lock_wait_ms:
+  - mean: 12.5
+  - p99: 8234.0                     # p99 > 5000ms = contención
+  - samples: 47
+- obsidian_git_present: true        # committer externo detectado
+```
+
+Sano: `wal_size_bytes` bajo unos pocos MB, `last_git_lock_wait_ms.p99` por debajo de 100ms.
+
+### Detectar un proceso hive zombi
+
+**POSIX (Linux, macOS)** — listar todos los procesos hive y su antigüedad:
+
+```bash
+ps -eo pid,etime,cmd | grep hive-vault | grep -v grep
+```
+
+Inspeccionar qué file handles mantiene un PID específico:
+
+```bash
+lsof -p <PID> | grep hive
+```
+
+Matar un zombi:
+
+```bash
+kill <PID>          # grácil
+kill -9 <PID>       # forzado
+```
+
+**Windows (PowerShell)** — listar procesos hive:
+
+```powershell
+Get-Process | Where-Object { $_.ProcessName -match "hive-vault|python" } |
+  Select-Object Id, StartTime, ProcessName, Path
+```
+
+Matar por PID:
+
+```powershell
+Stop-Process -Id <PID>           # grácil
+Stop-Process -Id <PID> -Force    # forzado
+```
+
+### Ajustar `HIVE_LOCK_TIMEOUT_S`
+
+Valor por defecto `30` segundos. Es el timeout de adquisición del lock usado cuando hive compite por el filelock de git. Limitado a 600 para evitar pies de plomo.
+
+| Escenario | Recomendado | Por qué |
+|---|---|---|
+| Por defecto | `30` | Coincide con el timeout de subprocess; absorbe ticks típicos de obsidian-git |
+| Vault grande + disco lento | `60-90` | El pull + commit + push de obsidian-git puede retener el lock 15-30s en un vault de 50 MB |
+| Red lenta + autoPull=true | `90-120` | El pull de red domina; subir para evitar abandonos |
+| Vault rápido, preferencia fail-fast | `10` | Si prefieres ver errores antes que esperar |
+
+Configurar vía variable de entorno `HIVE_LOCK_TIMEOUT_S=60`.
+
+### Ajustar `HIVE_WAL_CHECKPOINT_INTERVAL_S`
+
+Por defecto `30.0` segundos. Frecuencia con la que cada proceso hive ejecuta `PRAGMA wal_checkpoint(PASSIVE)` para drenar su WAL de SQLite. Menor = drenaje más agresivo; mayor = menos CPU en ticks ociosos.
+
+El default es apropiado para la mayoría. Sube a `120` si observas CPU excesiva en procesos hive ociosos (p. ej. en máquinas con recursos limitados); el trade-off es drenaje del WAL más lento.
+
+### Patrón de cooperación con obsidian-git
+
+Si tu vault usa obsidian-git para auto-backups, las dos herramientas cooperan limpiamente cuando se configuran correctamente:
+
+- Configura el `autoSaveInterval` de obsidian-git a 5-10 minutos (el default está bien).
+- Para flujos con muchas escrituras, prefiere `vault_write(commit=False)` / `vault_patch(commit=False)`. Hive escribe el fichero; obsidian-git lo commitea en su siguiente tick. El coste por escritura baja de ~150ms a ~5-15ms.
+- Usa `vault_commit` solo cuando necesites un flush explícito antes del siguiente tick de obsidian-git (p. ej. antes de cerrar Obsidian).
+- Vigila `vault_health.runtime.last_git_lock_wait_ms.p99`. Si se mantiene por encima de 5000ms, sube `HIVE_LOCK_TIMEOUT_S` para absorber las ventanas más largas.
+
+Una release futura hará la cooperación automática (auto-defer cuando el committer externo esté sano); por ahora es opt-in vía `commit=False`.
+
+## Obtener ayuda
 
 Si tu problema no está listado aquí:
 
-1. Ejecuta `vault_health` para comprobar conectividad del vault y recuentos de archivos — el bloque `## server` al principio reporta la versión en ejecución, python, ruta del vault y presencia de backends, así puedes incluirlo literal en un bug report (no se expone ninguna API key). Añade `include_runtime=True` para uptime, nombres de tools registrados y snapshot del presupuesto OpenRouter.
+1. Ejecuta `vault_health` para comprobar conectividad del vault y recuentos de archivos — el bloque `## server` al principio reporta la versión en ejecución, python, ruta del vault y presencia de backends, así puedes incluirlo literal en un bug report (no se expone ninguna API key). Añade `include_runtime=True` para uptime, nombres de tools registrados, métricas de contención multi-sesión y snapshot del presupuesto OpenRouter.
 2. Ejecuta `worker_status` para comprobar conectividad de proveedores y presupuesto
 3. Revisa `~/.local/share/hive/hive.log` para detalles de errores
 4. Consulta la página de [Configuración](/hive/es/configuration/) para todas las variables de entorno

--- a/site/src/content/docs/guides/troubleshooting.md
+++ b/site/src/content/docs/guides/troubleshooting.md
@@ -249,11 +249,102 @@ The counter resets when the server restarts. Each event is also logged at WARNIN
 
 Available from `hive-vault >= 1.14.0`. The empirical wire-behavior classifier ran 20 iterations on Linux and confirmed scenario (a) — ErrorData wins the race — in 20/20 cases; see ADR-007 Amendment #2 for the full retraction of the earlier "raw send" plan.
 
+## Multi-Session Contention (3-5 concurrent Claude Code sessions)
+
+**Baseline note:** Hive is commonly used with 3-5 Claude Code sessions open in parallel against the same vault. This is the daily-usage baseline, not edge case. The MCP stdio model spawns one `hive-vault` subprocess per session, so 4 windows = 4 sibling processes sharing the same SQLite DBs (`~/.local/share/hive/*.db`) and the same vault git repo.
+
+If those processes accumulate, or if you also run [obsidian-git](https://github.com/Vinzent03/obsidian-git) for auto-backups, three symptoms can appear:
+
+- **WAL file bloat.** `~/.local/share/hive/relevance.db-wal` grows 10-100× the size of the steady-state DB because concurrent readers prevent SQLite from checkpointing the WAL.
+- **Silent freezes during writes.** A `vault_write` or `capture_lesson` takes 10-30 seconds when obsidian-git is auto-committing in the background (its 10-minute interval holds `.git/index.lock` during pull + commit + push).
+- **Zombie hive processes.** A Claude Code window crashed or was force-quit, but its `uvx hive-vault` child stayed alive holding file handles open.
+
+### Inspect the current state
+
+Run `vault_health(include_runtime=True)` from any session. The `## runtime` block reports:
+
+```yaml
+- wal_size_bytes: 4137984          # >5 MB sustained = contention
+- competing_pid_count: 3            # other hive-vault PIDs (same user)
+- last_git_lock_wait_ms:
+  - mean: 12.5
+  - p99: 8234.0                     # p99 > 5000ms = contention
+  - samples: 47
+- obsidian_git_present: true        # external committer detected
+```
+
+Healthy: `wal_size_bytes` under a few MB, `last_git_lock_wait_ms.p99` under 100ms.
+
+### Spot a zombie hive process
+
+**POSIX (Linux, macOS)** — list all hive processes and their age:
+
+```bash
+ps -eo pid,etime,cmd | grep hive-vault | grep -v grep
+```
+
+Inspect which file handles a specific PID holds:
+
+```bash
+lsof -p <PID> | grep hive
+```
+
+Kill a zombie:
+
+```bash
+kill <PID>          # graceful
+kill -9 <PID>       # force
+```
+
+**Windows (PowerShell)** — list hive processes:
+
+```powershell
+Get-Process | Where-Object { $_.ProcessName -match "hive-vault|python" } |
+  Select-Object Id, StartTime, ProcessName, Path
+```
+
+Kill by PID:
+
+```powershell
+Stop-Process -Id <PID>           # graceful
+Stop-Process -Id <PID> -Force    # force
+```
+
+### Tune `HIVE_LOCK_TIMEOUT_S`
+
+Default `30` seconds. The lock-acquire timeout used when hive contends for the git filelock. Capped at 600 to prevent foot-guns.
+
+| Scenario | Recommended | Why |
+|---|---|---|
+| Default | `30` | Matches subprocess timeout; absorbs typical obsidian-git ticks |
+| Large vault + slow disk | `60-90` | obsidian-git's pull + commit + push can hold the lock 15-30s on a 50 MB vault |
+| Slow network + autoPull=true | `90-120` | Network pull dominates; raise to avoid abandons |
+| Fast vault, fail-fast preference | `10` | If you'd rather see errors than wait |
+
+Set via `HIVE_LOCK_TIMEOUT_S=60` env var.
+
+### Tune `HIVE_WAL_CHECKPOINT_INTERVAL_S`
+
+Default `30.0` seconds. How often each hive process runs `PRAGMA wal_checkpoint(PASSIVE)` to drain its SQLite WAL. Lower = more aggressive draining; higher = less CPU spent on idle ticks.
+
+Default is appropriate for most users. Raise to `120` if you observe excessive CPU on idle hive processes (e.g., on resource-constrained machines); the trade-off is slower WAL drain.
+
+### obsidian-git cooperation pattern
+
+If your vault uses obsidian-git for auto-backups, the two tools cooperate cleanly when configured properly:
+
+- Set obsidian-git's `autoSaveInterval` to 5-10 minutes (default is fine).
+- For write-heavy flows, prefer `vault_write(commit=False)` / `vault_patch(commit=False)`. Hive writes the file; obsidian-git commits on its next tick. Per-write cost drops from ~150ms to ~5-15ms.
+- Use `vault_commit` only when you need an explicit flush before obsidian-git's next tick (e.g., before closing Obsidian).
+- Watch `vault_health.runtime.last_git_lock_wait_ms.p99`. If it stays above 5000ms, raise `HIVE_LOCK_TIMEOUT_S` to absorb the longer windows.
+
+A future release will make the cooperation automatic (auto-defer when external committer healthy); for now it is opt-in via `commit=False`.
+
 ## Getting Help
 
 If your issue isn't listed here:
 
-1. Run `vault_health` to check vault connectivity and file counts — the `## server` identity block at the top reports the running version, python, vault path, and backend presence so you can include them verbatim in a bug report (no API keys are exposed). Add `include_runtime=True` for uptime, registered tool names, and the OpenRouter budget snapshot.
+1. Run `vault_health` to check vault connectivity and file counts — the `## server` identity block at the top reports the running version, python, vault path, and backend presence so you can include them verbatim in a bug report (no API keys are exposed). Add `include_runtime=True` for uptime, registered tool names, multi-session contention metrics, and the OpenRouter budget snapshot.
 2. Run `worker_status` to check provider connectivity and budget
 3. Check `~/.local/share/hive/hive.log` for error details
 4. Check the [Configuration](/hive/configuration/) page for all environment variables

--- a/specs/HIVE-115-latency-tail-redesign/proposal.md
+++ b/specs/HIVE-115-latency-tail-redesign/proposal.md
@@ -1,0 +1,79 @@
+---
+id: "HIVE-115-latency-tail-redesign"
+type: spec
+status: draft
+created: "2026-05-21"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HIVE-115: Latency Tail Redesign
+
+> File lives at `specs/HIVE-115-latency-tail-redesign/proposal.md`. Three-phase redesign per [[pattern-phased-redesign-with-telemetry-gates]]. v1.16.0 bundles Phase A + Phase B (PR-1 through PR-4); Phase C (daemon) is a planned follow-up.
+
+## Why
+
+<!-- from 10_projects/hive/11-tasks.md (HIVE-115 backlog entry, 2026-05-21):
+"Composition of locally-optimal decisions (ADR-001 process-per-client + ADR-006 best-effort commit + asyncio.timeout deadline) interacts badly under N=3-5 baseline + external committer (obsidian-git, 10-min interval, pullBeforePush=true). Empirical: 4.1MB WAL vs 53KB DB, 838s capture_lesson outlier, 2-month-stale worker.db-wal." -->
+
+Three open issues (#110, #111, #114) trace to a single root cause: hive's composition of process-per-MCP-client orchestration (ADR-001) + best-effort auto-commit (ADR-006) + asyncio.timeout-as-deadline interacts pathologically under real daily usage — **3-5 concurrent Claude Code sessions per user against the same vault, with obsidian-git auto-commits every 10 minutes**. Empirical evidence collected 2026-05-21: 4.1 MB `relevance.db-wal` vs 53 KB DB (77× ratio), `worker.db-wal` unchecked for 2 months, 838s `capture_lesson` outlier vs configured 60s deadline. Users experience silent 30-second freezes per write, invisible hangs, and `capture_lesson` calls that the host treats as user-rejected.
+
+The system is operating at the codo of ADR-005's own scale table during normal daily use. Without re-architecting the composition, the situation worsens as agent-driven workloads (anticipated N=10-15) come online.
+
+## What
+
+After this PR-bundle (v1.16.0):
+
+1. **WAL bloat is bounded and observable.** Every hive process runs a periodic `PRAGMA wal_checkpoint(PASSIVE)` thread (default 30s tick); `vault_health(include_runtime=True)` surfaces `wal_size_bytes` so growth is visible before it hurts.
+2. **External-committer contention is observable and tunable.** `last_git_lock_wait_ms` + `mcp.lock_contention` structured logs make obsidian-git coexistence visible. `HIVE_LOCK_TIMEOUT_S` env-tunable so large vaults / slow networks can absorb extended windows.
+3. **Tool deadlines are enforced as hard contracts.** `bounded_call` supervisor replaces `tool_span`'s asyncio-only mechanism: `subprocess.run → Popen` migration in 5 git callsites; on deadline expiry, supervisor terminates the registered child processes (cross-OS) and surfaces `mcp.protocol.TimeoutError` to the client (no more silent hangs, no more "Server busy" canned strings).
+4. **Vault git auto-defers to obsidian-git when healthy.** Outbox + Reconciler: when `detect_obsidian_git()` reports a healthy external committer (last commit < 2× autoSaveInterval ago), hive writes are implicit `commit=False`. Health probe + automatic fallback to hive's own reconciler when external committer is stale or absent.
+5. **`capture_lesson` defends against malformed XML inputs at the boundary.** SUSPECT_PATTERNS regex set warns and annotates corruption without rejecting the write (preserves agent's mid-turn work, surfaces the issue for cleanup).
+
+Closes issues #110 (mits #1+#2+#3+#5 + cooperation pattern), #111 (bounded_call), #114 (Tier-1 defense).
+
+## Out of scope
+
+- **Phase C (hive-vault daemon model)** — planned for v1.17.0 / v2.0 as ADR-011, after observing v1.16.0 telemetry under real load. The user's future state (agent-driven N=10-15) makes it inevitable, but its design needs Phase A+B telemetry as input.
+- **`pygit2` native bindings** to eliminate fork+exec git overhead — ADR-006 §D deferred this; remains deferred unless Phase B telemetry shows residual subprocess cost dominates.
+- **#114 Tier-2/Tier-3** (post-write self-check + vault_health lessons-integrity scan) — Tier-1 alone solves the immediate corruption surface; Tier-3 may come later if other malformed-input shapes surface.
+- **Cross-vault federation, multi-tenant hive backend** — explicitly v3+ if ever.
+- **Replacing the FastMCP stdio transport** — Phase C is when, not this.
+
+## Risks / open questions
+
+- **R1 — `psutil` cross-OS reliability.** New runtime dep. `process_iter(['open_files'])` is slow on Windows (~100ms); cache 30s. macOS requires admin for cross-user; we filter same-UID only. Antivirus / backup tools briefly opening DBs may inflate `competing_pid_count` — filter strictly by `name() == "hive-vault"`. Mitigation in `_vault_health` design; tests for each OS.
+- **R2 — `bounded_call` subprocess termination semantics on Windows.** `TerminateProcess` is NOT graceful; descendants may orphan without `CREATE_NEW_PROCESS_GROUP`. `.git/index.lock` cleanup must verify PID ownership before unlinking. Tests must cover: SIGTERM-then-grace POSIX path, TerminateProcess Windows path, partial-commit prevention, `.git/index.lock` left intact when written by obsidian-git's PID.
+- **R3 — Outbox eventual-consistency surface.** In Phase B, process A's `capture_lesson` writes to disk synchronously (markdown file) but reinforcement counter update goes through outbox + reconciler. Cross-process read sees stale rank for ~5s. Acceptable for ranking (informational) but document the contract clearly. **Resolved before tasks.md freeze:** verify no read paths assume immediate visibility of EMA/reinforcement updates.
+- **R4 — Detect-and-defer health probe correctness.** `git log -1 --since="<N> minutes ago"` returning empty does NOT necessarily mean obsidian-git is broken — it may be that no commits happened (idle vault). Need additional signal: `(time.time() - last_obsidian_commit_age) > 2 * autoSaveInterval AND vault is dirty`. **Resolved before Phase B implementation:** define the precise probe predicate.
+- **R5 — Behavior change from auto-defer.** In Phase B, when obsidian-git is present and healthy, `vault_write(commit=True)` becomes implicit `commit=False`. This is a hidden behavior change. **Resolved:** keep `commit=True` as documented default; auto-defer is OPTIONAL via `HIVE_AUTO_DEFER_TO_EXTERNAL_COMMITTER=true` (default false) for v1.16.0, then re-evaluate based on Phase A telemetry whether to flip the default in v1.17.0.
+
+## Acceptance criteria
+
+Each criterion is testable. Mapped 1:1 to `tasks.md` TDD entries.
+
+- [ ] **AC-1**: Every `_SqliteTracker` instance runs a daemon thread executing `PRAGMA wal_checkpoint(PASSIVE)` on a configurable interval (default 30s). Tests: thread starts on tracker init; thread exits on tracker close; checkpoint pragma is invoked at least once per N+1s test window.
+- [ ] **AC-2**: `_SqliteTracker.close()` executes `PRAGMA wal_checkpoint(TRUNCATE)` with a 2-second wall-clock guard. Test: close completes within 2.5s even when a sibling connection holds a snapshot (TRUNCATE degrades to PASSIVE behavior, does not block).
+- [ ] **AC-3**: `vault_health(include_runtime=True)` runtime block contains `wal_size_bytes` (sum of `~/.local/share/hive/*.db-wal`), `competing_pid_count` (psutil-based, same-UID, name-filtered, cached 30s), `last_git_lock_wait_ms` (rolling N=100 ring buffer with mean + p99), `obsidian_git_present` (boolean). Tests: presence under each scenario (0 / 1 / 3 hive procs, obsidian-git present/absent).
+- [ ] **AC-4**: `HIVE_LOCK_TIMEOUT_S` env var honored end-to-end (default 30, capped at 600). Default behavior unchanged from current. Test: set to 5, verify `_GIT_LOCK.acquire` abandons at 5s; set to 0 or >600, verify rejected with `ValueError`.
+- [ ] **AC-5**: Every `_GIT_LOCK.acquire` attempt emits exactly one structured log line `mcp.lock_contention` with fields `{tool, lock, waited_ms, abandoned, obsidian_git_present}`. Test: capture log with `caplog`, assert presence + correctness of fields for both success and timeout paths.
+- [ ] **AC-6**: `capture_lesson` invocations with SUSPECT_PATTERNS (`</context>`, `</parameter>`, `<parameter name=`, `</invoke>`) in title/context/problem/solution prepend `<!-- POSSIBLE_CORRUPTION: ... -->` to the body and surface `warning` field in the JSON response. Lesson is still written (warn-don't-reject). Test: parametrized with each pattern + negative case.
+- [ ] **AC-7**: `bounded_call(fn, deadline_s, process_registry=...)` raises `mcp.protocol.TimeoutError` within `deadline_s + 3` regardless of whether the work is in a thread, a subprocess, or chained. Test: 3 cases — async sleep > deadline, `subprocess.run(["sleep", str(deadline+10)])`, `asyncio.to_thread(blocking_sleep, deadline+10)`. All 3 return within deadline + grace.
+- [ ] **AC-8**: `bounded_call` deadline expiry terminates registered `Popen` children. Test: spawn `sleep 60`, expire 2s deadline, verify `Popen.poll()` is non-None within `2 + grace_s` of expiry; no zombie subprocess after `wait_for_zombies` helper.
+- [ ] **AC-9**: `_cleanup_index_lock` removes `.git/index.lock` ONLY when PID matches our Popen.pid. Test: simulate lock file with our PID (cleaned), with another PID (untouched).
+- [ ] **AC-10**: `subprocess.run → Popen` migration in 5 git callsites does not regress existing test suite. Test: full `make check` passes; HIVE-104 coalescer tests still pass; ghost-response test (`test_classify_cancellation_race`) still passes.
+- [ ] **AC-11** (Phase B / PR-4): in-process outbox for `RelevanceTracker` + `LessonReinforcementTracker`. Writes buffered; reconciler thread flushes every 5s with PASSIVE checkpoint. Read paths check outbox FIRST. Test: write-then-read same-process is immediate; cross-process read sees the write within `2 * tick_interval`.
+- [ ] **AC-12** (Phase B / PR-4): detect-and-defer behavior. When `HIVE_AUTO_DEFER_TO_EXTERNAL_COMMITTER=true` AND `detect_obsidian_git()` reports healthy (last commit < `2 * autoSaveInterval` min ago in `git log`), `vault_write(commit=True)` is silently treated as `commit=False` and surfaces `{committed: false, deferred_to: "obsidian-git"}` in response. Test: cover both healthy and stale scenarios.
+- [ ] **AC-13** (cross-cutting): documentation site (EN + ES) has a new "Troubleshooting > Multi-session contention" page with zombie-detection recipes (`ps`/`lsof`/`Get-Process`/`tasklist`), `HIVE_LOCK_TIMEOUT_S` recommended ranges, and a sub-section on the obsidian-git cooperation pattern. Bilingual sync verified.
+- [ ] **AC-14**: All 4 ADRs (008, 009 v1, 010) and 2 amendments (005, 006) committed to vault. Pattern `pattern-multi-process-mcp-server` extended with primitives 5-7. 5 lessons captured in `hive/90-lessons.md` + 1 meta-pattern in `_meta/patterns/`. Reference: 2026-05-21 vault commits `4d9c642` (lessons + meta-pattern) and `02d1f63` (ADRs).
+
+## References
+
+- Vault backlog: `10_projects/hive/11-tasks.md` (HIVE-115 entry, 2026-05-21)
+- ADRs (vault): [[adr-008-hard-deadline-enforcement]], [[adr-009-multi-process-wal-policy]], [[adr-010-external-committer-coexistence]]
+- ADR amendments (vault): [[adr-005-transport-and-scale]] (HIVE-115 telemetry gate triggered), [[adr-006-commit-policy]] (§C gate triggered)
+- Patterns (vault): [[pattern-multi-process-mcp-server]] (extended with primitives 5-7), [[pattern-phased-redesign-with-telemetry-gates]] (meta-pattern, this redesign is its origin)
+- Lessons (vault): [[lesson-three-timeouts-chain-not-deadline]], [[lesson-sqlite-wal-no-checkpoint-with-readers]], [[lesson-cooperative-external-committer]], [[lesson-telemetry-is-the-design]]
+- TDD discipline: [[pattern-testing-standards]] — red-green-refactor, pytest+coverage, fixtures with tmp_path, parametrize for cross-OS
+- Issues: [#110](https://github.com/mlorentedev/hive/issues/110), [#111](https://github.com/mlorentedev/hive/issues/111), [#114](https://github.com/mlorentedev/hive/issues/114)
+- Prior HIVE-104 spec (archived): `specs/archive/HIVE-104-write-throughput/` — established `commit=False` + `vault_commit` + obsidian-git detection foundations

--- a/specs/HIVE-115-latency-tail-redesign/tasks.md
+++ b/specs/HIVE-115-latency-tail-redesign/tasks.md
@@ -1,0 +1,174 @@
+---
+tags: [spec, tasks, HIVE-115]
+created: "2026-05-21"
+---
+
+# Tasks — HIVE-115-latency-tail-redesign
+
+> TDD order per [[pattern-testing-standards]] — red, green, refactor. One task = one focused commit. Reorder freely while spec is `draft`; freeze on transition to `implementing`.
+>
+> Bundle: v1.16.0 = PR-1 (Phase A defensive) + PR-2 (#114 XML defense) + PR-3 (bounded_call) + PR-4 (Outbox+detect-and-defer). PR-4 may slip to v1.17.0 if review reveals issues.
+
+## Setup
+
+- [ ] Branch `feat/HIVE-115-latency-tail` cut from `master`
+- [ ] `proposal.md` complete; R3 + R4 + R5 (open questions) resolved before any code
+- [ ] `make check` passes on master baseline (508 passed, 3 skipped per v1.15.0)
+- [ ] `psutil` added to `pyproject.toml` runtime deps (planned for PR-1)
+
+---
+
+## PR-1 — Phase A defensive (target ~170 LOC)
+
+> Closes #110 mits #1+#2+#3+#5 (operational, observability, tunable, periodic WAL drain).
+
+### Red — failing tests first
+
+- [ ] T1.1: write failing test `tests/test_sqlite_checkpoint.py::test_passive_checkpoint_runs_on_interval` — create `RelevanceTracker`, write 1000 events, sleep 35s, assert `cursor.execute("PRAGMA wal_checkpoint")` reports advancement
+- [ ] T1.2: write failing test `tests/test_sqlite_checkpoint.py::test_checkpoint_thread_dies_with_parent` — assert thread is `daemon=True`
+- [ ] T1.3: write failing test `tests/test_sqlite_checkpoint.py::test_close_truncates_with_2s_guard` — open tracker with sibling connection holding read snapshot; close should complete within 2.5s
+- [ ] T1.4: write failing tests `tests/test_vault_health.py::TestRuntimeWalMetrics` — parametrized: `wal_size_bytes` reflects actual file size; `competing_pid_count` returns 0 baseline, increments under sibling subprocess
+- [ ] T1.5: write failing test `tests/test_vault_health.py::test_last_git_lock_wait_ms_rolling_window` — emit 150 acquire events, assert ring buffer keeps last 100 and exposes mean + p99
+- [ ] T1.6: write failing test `tests/test_vault_health.py::test_obsidian_git_present_surfaces` — fixture creates `.obsidian/plugins/obsidian-git/data.json`; assert `vault_health.runtime` reflects it
+- [ ] T1.7: write failing test `tests/test_settings.py::test_hive_lock_timeout_s_env` — `HIVE_LOCK_TIMEOUT_S=5` honored; `=0` and `=601` rejected with `ValueError`
+- [ ] T1.8: write failing test `tests/test_helpers.py::test_git_lock_emits_structured_log` — caplog captures `mcp.lock_contention` event with required fields on both timeout-pass and timeout-fail paths
+
+### Green — implement
+
+- [ ] T1.9: `src/hive/_sqlite_tracker.py` — add `_checkpoint_loop` daemon thread + `_stop_checkpoint` Event; wire from `__init__` and `close`. Use `with self._lock` around `cursor.execute("PRAGMA wal_checkpoint(PASSIVE)")`. Honor `HIVE_WAL_CHECKPOINT_INTERVAL_S` env (default 30)
+- [ ] T1.10: `src/hive/_vault_health.py::_runtime_block` — extend with `wal_size_bytes` (`Path(state_dir).glob('*.db-wal')` size sum), `competing_pid_count` (new helper `_count_competing_hive_processes` using `psutil.process_iter`, cached 30s via functools.lru_cache + time-based eviction), `last_git_lock_wait_ms` (rolling window in `_helpers._GIT_LOCK_STATS` global), `obsidian_git_present` (reuse `detect_obsidian_git()` from HIVE-104)
+- [ ] T1.11: `pyproject.toml` — add `psutil>=5.9.0` to `dependencies` (runtime). `uv lock` regenerated
+- [ ] T1.12: `src/hive/config.py` — add `HiveSettings.lock_timeout_s` (env `HIVE_LOCK_TIMEOUT_S`, default 30, validator 1≤x≤600); `HiveSettings.wal_checkpoint_interval_s` (default 30)
+- [ ] T1.13: `src/hive/_helpers.py:551` — replace hardcoded `_LOCK_TIMEOUT = 30` with `ctx.lock_timeout_s`; refactor `_GIT_LOCK.acquire(timeout=...)` callsites; instrument with `time.monotonic()` brackets emitting `mcp.lock_contention` structured log
+
+### Refactor
+
+- [ ] T1.14: extract `_compute_wal_size_bytes(state_dir: Path) -> int` and `_count_competing_hive_processes(self_pid: int) -> int` as pure helpers in `_helpers.py` for testability
+- [ ] T1.15: deduplicate ring-buffer logic between `_GIT_LOCK_STATS` and any future tracker stats (if applicable)
+
+### Docs
+
+- [ ] T1.16: `site/src/content/docs/guides/troubleshooting.md` — add "Multi-session contention" section: zombie kill recipes for POSIX (`ps`, `lsof`) and Windows (`Get-Process`, `tasklist`); `HIVE_LOCK_TIMEOUT_S` recommended ranges; obsidian-git cooperation pattern
+- [ ] T1.17: `site/src/content/docs/es/guides/troubleshooting.md` — mirror EN (bilingual sync mandatory per CLAUDE.md)
+- [ ] T1.18: `site/src/content/docs/configuration.md` + `es/configuration.md` — document new env vars `HIVE_LOCK_TIMEOUT_S` + `HIVE_WAL_CHECKPOINT_INTERVAL_S`
+
+### Closing PR-1
+
+- [ ] AC-1..AC-5 + AC-13 verified
+- [ ] `make check` green
+- [ ] Conventional commit `feat(hive): HIVE-115 Phase A defensive — WAL periodic + telemetry + tunable lock`
+- [ ] PR opened against master referencing #110
+
+---
+
+## PR-2 — #114 Tier-1 capture_lesson XML defense (target ~30 LOC)
+
+> Closes #114. Independent of PR-1/3/4; can ship in any order. Sonnet or haiku.
+
+### Red
+
+- [ ] T2.1: failing test `tests/test_workers.py::TestCaptureLessonXmlDefense` — parametrized over `SUSPECT_PATTERNS`; assert response includes `warning` field; assert body contains `<!-- POSSIBLE_CORRUPTION ... -->` comment
+- [ ] T2.2: negative test — normal lesson body without patterns has no warning, no HTML comment
+
+### Green
+
+- [ ] T2.3: `src/hive/_workers.py::capture_lesson` — add `SUSPECT_PATTERNS = [r"</context>", r"</parameter>", r"<parameter name=", r"</invoke>"]` (compiled regex)
+- [ ] T2.4: scan `title`, `context`, `problem`, `solution` strings; if any match, prepend `<!-- POSSIBLE_CORRUPTION: detected XML-tag leak in input; review and clean manually -->` to the final body; return `warning` field
+
+### Closing PR-2
+
+- [ ] AC-6 verified
+- [ ] Conventional commit `feat(hive): HIVE-115 capture_lesson XML-leak defense (#114 Tier-1)`
+- [ ] PR opened against master referencing #114
+
+---
+
+## PR-3 — `bounded_call` hard deadline (target ~250 LOC)
+
+> Closes #111. Opus-tier. Bundled with PR-1/2 for v1.16.0.
+
+### Red
+
+- [ ] T3.1: failing test `tests/test_bounded_call.py::test_async_sleep_terminated` — `bounded_call(asyncio.sleep, 10, deadline_s=2)` returns `TimeoutError` within `2 + grace_s`
+- [ ] T3.2: failing test `tests/test_bounded_call.py::test_blocking_thread_sleep_terminated` — `bounded_call(asyncio.to_thread(time.sleep, 10), deadline_s=2)` returns within `2 + grace_s`
+- [ ] T3.3: failing test `tests/test_bounded_call.py::test_subprocess_terminated` — spawn `subprocess.Popen(["sleep", "60"])`, register, expire 2s deadline, assert `proc.poll()` is non-None within 4s; assert `proc.returncode` non-zero
+- [ ] T3.4: failing test `tests/test_bounded_call.py::test_index_lock_pid_ownership` — write `.git/index.lock` with PID 99999 (not ours), expire deadline, assert lock untouched. Then write with our PID, assert cleaned up
+- [ ] T3.5: failing test `tests/test_bounded_call.py::test_partial_commit_prevention` — start `git commit` Popen, kill mid-flight, assert HEAD unchanged (no half commit)
+- [ ] T3.6: regression test `tests/test_compat_shim.py::test_classify_cancellation_race` still passes (ghost-response test untouched)
+- [ ] T3.7 (Windows): conditional test marked `@pytest.mark.skipif(not IS_WINDOWS)` — spawn cmd /c sleep 60, verify `TerminateProcess` + `CREATE_NEW_PROCESS_GROUP` correctly reaches descendants
+
+### Green
+
+- [ ] T3.8: new `src/hive/_deadline.py` module — `bounded_call(fn, *args, deadline_s, process_registry=None, **kwargs)`. Async-only signature; inner work either awaits or uses `asyncio.to_thread`. On deadline expiry: iterate `process_registry`, `terminate()`, sleep 2s, `kill()` any survivors, drain stdio best-effort, raise `mcp.protocol.TimeoutError` with structured payload
+- [ ] T3.9: `src/hive/_helpers.py` — refactor `_git_commit(paths, message)` from `subprocess.run` to `subprocess.Popen` + `proc.communicate(timeout=30)`. Add `process_registry` parameter; register the Popen. Replace remaining `subprocess.run` calls (`_git_commit_all`, `_git_log_recent`, `_current_head_sha`, status callers) with same pattern
+- [ ] T3.10: cross-OS termination — `creationflags=subprocess.CREATE_NEW_PROCESS_GROUP` when `sys.platform == "win32"`; otherwise no flag (POSIX uses signal-based termination)
+- [ ] T3.11: `_cleanup_index_lock(vault: Path, our_pid: int)` helper — read PID from lock file, compare, unlink ONLY if match. Wrap in try/except OSError
+- [ ] T3.12: replace `tool_span` (`src/hive/_helpers.py`) with wrapper that delegates to `bounded_call`. Existing `HIVE_TOOL_TIMEOUT` env honored unchanged
+
+### Refactor
+
+- [ ] T3.13: extract subprocess context manager from each git callsite into shared helper `_run_git(args, vault, registry, timeout) -> tuple[returncode, stdout, stderr]`
+- [ ] T3.14: assert all 5 git callsites use the new helper (audit via grep `subprocess.run` should return 0 hits in hive source after refactor; non-git subprocess uses stay)
+
+### Closing PR-3
+
+- [ ] AC-7 + AC-8 + AC-9 + AC-10 verified
+- [ ] `make check` green; `pytest tests/test_compat_shim.py` regression untouched
+- [ ] Conventional commit `feat(hive): HIVE-115 bounded_call hard deadline (#111, ADR-008)`
+- [ ] PR opened against master referencing #111
+
+---
+
+## PR-4 — Outbox + Reconciler + detect-and-defer (target ~300 LOC)
+
+> Closes #110 fully; Phase B semantic change. Opus-tier. Pre-flight: PR-3 must merge first (reconciler thread relies on bounded_call for preemption authority). May slip to v1.17.0 if review reveals issues.
+
+### Red
+
+- [ ] T4.1: failing test `tests/test_outbox.py::test_same_process_read_after_write` — `RelevanceTracker.record('x')` then `RelevanceTracker.score('x')` returns the recorded value immediately (outbox-first read path)
+- [ ] T4.2: failing test `tests/test_outbox.py::test_cross_process_eventual_consistency` — process A writes; process B reads within `tick_interval` does NOT see it; process B reads after `2 * tick_interval` does see it
+- [ ] T4.3: failing test `tests/test_outbox.py::test_reconciler_thread_bounded_by_supervisor` — reconciler's `BEGIN IMMEDIATE` blocks > deadline; `bounded_call` terminates it; outbox preserved for next tick
+- [ ] T4.4: failing test `tests/test_detect_and_defer.py::test_auto_defer_when_obsidian_healthy` — `HIVE_AUTO_DEFER_TO_EXTERNAL_COMMITTER=true` + `detect_obsidian_git` healthy → `vault_write(commit=True)` returns `{committed: false, deferred_to: "obsidian-git"}`
+- [ ] T4.5: failing test `tests/test_detect_and_defer.py::test_fallback_when_obsidian_stale` — obsidian-git config present BUT `git log -1 --since="<2*interval>"` returns empty → fallback to hive commit
+- [ ] T4.6: failing test `tests/test_detect_and_defer.py::test_no_external_committer_uses_internal_reconciler` — no obsidian-git → hive's reconciler does its own commit with backoff retry on lock contention
+
+### Green
+
+- [ ] T4.7: new `src/hive/_outbox.py` — `Outbox` class with thread-safe append + drain. Subclassable per resource (SQLite outbox, vault outbox).
+- [ ] T4.8: `RelevanceTracker` + `LessonReinforcementTracker` — replace direct INSERT/UPSERT with outbox append; reconciler thread drains every 5s (configurable via `HIVE_OUTBOX_TICK_S`)
+- [ ] T4.9: reconciler thread does `BEGIN IMMEDIATE` + UPSERT bulk + `PRAGMA wal_checkpoint(PASSIVE)` per tick; wrapped in `bounded_call` (from PR-3) so a hung reconciler cannot stall shutdown
+- [ ] T4.10: `src/hive/_vault_write.py` — `vault_write`/`vault_patch` consult `_should_defer_to_external_committer(ctx)` before invoking `_git_commit`. Helper checks `HIVE_AUTO_DEFER_TO_EXTERNAL_COMMITTER` env + `detect_obsidian_git()` + recency probe (`git log -1 --since=...`)
+- [ ] T4.11: when deferred, response includes `{committed: false, deferred_to: "obsidian-git"}`; when fallback fires, response includes `{committed: true, fallback_from: "obsidian-git-stale"}` so tests can assert behavior
+- [ ] T4.12: backoff retry helper `_acquire_git_lock_with_backoff(ctx, backoffs=(3, 6, 12))` for the case where no external committer is present and hive's reconciler hits contention. After exhausting backoffs, abandon with structured log
+
+### Refactor
+
+- [ ] T4.13: deduplicate outbox-read pattern across trackers (`get` always checks outbox first, then DB)
+- [ ] T4.14: extract `_is_external_committer_healthy(vault, autoSaveInterval) -> bool` for testability
+
+### Docs
+
+- [ ] T4.15: site docs (EN + ES) update — "obsidian-git integration" page describing auto-defer behavior, env var `HIVE_AUTO_DEFER_TO_EXTERNAL_COMMITTER`, fallback semantics
+- [ ] T4.16: README — link to new troubleshooting + obsidian-git pages
+
+### Closing PR-4
+
+- [ ] AC-11 + AC-12 verified
+- [ ] `make check` green; full suite including outbox + detect-and-defer tests
+- [ ] Conventional commit `feat(hive): HIVE-115 Outbox + Reconciler + detect-and-defer (ADR-009 v2, ADR-010)`
+- [ ] PR opened against master, referencing #110 (closes when merged)
+
+---
+
+## Release & verification
+
+- [ ] After PR-1..PR-4 merged: release-please auto-bumps to v1.16.0
+- [ ] After v1.16.0 ships: schedule cron firing 14 days later for Phase C decision (per task #13 in session task list)
+- [ ] Fill `verification.md` with concrete evidence (commit hashes, test names, observed behavior); flag promotion candidates (mostly "no" since ADRs/lessons/pattern already promoted)
+- [ ] `/spec archive HIVE-115-latency-tail-redesign --pr <pr-urls>` ticks backlog entry
+
+---
+
+## Machine-readable features
+
+Will emit `specs/HIVE-115-latency-tail-redesign/features.json` mapping ACs 1-14 to verification commands per [[pattern-feature-list-as-primitive]]. Drafted alongside PR-1 implementation (T1.16/T1.17 area).

--- a/specs/HIVE-115-latency-tail-redesign/verification.md
+++ b/specs/HIVE-115-latency-tail-redesign/verification.md
@@ -1,0 +1,68 @@
+---
+tags: [spec, verification, HIVE-115]
+created: "2026-05-21"
+---
+
+# Verification — HIVE-115-latency-tail-redesign
+
+> Filled progressively as PR-1..PR-4 merge. Routine implementation choices belong in commit messages, not here.
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior). To be filled per-PR.
+
+- [ ] AC-1 (PASSIVE checkpoint thread) → commit `<hash>` / test `tests/test_sqlite_checkpoint.py::test_passive_checkpoint_runs_on_interval`
+- [ ] AC-2 (TRUNCATE on close with 2s guard) → commit `<hash>` / test `tests/test_sqlite_checkpoint.py::test_close_truncates_with_2s_guard`
+- [ ] AC-3 (vault_health runtime metrics) → commit `<hash>` / test `tests/test_vault_health.py::TestRuntimeWalMetrics` + `test_obsidian_git_present_surfaces`
+- [ ] AC-4 (HIVE_LOCK_TIMEOUT_S env) → commit `<hash>` / test `tests/test_settings.py::test_hive_lock_timeout_s_env`
+- [ ] AC-5 (mcp.lock_contention structured log) → commit `<hash>` / test `tests/test_helpers.py::test_git_lock_emits_structured_log`
+- [ ] AC-6 (capture_lesson XML defense) → commit `<hash>` / test `tests/test_workers.py::TestCaptureLessonXmlDefense`
+- [ ] AC-7 (bounded_call enforces deadline across async/thread/subprocess) → commit `<hash>` / tests `tests/test_bounded_call.py::test_async_sleep_terminated` + `test_blocking_thread_sleep_terminated` + `test_subprocess_terminated`
+- [ ] AC-8 (bounded_call terminates registered Popen) → commit `<hash>` / test `tests/test_bounded_call.py::test_subprocess_terminated`
+- [ ] AC-9 (.git/index.lock PID-ownership cleanup) → commit `<hash>` / test `tests/test_bounded_call.py::test_index_lock_pid_ownership`
+- [ ] AC-10 (no regression in existing test suite) → `make check` green; ghost-response test passes; HIVE-104 coalescer tests pass
+- [ ] AC-11 (outbox + reconciler for SQLite trackers) → commit `<hash>` / tests `tests/test_outbox.py::*`
+- [ ] AC-12 (detect-and-defer to obsidian-git) → commit `<hash>` / tests `tests/test_detect_and_defer.py::*`
+- [ ] AC-13 (bilingual troubleshooting docs) → commits `<hashes>` / files `site/.../guides/troubleshooting.md` (EN + ES)
+- [ ] AC-14 (ADRs + lessons + pattern persisted in vault) → vault commits `4d9c642` (lessons + meta-pattern, 2026-05-21) and `02d1f63` (ADRs + amendments + pattern extension, 2026-05-21); plus repo commit `<hash>` (specs/HIVE-115-latency-tail-redesign/* — this spec scaffold)
+
+## Test status
+
+Per-PR fill-in:
+
+- PR-1: `make check` → `<output>` / coverage `<pct>%`
+- PR-2: `make check` → `<output>`
+- PR-3: `make check` → `<output>` / regression `tests/test_compat_shim.py` → `<output>`
+- PR-4: `make check` → `<output>` / cross-process eventual-consistency test `<output>`
+
+Manual smoke test:
+
+- (PR-1) Open 3 Claude Code sessions concurrently; observe `vault_health(include_runtime=True)` reports `competing_pid_count: 3`, `wal_size_bytes` stays bounded after periodic checkpoint runs; verify `mcp.lock_contention` logs accumulate in per-PID log files
+- (PR-3) Trigger an artificial git lock contention (hold `.git/index.lock` manually with `sleep 120 > .git/index.lock` style); fire `vault_write`; verify bounded_call surfaces `mcp.protocol.TimeoutError` within `HIVE_TOOL_TIMEOUT + 3s`; verify no zombie subprocess
+- (PR-4) With `HIVE_AUTO_DEFER_TO_EXTERNAL_COMMITTER=true` and obsidian-git active, fire 5 `vault_write` calls; verify responses say `{deferred_to: "obsidian-git"}`; verify obsidian-git's next tick produces a single commit with all 5 files
+
+## Decisions made during implementation
+
+Non-obvious trade-offs and course corrections taken during the work. Filled per-PR.
+
+- (PR-1): _filled at PR-1 completion_
+- (PR-2): _filled at PR-2 completion_
+- (PR-3): _filled at PR-3 completion_
+- (PR-4): _filled at PR-4 completion_
+
+## Promotion candidates
+
+ADRs and lessons were already promoted to the vault BEFORE implementation (the rationale is the spec's foundation). Cross-reference, don't re-promote.
+
+- [x] Lessons for `hive/90-lessons.md`? **YES — pre-promoted 2026-05-21.** Four lessons captured: [[lesson-three-timeouts-chain-not-deadline]], [[lesson-sqlite-wal-no-checkpoint-with-readers]], [[lesson-cooperative-external-committer]], [[lesson-telemetry-is-the-design]] (vault commit `4d9c642`).
+- [x] ADR-worthy decisions for `hive/30-architecture/adr-XXX.md`? **YES — pre-promoted 2026-05-21.** Three new: [[adr-008-hard-deadline-enforcement]], [[adr-009-multi-process-wal-policy]], [[adr-010-external-committer-coexistence]]. Two amended: [[adr-005-transport-and-scale]], [[adr-006-commit-policy]] (vault commit `02d1f63`).
+- [x] New pattern candidate for `00_meta/patterns/`? **YES — pre-promoted 2026-05-21.** [[pattern-phased-redesign-with-telemetry-gates]] created; [[pattern-multi-process-mcp-server]] extended with primitives 5-7 (vault commits `4d9c642` + `02d1f63`).
+- [ ] Implementation-time lesson (only fill if something unexpected emerges during coding): `<yes / no — one line>`
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HIVE-115-latency-tail-redesign/` → `specs/archive/HIVE-115-latency-tail-redesign/`
+- [ ] Backlog entry in vault `hive/11-tasks.md` ticked with PR links (PR-1 + PR-2 + PR-3 + PR-4)
+- [ ] Promotions above already executed (pre-implementation); no further vault writes needed unless an implementation-time lesson emerges
+- [ ] Cron scheduled for v1.16.0 + 14 days (Phase C daemon decision per ADR-011)

--- a/src/hive/_helpers.py
+++ b/src/hive/_helpers.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import difflib
+import functools
 import json
 import logging
+import os
 import re
 import subprocess
 import threading
@@ -549,6 +552,105 @@ _GIT_LOCK = threading.Lock()
 _WRITE_LOCK = threading.Lock()
 
 
+_GIT_LOCK_WAIT_HISTORY: deque[int] = deque(maxlen=100)
+_GIT_LOCK_WAIT_GUARD = threading.Lock()
+
+
+def _record_lock_wait(waited_ms: int) -> None:
+    """Append a lock-wait sample to the rolling N=100 window (thread-safe)."""
+    with _GIT_LOCK_WAIT_GUARD:
+        _GIT_LOCK_WAIT_HISTORY.append(waited_ms)
+
+
+def _git_lock_stats_snapshot() -> dict[str, float | int]:
+    """Snapshot of last_git_lock_wait_ms rolling window (mean, p99, count).
+
+    HIVE-115 / ADR-010 telemetry — feeds Phase B gate decision. Surfaced
+    in ``vault_health(include_runtime=True)``.
+    """
+    with _GIT_LOCK_WAIT_GUARD:
+        samples = list(_GIT_LOCK_WAIT_HISTORY)
+    n = len(samples)
+    if n == 0:
+        return {"mean_ms": 0.0, "p99_ms": 0.0, "sample_count": 0}
+    mean = sum(samples) / n
+    sorted_s = sorted(samples)
+    p99_idx = min(n - 1, max(0, int(n * 0.99)))
+    return {
+        "mean_ms": float(mean),
+        "p99_ms": float(sorted_s[p99_idx]),
+        "sample_count": n,
+    }
+
+
+def _compute_wal_size_bytes(state_dir: Path) -> int:
+    """Sum size of all ``*.db-wal`` files under ``state_dir`` (stat-only).
+
+    HIVE-115 / ADR-009 telemetry — bounded WAL is the success signal
+    for the periodic ``PRAGMA wal_checkpoint(PASSIVE)`` thread.
+    """
+    total = 0
+    try:
+        for wal in state_dir.glob("*.db-wal"):
+            with contextlib.suppress(OSError):
+                total += wal.stat().st_size
+    except OSError:
+        pass
+    return total
+
+
+def _count_competing_hive_processes() -> int:
+    """Count distinct ``hive-vault`` PIDs (excluding self), same user only.
+
+    Cached for ~30s via an epoch-bucket key on :func:`functools.lru_cache`
+    so ``vault_health`` calls do not pay psutil's process-iter cost on every
+    request (Windows ~100ms, POSIX ~10ms). Filters strictly by process
+    name AND same user to avoid antivirus / backup-tool false positives
+    (HIVE-115 audit MINOR finding).
+    """
+    epoch_bucket = int(time.time() // 30)
+    return _competing_pid_count_cached(epoch_bucket)
+
+
+@functools.lru_cache(maxsize=1)
+def _competing_pid_count_cached(epoch_bucket: int) -> int:  # noqa: ARG001
+    """Real count behind :func:`_count_competing_hive_processes`.
+
+    The ``epoch_bucket`` argument is used solely as the lru_cache key so
+    callers get a fresh result every 30 seconds while not paying for
+    process_iter on every call.
+    """
+    try:
+        import psutil
+    except ImportError:
+        return 0
+
+    self_pid = os.getpid()
+    try:
+        self_user = psutil.Process(self_pid).username()
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        self_user = None
+
+    count = 0
+    try:
+        for proc in psutil.process_iter(attrs=["name", "pid", "username"]):
+            try:
+                info = proc.info
+                if info.get("pid") == self_pid:
+                    continue
+                name = (info.get("name") or "").lower()
+                if "hive-vault" not in name and "hive_vault" not in name:
+                    continue
+                if self_user is not None and info.get("username") != self_user:
+                    continue
+                count += 1
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+    except Exception:  # noqa: BLE001 — psutil can raise OS-specific errors
+        return 0
+    return count
+
+
 def _lock_timeout() -> int:
     """Current lock-acquire timeout in seconds (HIVE-115 / ADR-010).
 
@@ -582,6 +684,7 @@ def _acquire_with_telemetry(
         waited_ms,
         "false" if acquired else "true",
     )
+    _record_lock_wait(waited_ms)
     return acquired
 
 
@@ -608,6 +711,7 @@ def _filelock_with_telemetry(
                 lock_name,
                 waited_ms,
             )
+            _record_lock_wait(waited_ms)
             yield
     except filelock.Timeout:
         waited_ms = int((time.monotonic() - start) * 1000)
@@ -616,6 +720,7 @@ def _filelock_with_telemetry(
             lock_name,
             waited_ms,
         )
+        _record_lock_wait(waited_ms)
         raise
 
 

--- a/src/hive/_helpers.py
+++ b/src/hive/_helpers.py
@@ -548,7 +548,75 @@ def track(
 _GIT_LOCK = threading.Lock()
 _WRITE_LOCK = threading.Lock()
 
-_LOCK_TIMEOUT = 30  # seconds — matches subprocess timeout
+
+def _lock_timeout() -> int:
+    """Current lock-acquire timeout in seconds (HIVE-115 / ADR-010).
+
+    Lazy read of ``settings.lock_timeout_s`` so tests can monkeypatch the
+    settings object after import. Env: ``HIVE_LOCK_TIMEOUT_S`` (default 30,
+    validated 1..600).
+    """
+    from hive.config import settings
+
+    return settings.lock_timeout_s
+
+
+def _acquire_with_telemetry(
+    lock: threading.Lock,
+    lock_name: str,
+    timeout: float | None = None,
+) -> bool:
+    """Acquire a threading.Lock and emit structured ``mcp.lock_contention`` log.
+
+    Records ``waited_ms`` and ``abandoned`` (true on timeout). Feeds the
+    Phase B gate decision per HIVE-115 (see vault backlog HIVE-115 entry +
+    [[adr-010-external-committer-coexistence]]).
+    """
+    actual_timeout = float(timeout) if timeout is not None else float(_lock_timeout())
+    start = time.monotonic()
+    acquired = lock.acquire(timeout=actual_timeout)
+    waited_ms = int((time.monotonic() - start) * 1000)
+    _log.info(
+        "mcp.lock_contention lock=%s waited_ms=%d abandoned=%s",
+        lock_name,
+        waited_ms,
+        "false" if acquired else "true",
+    )
+    return acquired
+
+
+@contextmanager
+def _filelock_with_telemetry(
+    lock: filelock.BaseFileLock,
+    lock_name: str,
+    timeout: float | None = None,
+) -> Iterator[None]:
+    """Acquire a filelock as a context manager with structured telemetry.
+
+    Mirror of :func:`_acquire_with_telemetry` for inter-process locks.
+    Emits exactly one ``mcp.lock_contention`` log line per attempt; on
+    timeout, emits ``abandoned=true`` and re-raises ``filelock.Timeout``
+    so callers can fall through to their existing error path unchanged.
+    """
+    actual_timeout = float(timeout) if timeout is not None else float(_lock_timeout())
+    start = time.monotonic()
+    try:
+        with lock.acquire(timeout=actual_timeout):
+            waited_ms = int((time.monotonic() - start) * 1000)
+            _log.info(
+                "mcp.lock_contention lock=%s waited_ms=%d abandoned=false",
+                lock_name,
+                waited_ms,
+            )
+            yield
+    except filelock.Timeout:
+        waited_ms = int((time.monotonic() - start) * 1000)
+        _log.info(
+            "mcp.lock_contention lock=%s waited_ms=%d abandoned=true",
+            lock_name,
+            waited_ms,
+        )
+        raise
 
 
 class WriteLockTimeout(Exception):  # noqa: N818  # mirrors stdlib TimeoutError naming
@@ -572,11 +640,11 @@ def vault_write_lock(vault_path: Path) -> Iterator[None]:
     The filelock is the singleton from :func:`_git_filelock`, so a nested
     ``_git_commit`` inside this block re-enters the same lock cleanly.
     """
-    if not _WRITE_LOCK.acquire(timeout=_LOCK_TIMEOUT):
+    if not _acquire_with_telemetry(_WRITE_LOCK, "_WRITE_LOCK"):
         raise WriteLockTimeout("write lock timeout")
     try:
         try:
-            with _git_filelock(vault_path).acquire(timeout=_LOCK_TIMEOUT):
+            with _filelock_with_telemetry(_git_filelock(vault_path), "_git_filelock"):
                 yield
         except filelock.Timeout as exc:
             raise WriteLockTimeout("inter-process lock timeout") from exc
@@ -730,15 +798,15 @@ def _git_commit(
         return
     safe_msg = message.replace("\n", " ").replace("\r", " ")
     path_strs = [str(p) for p in rel_paths]
-    if not _GIT_LOCK.acquire(timeout=_LOCK_TIMEOUT):
+    if not _acquire_with_telemetry(_GIT_LOCK, "_GIT_LOCK"):
         _log.warning(
             "git commit skipped for %s: thread lock timeout (%ds)",
-            path_strs, _LOCK_TIMEOUT,
+            path_strs, _lock_timeout(),
         )
         return
     try:
         try:
-            with _git_filelock(vault_path).acquire(timeout=_LOCK_TIMEOUT):
+            with _filelock_with_telemetry(_git_filelock(vault_path), "_git_filelock"):
                 subprocess.run(
                     ["git", "add", *path_strs],
                     cwd=vault_path,
@@ -756,7 +824,7 @@ def _git_commit(
         except filelock.Timeout:
             _log.warning(
                 "git commit skipped for %s: inter-process lock timeout (%ds)",
-                path_strs, _LOCK_TIMEOUT,
+                path_strs, _lock_timeout(),
             )
         except subprocess.CalledProcessError as exc:
             _log.warning("git commit failed for %s: %s", path_strs, exc)
@@ -784,11 +852,11 @@ def _git_commit_all(
     accumulated by ``commit=False`` writes (HIVE-104 Fase B1).
     """
     safe_msg = message.replace("\n", " ").replace("\r", " ") or "vault: batch update"
-    if not _GIT_LOCK.acquire(timeout=_LOCK_TIMEOUT):
+    if not _acquire_with_telemetry(_GIT_LOCK, "_GIT_LOCK"):
         return "error", "thread lock timeout"
     try:
         try:
-            with _git_filelock(vault_path).acquire(timeout=_LOCK_TIMEOUT):
+            with _filelock_with_telemetry(_git_filelock(vault_path), "_git_filelock"):
                 porcelain = subprocess.run(
                     ["git", "status", "--porcelain"],
                     cwd=vault_path,

--- a/src/hive/_sqlite_tracker.py
+++ b/src/hive/_sqlite_tracker.py
@@ -1,13 +1,24 @@
-"""Shared SQLite tracker base — thread-safe init, WAL mode, schema setup."""
+"""Shared SQLite tracker base — thread-safe init, WAL mode, schema setup.
+
+Includes periodic ``PRAGMA wal_checkpoint(PASSIVE)`` daemon thread (HIVE-115,
+ADR-009): at N=3-5 baseline concurrent hive sessions, sibling readers always
+hold WAL snapshots that block automatic checkpoint advancement. The daemon
+thread runs PASSIVE checkpoints on a configurable interval as the actual
+drain mechanism; ``close()`` runs a final TRUNCATE attempt.
+"""
 
 from __future__ import annotations
 
 import contextlib
+import logging
 import sqlite3
 import threading
 from pathlib import Path
 
+_log = logging.getLogger(__name__)
+
 _BUSY_TIMEOUT_SECONDS = 10  # connect-level + PRAGMA busy_timeout
+_CLOSE_THREAD_JOIN_TIMEOUT_S = 2.0  # ceiling for checkpoint thread join on close
 
 
 class _SqliteTracker:
@@ -16,7 +27,7 @@ class _SqliteTracker:
     Subclasses define `_SCHEMA` as a SQL string with one or more
     CREATE TABLE statements; the base handles connection setup, parent
     directory creation, WAL mode for on-disk databases, lock allocation,
-    and connection teardown.
+    a periodic checkpoint daemon thread, and connection teardown.
 
     The connect-level ``timeout`` and the ``PRAGMA busy_timeout`` are
     both set to 10s so that two hive processes writing to the same
@@ -27,10 +38,16 @@ class _SqliteTracker:
 
     _SCHEMA: str = ""
 
-    def __init__(self, db_path: str = ":memory:") -> None:
+    def __init__(
+        self,
+        db_path: str = ":memory:",
+        *,
+        checkpoint_interval_s: float | None = None,
+    ) -> None:
         if db_path != ":memory:":
             Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.Lock()
+        self._db_path = db_path
         self._conn = sqlite3.connect(
             db_path,
             check_same_thread=False,
@@ -53,11 +70,85 @@ class _SqliteTracker:
             self._conn.execute("PRAGMA wal_autocheckpoint=200")
         self._conn.executescript(self._SCHEMA)
 
+        # ── Checkpoint daemon thread (HIVE-115 / ADR-009) ──────────────
+        # At N=3-5 baseline sessions, the autocheckpoint above is blocked
+        # by sibling readers holding snapshots. PASSIVE periodic is the
+        # actual drain. :memory: DBs have no WAL and skip this entirely.
+        self._checkpoint_count = 0
+        self._stop_checkpoint = threading.Event()
+        self._checkpoint_thread: threading.Thread | None = None
+        if db_path != ":memory:":
+            self._checkpoint_interval_s = (
+                checkpoint_interval_s
+                if checkpoint_interval_s is not None
+                else _default_checkpoint_interval_s()
+            )
+            self._checkpoint_thread = threading.Thread(
+                target=self._checkpoint_loop,
+                name=f"hive-checkpoint-{Path(db_path).stem}",
+                daemon=True,
+            )
+            self._checkpoint_thread.start()
+        else:
+            self._checkpoint_interval_s = (
+                checkpoint_interval_s if checkpoint_interval_s is not None else 0.0
+            )
+
+    def _checkpoint_loop(self) -> None:
+        """Daemon loop running PRAGMA wal_checkpoint(PASSIVE) on interval.
+
+        PASSIVE does not block readers and advances checkpoint as far as
+        current frame state allows. Survives transient ``sqlite3.Error``
+        (logged at WARNING) so a temporary contention does not kill the
+        thread.
+        """
+        while not self._stop_checkpoint.wait(timeout=self._checkpoint_interval_s):
+            try:
+                with self._lock:
+                    self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+                self._checkpoint_count += 1
+            except sqlite3.Error as e:
+                _log.warning(
+                    "WAL checkpoint failed for %s: %s",
+                    self._db_path,
+                    e,
+                )
+                # Continue — next tick retries; if close was called the
+                # Event will be set and the loop exits cleanly.
+
     def close(self) -> None:
-        """Close the database connection."""
+        """Stop checkpoint thread, run final TRUNCATE checkpoint, close conn.
+
+        TRUNCATE only succeeds when no other connections hold snapshots;
+        under contention it degrades to PASSIVE behavior (non-blocking
+        per SQLite docs). The thread join has a 2-second ceiling so a
+        hung worker cannot block shutdown.
+        """
+        self._stop_checkpoint.set()
+        if self._checkpoint_thread is not None and self._checkpoint_thread.is_alive():
+            self._checkpoint_thread.join(timeout=_CLOSE_THREAD_JOIN_TIMEOUT_S)
         with self._lock:
+            with contextlib.suppress(sqlite3.Error):
+                # Drop busy_timeout to 500ms for the final TRUNCATE so a
+                # sibling reader cannot keep close() blocked for the full
+                # 10-second busy_timeout. With siblings: TRUNCATE waits
+                # 500ms then returns (no truncation, WAL stays — siblings
+                # keep it alive anyway). Without siblings: TRUNCATE drains
+                # the WAL fully in well under 500ms.
+                self._conn.execute("PRAGMA busy_timeout=500")
+                self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
             self._conn.close()
 
     def __del__(self) -> None:
         with contextlib.suppress(Exception):
-            self._conn.close()
+            self.close()
+
+
+def _default_checkpoint_interval_s() -> float:
+    """Read default checkpoint interval from settings (lazy import to avoid cycles).
+
+    Tests can monkeypatch ``hive.config.settings`` to override.
+    """
+    from hive.config import settings
+
+    return float(settings.wal_checkpoint_interval_s)

--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -8,6 +8,7 @@ import sys
 import time
 from datetime import UTC, date, datetime, timedelta
 from importlib import metadata
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from hive._helpers import (
@@ -32,8 +33,6 @@ from hive.frontmatter import (
 )
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from fastmcp import FastMCP
 
     from hive._context import ServerContext
@@ -103,16 +102,42 @@ def _registered_tool_names(mcp: FastMCP) -> list[str]:
 
 
 def runtime_block_text(ctx: ServerContext, mcp: FastMCP) -> str:
-    """Opt-in runtime block — issue #109 acceptance criterion 2."""
+    """Opt-in runtime block — issue #109 + HIVE-115 multi-process telemetry.
+
+    Surfaces (HIVE-115 / ADR-009 + ADR-010):
+    - ``wal_size_bytes`` — sum of ``*.db-wal`` under hive state dir
+    - ``competing_pid_count`` — other ``hive-vault`` processes (same user)
+    - ``last_git_lock_wait_ms`` — rolling-100 mean + p99
+    - ``obsidian_git_present`` — external committer detection
+    """
+    from hive import _helpers
+    from hive.config import settings as _settings
+
     uptime_s = max(0.0, time.monotonic() - ctx.started_at_monotonic)
     tools = _registered_tool_names(mcp)
     period = datetime.now(UTC).strftime("%Y-%m")
     stats = ctx.budget.month_stats(ctx.openrouter_budget)
+
+    # HIVE-115 telemetry. Each computation is defensive: a psutil error
+    # or stat failure must NEVER prevent vault_health from returning.
+    state_dir = Path(_settings.db_path).parent
+    wal_size = _helpers._compute_wal_size_bytes(state_dir)
+    competing = _helpers._count_competing_hive_processes()
+    lock_stats = _helpers._git_lock_stats_snapshot()
+    obsidian = _helpers.detect_obsidian_git(ctx.vault) is not None
+
     lines = [
         "## runtime",
         f"- uptime_s: {uptime_s:.1f}",
         f"- tools_registered: {len(tools)} "
         f"({', '.join(tools) if tools else '<empty>'})",
+        f"- wal_size_bytes: {wal_size}",
+        f"- competing_pid_count: {competing}",
+        "- last_git_lock_wait_ms:",
+        f"  - mean: {lock_stats['mean_ms']:.1f}",
+        f"  - p99: {lock_stats['p99_ms']:.1f}",
+        f"  - samples: {lock_stats['sample_count']}",
+        f"- obsidian_git_present: {str(obsidian).lower()}",
         "- openrouter_budget:",
         f"  - spent_usd: {float(stats['spent']):.4f}",
         f"  - cap_usd: {ctx.openrouter_budget}",

--- a/src/hive/config.py
+++ b/src/hive/config.py
@@ -40,6 +40,10 @@ class HiveSettings(BaseSettings):
     relevance_epsilon: float = 0.15
     log_path: str = str(Path.home() / ".local" / "share" / "hive" / "hive.log")
     log_level: str = "INFO"
+    # HIVE-115 / ADR-009: WAL checkpoint daemon thread interval.
+    wal_checkpoint_interval_s: float = Field(default=30.0, gt=0.0, le=3600.0)
+    # HIVE-115 / ADR-010: tunable lock acquire timeout (vault git operations).
+    lock_timeout_s: int = Field(default=30, ge=1, le=600)
 
 
 settings = HiveSettings()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,39 @@ class TestDefaults:
 
 
 class TestEnvOverride:
+    def test_hive_lock_timeout_s_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """HIVE_LOCK_TIMEOUT_S env honored end-to-end (HIVE-115 / ADR-010)."""
+        monkeypatch.setenv("HIVE_LOCK_TIMEOUT_S", "60")
+        s = HiveSettings()
+        assert s.lock_timeout_s == 60
+
+    def test_hive_lock_timeout_s_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("HIVE_LOCK_TIMEOUT_S", raising=False)
+        assert HiveSettings().lock_timeout_s == 30
+
+    def test_hive_lock_timeout_s_validation_low(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reject HIVE_LOCK_TIMEOUT_S=0 (must be ≥1)."""
+        monkeypatch.setenv("HIVE_LOCK_TIMEOUT_S", "0")
+        with pytest.raises(ValidationError):
+            HiveSettings()
+
+    def test_hive_lock_timeout_s_validation_high(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reject HIVE_LOCK_TIMEOUT_S>600 (foot-gun protection)."""
+        monkeypatch.setenv("HIVE_LOCK_TIMEOUT_S", "601")
+        with pytest.raises(ValidationError):
+            HiveSettings()
+
+    def test_hive_wal_checkpoint_interval_s_env(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """HIVE_WAL_CHECKPOINT_INTERVAL_S env honored (HIVE-115 / ADR-009)."""
+        monkeypatch.setenv("HIVE_WAL_CHECKPOINT_INTERVAL_S", "15.5")
+        assert HiveSettings().wal_checkpoint_interval_s == 15.5
+
     def test_hive_prefix_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HIVE_OLLAMA_MODEL", "llama3:8b")
         assert HiveSettings().ollama_model == "llama3:8b"

--- a/tests/test_lock_telemetry.py
+++ b/tests/test_lock_telemetry.py
@@ -145,3 +145,99 @@ def test_filelock_with_telemetry_timeout_emits_and_reraises(
     assert len(matching) == 1
     assert "lock=_TEST_FILELOCK" in matching[0].getMessage()
     assert "abandoned=true" in matching[0].getMessage()
+
+
+# ── Rolling-window stats + compute helpers (HIVE-115 / ADR-009/010) ─────
+
+
+def test_record_lock_wait_and_snapshot_empty() -> None:
+    """Empty window returns zeros, not errors."""
+    from hive._helpers import _GIT_LOCK_WAIT_HISTORY, _git_lock_stats_snapshot
+
+    _GIT_LOCK_WAIT_HISTORY.clear()
+    snap = _git_lock_stats_snapshot()
+    assert snap == {"mean_ms": 0.0, "p99_ms": 0.0, "sample_count": 0}
+
+
+def test_record_lock_wait_window_stats() -> None:
+    """Window computes mean + p99 + sample_count correctly."""
+    from hive._helpers import (
+        _GIT_LOCK_WAIT_HISTORY,
+        _git_lock_stats_snapshot,
+        _record_lock_wait,
+    )
+
+    _GIT_LOCK_WAIT_HISTORY.clear()
+    samples = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+    for s in samples:
+        _record_lock_wait(s)
+    snap = _git_lock_stats_snapshot()
+    assert snap["sample_count"] == 10
+    assert snap["mean_ms"] == 55.0
+    # p99 with n=10 → index min(9, int(10*0.99)) = min(9, 9) = 9 → 100ms
+    assert snap["p99_ms"] == 100.0
+
+
+def test_record_lock_wait_window_bounded_to_100() -> None:
+    """Rolling window keeps only the last 100 samples."""
+    from hive._helpers import (
+        _GIT_LOCK_WAIT_HISTORY,
+        _git_lock_stats_snapshot,
+        _record_lock_wait,
+    )
+
+    _GIT_LOCK_WAIT_HISTORY.clear()
+    for i in range(150):
+        _record_lock_wait(i)
+    snap = _git_lock_stats_snapshot()
+    assert snap["sample_count"] == 100
+    # Should contain only the latest 100: 50..149, mean = (50+149)/2 = 99.5
+    assert snap["mean_ms"] == 99.5
+
+
+def test_acquire_with_telemetry_records_into_window() -> None:
+    """`_acquire_with_telemetry` populates the rolling window."""
+    import threading as _threading
+
+    from hive._helpers import (
+        _GIT_LOCK_WAIT_HISTORY,
+        _acquire_with_telemetry,
+        _git_lock_stats_snapshot,
+    )
+
+    _GIT_LOCK_WAIT_HISTORY.clear()
+    lock = _threading.Lock()
+    acquired = _acquire_with_telemetry(lock, "_TEST_RECORD", timeout=1)
+    try:
+        snap = _git_lock_stats_snapshot()
+        assert snap["sample_count"] == 1
+    finally:
+        if acquired:
+            lock.release()
+
+
+def test_compute_wal_size_bytes_empty_dir(tmp_path: Path) -> None:
+    """Empty state dir returns 0."""
+    from hive._helpers import _compute_wal_size_bytes
+
+    assert _compute_wal_size_bytes(tmp_path) == 0
+
+
+def test_compute_wal_size_bytes_sums_only_wal_files(tmp_path: Path) -> None:
+    """Sums *.db-wal files only, ignoring other files."""
+    from hive._helpers import _compute_wal_size_bytes
+
+    (tmp_path / "a.db-wal").write_bytes(b"x" * 100)
+    (tmp_path / "b.db-wal").write_bytes(b"y" * 250)
+    (tmp_path / "c.db").write_bytes(b"z" * 9999)  # not WAL
+    (tmp_path / "d.db-shm").write_bytes(b"q" * 9999)  # not WAL
+    assert _compute_wal_size_bytes(tmp_path) == 350
+
+
+def test_count_competing_hive_processes_returns_non_negative_int() -> None:
+    """Helper is robust (never throws); cached snapshot is non-negative int."""
+    from hive._helpers import _count_competing_hive_processes
+
+    n = _count_competing_hive_processes()
+    assert isinstance(n, int)
+    assert n >= 0

--- a/tests/test_lock_telemetry.py
+++ b/tests/test_lock_telemetry.py
@@ -1,0 +1,147 @@
+"""Tests for lock-acquire telemetry helpers in _helpers (HIVE-115 / ADR-010).
+
+`_acquire_with_telemetry` and `_filelock_with_telemetry` wrap the existing
+threading.Lock and filelock.FileLock acquires to emit a structured
+``mcp.lock_contention`` log line on every attempt — success or timeout —
+with ``waited_ms`` and ``abandoned`` fields. Telemetry feeds the Phase B
+gate decision (see HIVE-115 backlog).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import filelock
+import pytest
+
+from hive._helpers import (
+    _acquire_with_telemetry,
+    _filelock_with_telemetry,
+    _lock_timeout,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_lock_timeout_reads_from_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_lock_timeout()` returns ``settings.lock_timeout_s`` (env-tunable)."""
+    monkeypatch.setenv("HIVE_LOCK_TIMEOUT_S", "42")
+    from hive import config as hive_config
+
+    monkeypatch.setattr(hive_config, "settings", hive_config.HiveSettings())
+    assert _lock_timeout() == 42
+
+
+def test_acquire_with_telemetry_success_emits_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Successful acquire emits `mcp.lock_contention` with abandoned=false."""
+    lock = threading.Lock()
+    with caplog.at_level(logging.INFO, logger="hive._helpers"):
+        acquired = _acquire_with_telemetry(lock, "_TEST_LOCK", timeout=1)
+        try:
+            assert acquired is True
+        finally:
+            lock.release()
+
+    matching = [r for r in caplog.records if "mcp.lock_contention" in r.getMessage()]
+    assert len(matching) == 1, f"expected 1 lock_contention log, got {len(matching)}"
+    msg = matching[0].getMessage()
+    assert "lock=_TEST_LOCK" in msg
+    assert "abandoned=false" in msg
+    assert "waited_ms=" in msg
+
+
+def test_acquire_with_telemetry_timeout_emits_abandoned_true(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Timed-out acquire emits `mcp.lock_contention` with abandoned=true."""
+    lock = threading.Lock()
+    lock.acquire()  # block the lock
+    try:
+        with caplog.at_level(logging.INFO, logger="hive._helpers"):
+            start = time.monotonic()
+            acquired = _acquire_with_telemetry(lock, "_TEST_LOCK", timeout=0.1)
+            elapsed = time.monotonic() - start
+        assert acquired is False
+        # Should have respected the 0.1s timeout.
+        assert 0.05 < elapsed < 0.5, f"timeout misbehaving: {elapsed:.3f}s"
+    finally:
+        lock.release()
+
+    matching = [r for r in caplog.records if "mcp.lock_contention" in r.getMessage()]
+    assert len(matching) == 1
+    msg = matching[0].getMessage()
+    assert "lock=_TEST_LOCK" in msg
+    assert "abandoned=true" in msg
+    assert "waited_ms=" in msg
+
+
+def test_acquire_with_telemetry_default_timeout_from_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When `timeout` not passed, helper uses `settings.lock_timeout_s`."""
+    monkeypatch.setenv("HIVE_LOCK_TIMEOUT_S", "1")
+    from hive import config as hive_config
+
+    monkeypatch.setattr(hive_config, "settings", hive_config.HiveSettings())
+
+    lock = threading.Lock()
+    lock.acquire()
+    try:
+        start = time.monotonic()
+        acquired = _acquire_with_telemetry(lock, "_TEST_LOCK")  # no explicit timeout
+        elapsed = time.monotonic() - start
+        assert acquired is False
+        assert 0.5 < elapsed < 2.0, f"should honor 1s settings default, got {elapsed:.3f}s"
+    finally:
+        lock.release()
+
+
+def test_filelock_with_telemetry_success_emits_log(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """Successful filelock acquire emits abandoned=false."""
+    lock_path = tmp_path / "test.lock"
+    lock = filelock.FileLock(str(lock_path))
+    with (
+        caplog.at_level(logging.INFO, logger="hive._helpers"),
+        _filelock_with_telemetry(lock, "_TEST_FILELOCK", timeout=1),
+    ):
+        pass  # acquired, do nothing
+
+    matching = [r for r in caplog.records if "mcp.lock_contention" in r.getMessage()]
+    assert len(matching) == 1
+    msg = matching[0].getMessage()
+    assert "lock=_TEST_FILELOCK" in msg
+    assert "abandoned=false" in msg
+
+
+def test_filelock_with_telemetry_timeout_emits_and_reraises(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """Timed-out filelock emits abandoned=true and re-raises Timeout."""
+    lock_path = tmp_path / "test.lock"
+    holder = filelock.FileLock(str(lock_path))
+    holder.acquire(timeout=1)
+    try:
+        contender = filelock.FileLock(str(lock_path))
+        with (
+            caplog.at_level(logging.INFO, logger="hive._helpers"),
+            pytest.raises(filelock.Timeout),
+            _filelock_with_telemetry(contender, "_TEST_FILELOCK", timeout=0.1),
+        ):
+            pass  # never reached
+    finally:
+        holder.release()
+
+    matching = [r for r in caplog.records if "mcp.lock_contention" in r.getMessage()]
+    assert len(matching) == 1
+    assert "lock=_TEST_FILELOCK" in matching[0].getMessage()
+    assert "abandoned=true" in matching[0].getMessage()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -736,6 +736,86 @@ class TestVaultHealthRuntime:
             or "Total calls:" in result
         )
 
+    async def test_runtime_block_includes_wal_size_bytes(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        """HIVE-115 / ADR-009: wal_size_bytes field present as non-negative int."""
+        import re
+
+        result = _text(
+            await vault_mcp.call_tool(
+                "vault_health", {"include_runtime": True},
+            ),
+        )
+        m = re.search(r"wal_size_bytes:\s*(\d+)", result)
+        assert m is not None, f"wal_size_bytes field missing in:\n{result}"
+        assert int(m.group(1)) >= 0
+
+    async def test_runtime_block_includes_competing_pid_count(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        """HIVE-115 / ADR-009: competing_pid_count field present (non-negative int)."""
+        import re
+
+        result = _text(
+            await vault_mcp.call_tool(
+                "vault_health", {"include_runtime": True},
+            ),
+        )
+        m = re.search(r"competing_pid_count:\s*(\d+)", result)
+        assert m is not None, f"competing_pid_count field missing in:\n{result}"
+        assert int(m.group(1)) >= 0
+
+    async def test_runtime_block_includes_last_git_lock_wait_ms(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        """HIVE-115 / ADR-010: last_git_lock_wait_ms surfaces mean + p99 + samples."""
+        result = _text(
+            await vault_mcp.call_tool(
+                "vault_health", {"include_runtime": True},
+            ),
+        )
+        assert "last_git_lock_wait_ms:" in result
+        assert "mean:" in result
+        assert "p99:" in result
+        assert "samples:" in result
+
+    async def test_runtime_block_includes_obsidian_git_present(
+        self, vault_mcp: FastMCP,
+    ) -> None:
+        """HIVE-115 / ADR-010: obsidian_git_present field is true/false."""
+        import re
+
+        result = _text(
+            await vault_mcp.call_tool(
+                "vault_health", {"include_runtime": True},
+            ),
+        )
+        m = re.search(r"obsidian_git_present:\s*(true|false)", result)
+        assert m is not None, f"obsidian_git_present field missing in:\n{result}"
+
+    async def test_runtime_block_obsidian_git_present_when_plugin_active(
+        self, mock_vault: Path,
+    ) -> None:
+        """When the obsidian-git plugin config exists, presence flips to true."""
+        import json
+
+        plugin_dir = mock_vault / ".obsidian" / "plugins" / "obsidian-git"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "data.json").write_text(
+            json.dumps({"commitInterval": 10}), encoding="utf-8",
+        )
+        mcp = create_server(vault_path=mock_vault)
+        try:
+            result = _text(
+                await mcp.call_tool(
+                    "vault_health", {"include_runtime": True},
+                ),
+            )
+            assert "obsidian_git_present: true" in result
+        finally:
+            _close_server(mcp)
+
     async def test_runtime_budget_does_not_leak_api_key(
         self, mock_vault: Path,
     ) -> None:

--- a/tests/test_sqlite_checkpoint.py
+++ b/tests/test_sqlite_checkpoint.py
@@ -1,0 +1,236 @@
+"""Tests for the WAL checkpoint daemon thread on `_SqliteTracker`.
+
+Phase A of HIVE-115 (ADR-009 multi-process WAL policy): every tracker runs a
+background daemon thread executing ``PRAGMA wal_checkpoint(PASSIVE)`` on a
+configurable interval, plus a final ``PRAGMA wal_checkpoint(TRUNCATE)`` on
+``close()``. This file is the TDD spec for that behavior.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from hive._sqlite_tracker import _SqliteTracker
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class _ExampleTracker(_SqliteTracker):
+    """Minimal concrete subclass for testing the base class itself."""
+
+    _SCHEMA = "CREATE TABLE IF NOT EXISTS events (id INTEGER PRIMARY KEY);"
+
+
+def _seed_wal(tracker: _SqliteTracker, n: int = 100) -> None:
+    """Write enough rows to materialize WAL frames."""
+    with tracker._lock:
+        for _ in range(n):
+            tracker._conn.execute("INSERT INTO events DEFAULT VALUES")
+        tracker._conn.commit()
+
+
+def test_passive_checkpoint_runs_on_interval(tmp_path: Path) -> None:
+    """A daemon thread executes PRAGMA wal_checkpoint(PASSIVE) on each tick.
+
+    HIVE-115 / ADR-009: at N=3-5 baseline, sibling processes always hold
+    snapshots, so PASSIVE periodic is the actual drain mechanism. We verify
+    the thread fires by reading a counter that the loop increments on each
+    successful PRAGMA execution.
+    """
+    db_path = str(tmp_path / "test.db")
+    tracker = _ExampleTracker(db_path, checkpoint_interval_s=0.1)
+    try:
+        _seed_wal(tracker)
+        time.sleep(0.5)  # let 4-5 ticks happen at 0.1s interval
+        assert tracker._checkpoint_count >= 3, (
+            f"expected ≥3 checkpoint ticks within 0.5s at 0.1s interval, "
+            f"got {tracker._checkpoint_count}"
+        )
+    finally:
+        tracker.close()
+
+
+def test_checkpoint_thread_is_daemon(tmp_path: Path) -> None:
+    """The checkpoint thread is ``daemon=True`` so it dies with the parent.
+
+    Non-daemon threads would prevent interpreter shutdown when the
+    parent process exits ungracefully, leaving zombie hive processes
+    holding SQLite file handles open — exactly the failure class
+    HIVE-115 is closing.
+    """
+    db_path = str(tmp_path / "test.db")
+    tracker = _ExampleTracker(db_path, checkpoint_interval_s=30.0)
+    try:
+        assert tracker._checkpoint_thread is not None
+        assert tracker._checkpoint_thread.daemon is True, (
+            "checkpoint thread must be daemon=True to die with the parent process"
+        )
+    finally:
+        tracker.close()
+
+
+def test_in_memory_db_has_no_checkpoint_thread(tmp_path: Path) -> None:
+    """`:memory:` DBs do not use WAL and do not need a checkpoint thread.
+
+    Avoids spawning a useless thread per in-memory tracker (a common test
+    pattern via fixtures with ``db_path=":memory:"``).
+    """
+    tracker = _ExampleTracker(":memory:")
+    try:
+        assert tracker._checkpoint_thread is None, (
+            ":memory: tracker should not spawn a checkpoint thread (no WAL)"
+        )
+    finally:
+        tracker.close()
+
+
+def test_close_runs_truncate_checkpoint(tmp_path: Path) -> None:
+    """`close()` runs PRAGMA wal_checkpoint(TRUNCATE) as the last drain attempt.
+
+    TRUNCATE only fully succeeds when no other connections hold snapshots;
+    under contention it degrades to PASSIVE behavior. Either way, close()
+    is the last opportunity for this process to advance the checkpoint.
+
+    We assert post-close WAL size is <= pre-close WAL size — TRUNCATE either
+    succeeded (size 0 or file gone) or fell through to PASSIVE-equivalent
+    (advancement, no growth).
+    """
+    db_path = str(tmp_path / "test.db")
+    tracker = _ExampleTracker(db_path, checkpoint_interval_s=999.0)  # disable periodic
+    _seed_wal(tracker, n=500)  # generate substantial WAL
+
+    wal_path = Path(f"{db_path}-wal")
+    pre_size = wal_path.stat().st_size if wal_path.exists() else 0
+    assert pre_size > 0, "test setup invalid: WAL should have frames before close"
+
+    tracker.close()
+
+    post_size = wal_path.stat().st_size if wal_path.exists() else 0
+    assert post_size <= pre_size, (
+        f"WAL not drained on close: pre={pre_size}, post={post_size}"
+    )
+
+
+def test_close_completes_within_guard_under_sibling_reader(tmp_path: Path) -> None:
+    """`close()` does not hang when a sibling connection holds a read snapshot.
+
+    Under multi-process load (N=3-5 baseline), other hive processes hold
+    open snapshots constantly. close() must not block waiting for them —
+    the TRUNCATE falls through to PASSIVE behavior and returns quickly.
+
+    Wall-clock guard: close() should complete well under 2.5s even under
+    a held sibling snapshot. Sets the bound for the close() time budget.
+    """
+    db_path = str(tmp_path / "test.db")
+    tracker = _ExampleTracker(db_path, checkpoint_interval_s=999.0)
+    _seed_wal(tracker)
+
+    sibling = sqlite3.connect(db_path)
+    sibling.execute("BEGIN")
+    sibling.execute("SELECT * FROM events")  # holds snapshot
+    try:
+        start = time.monotonic()
+        tracker.close()
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.5, (
+            f"close() took {elapsed:.2f}s under sibling reader load; "
+            f"should complete <2.5s (TRUNCATE degrades to PASSIVE, non-blocking)"
+        )
+    finally:
+        sibling.close()
+
+
+def test_close_stops_checkpoint_thread(tmp_path: Path) -> None:
+    """`close()` signals the checkpoint thread to stop and joins it.
+
+    Verifies the lifecycle: after close(), the thread is no longer alive,
+    and subsequent counter reads do not increment.
+    """
+    db_path = str(tmp_path / "test.db")
+    tracker = _ExampleTracker(db_path, checkpoint_interval_s=0.05)
+    try:
+        _seed_wal(tracker)
+        time.sleep(0.2)  # let some ticks happen
+        count_before = tracker._checkpoint_count
+        assert count_before > 0, "test setup: thread should have run before close"
+    finally:
+        tracker.close()
+
+    # After close: thread should have stopped, count should be stable.
+    assert tracker._checkpoint_thread is not None
+    assert not tracker._checkpoint_thread.is_alive(), (
+        "checkpoint thread should have stopped after close()"
+    )
+
+    # Wait briefly and verify no new ticks happened.
+    count_after_close = tracker._checkpoint_count
+    time.sleep(0.15)
+    assert tracker._checkpoint_count == count_after_close, (
+        "checkpoint_count should not increment after close()"
+    )
+
+
+def test_checkpoint_loop_survives_sqlite_errors(tmp_path: Path) -> None:
+    """The checkpoint loop catches sqlite3.Error and continues on next tick.
+
+    A transient lock contention or temporary error must not kill the
+    daemon thread; otherwise one bad tick stops all future drains.
+    """
+    db_path = str(tmp_path / "test.db")
+    tracker = _ExampleTracker(db_path, checkpoint_interval_s=0.1)
+    try:
+        _seed_wal(tracker)
+        time.sleep(0.25)  # at least 2 ticks
+        early_count = tracker._checkpoint_count
+        assert early_count >= 2
+
+        # Forcefully simulate a transient error by closing & reopening the
+        # connection out from under the loop. The next tick should encounter
+        # an error, log it, and continue.
+        with tracker._lock:
+            tracker._conn.close()
+            tracker._conn = sqlite3.connect(
+                db_path,
+                check_same_thread=False,
+                timeout=10,
+            )
+            tracker._conn.execute("PRAGMA journal_mode=WAL")
+
+        time.sleep(0.25)  # let a few more ticks run with the new conn
+        # Even after the reconnect, the loop should have continued.
+        # We can't assert exact count (the error-recovery branch
+        # may suppress the increment), but the thread must be alive.
+        assert tracker._checkpoint_thread is not None
+        assert tracker._checkpoint_thread.is_alive(), (
+            "checkpoint thread must survive transient sqlite3.Error"
+        )
+    finally:
+        tracker.close()
+
+
+def test_default_interval_from_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Default ``checkpoint_interval_s`` comes from ``HiveSettings.wal_checkpoint_interval_s``.
+
+    Constructor explicit arg wins; if None, fall back to settings (which
+    in turn read ``HIVE_WAL_CHECKPOINT_INTERVAL_S`` env var).
+    """
+    # We don't actually want the thread firing during this test, just verify
+    # the constructor reads from settings when interval not passed.
+    monkeypatch.setenv("HIVE_WAL_CHECKPOINT_INTERVAL_S", "42.0")
+
+    # Reload settings to pick up the env override.
+    from hive import config as hive_config
+    monkeypatch.setattr(hive_config, "settings", hive_config.HiveSettings())
+
+    db_path = str(tmp_path / "test.db")
+    tracker = _ExampleTracker(db_path)  # no explicit interval
+    try:
+        assert tracker._checkpoint_interval_s == 42.0, (
+            f"expected interval 42.0 from env, got {tracker._checkpoint_interval_s}"
+        )
+    finally:
+        tracker.close()

--- a/uv.lock
+++ b/uv.lock
@@ -527,6 +527,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "filelock" },
     { name = "httpx" },
+    { name = "psutil" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
 ]
@@ -538,6 +539,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-psutil" },
     { name = "types-pyyaml" },
 ]
 
@@ -547,12 +549,14 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.13" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
+    { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "types-psutil", marker = "extra == 'dev'", specifier = ">=5.9.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
 provides-extras = ["dev"]
@@ -981,6 +985,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -1469,6 +1501,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "types-psutil"
+version = "7.2.2.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/f1/6901857281d4e8d792492e1495eef6f4f01318a3b6a066486d81000a4511/types_psutil-7.2.2.20260518.tar.gz", hash = "sha256:9f825f631463a5b4d26f19f63aebc9ec25f01140d655026f3ad8a67841f9b331", size = 26660, upload-time = "2026-05-18T06:05:09.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/eb/f726339668879819599c74c2e1f0cab760912a4159046942bdae2ad37bd6/types_psutil-7.2.2.20260518-py3-none-any.whl", hash = "sha256:6a3d697665754a60d7b5a41d5a2cff12b53f5e0676d77810cd28ba5e14cb4049", size = 32820, upload-time = "2026-05-18T06:05:08.321Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase A of [HIVE-115](https://github.com/mlorentedev/hive/blob/master/specs/HIVE-115-latency-tail-redesign/proposal.md) — defensive + observable layer against multi-process latency tail at the N=3-5 baseline (typical hive usage with 3-5 concurrent Claude Code sessions per user).

- **Periodic WAL drain.** Every `_SqliteTracker` runs a daemon thread executing `PRAGMA wal_checkpoint(PASSIVE)` every 30s (configurable via `HIVE_WAL_CHECKPOINT_INTERVAL_S`). Solves the "WAL never drains because sibling readers always hold snapshots" pathology — confirmed locally: `relevance.db-wal` reached 4.1 MB vs 53 KB DB (77× ratio), `worker.db-wal` last checkpointed 2 months ago.
- **`vault_health(include_runtime=True)` extended** with `wal_size_bytes`, `competing_pid_count` (psutil cross-OS, same-user filter, 30s cache), `last_git_lock_wait_ms` (rolling-100 mean + p99), `obsidian_git_present`. These metrics are the gating signals for Phase B.
- **`HIVE_LOCK_TIMEOUT_S` env-tunable** (default 30, validated 1..600) replaces the hardcoded `_LOCK_TIMEOUT`. Every `_GIT_LOCK.acquire` emits structured `mcp.lock_contention lock=NAME waited_ms=N abandoned=BOOL` for greppable observability.
- **Bilingual troubleshooting + configuration docs** describe the multi-session contention pattern with cross-OS zombie-detection recipes (POSIX `ps`/`lsof`, Windows `Get-Process`).

## Acceptance criteria covered

- AC-1: periodic PASSIVE checkpoint thread (HIVE-115 spec)
- AC-2: TRUNCATE on close with 2.5s ceiling under sibling-reader contention (`busy_timeout=500ms` discovered via TDD)
- AC-3: vault_health runtime: `wal_size_bytes` + `competing_pid_count` + `last_git_lock_wait_ms` + `obsidian_git_present`
- AC-4: HIVE_LOCK_TIMEOUT_S honored end-to-end + validated 1..600
- AC-5: structured `mcp.lock_contention` log on every acquire
- AC-13: bilingual troubleshooting docs (EN + ES)

Phase B ACs (AC-6 through AC-12) covered in subsequent PRs (PR-2 #114 XML defense, PR-3 #111 bounded_call, PR-4 outbox + detect-and-defer).

## Test plan

- [x] `make check` green — 541 passed, 1 skipped (Windows-only), 0 failed
- [x] Coverage 90% (unchanged from baseline)
- [x] Lint clean (ruff)
- [x] Mypy clean (added `types-psutil` to dev deps)
- [x] TDD red → green → refactor cycle followed; 8 new tests in `tests/test_sqlite_checkpoint.py`, 13 new in `tests/test_lock_telemetry.py`, 5 new in `tests/test_server.py::TestVaultHealthRuntime`, 5 new in `tests/test_config.py`
- [x] No regression in existing transport recovery tests (`tests/test_compat_shim.py`)
- [ ] Manual smoke under N=3 concurrent Claude Code sessions: verify `vault_health(include_runtime=True)` reports `competing_pid_count: 3` and `wal_size_bytes` stays bounded after a few checkpoint intervals (deferred to v1.16.0 telemetry window)

## Rationale (already crystallized in vault)

ADRs introduced in this PR's prep work (vault commit 02d1f63):
- [ADR-009 multi-process WAL policy](https://github.com/mlorentedev/knowledge/blob/main/10_projects/hive/30-architecture/adr-009-multi-process-wal-policy.md) — v1 (Phase A); v2 (Outbox + Reconciler) will land alongside PR-4
- [ADR-010 external committer coexistence](https://github.com/mlorentedev/knowledge/blob/main/10_projects/hive/30-architecture/adr-010-external-committer-coexistence.md)
- ADR-005 amended: telemetry gate triggered, Phase C (daemon) bumped to probable v2.0
- ADR-006 amended: §C "re-evaluate" gate invoked with empirical data

Lessons (vault commit 4d9c642):
- "Three timeouts in a chain aren't a deadline" → motivates #111 / PR-3
- "SQLite WAL doesn't auto-checkpoint when N processes hold readers" → motivates this PR
- "Cooperative external committer needs explicit coordination" → motivates ADR-010 / PR-4
- "Telemetry IS the design, not an afterthought" → motivates the instrumentation here
- New meta-pattern: `pattern-phased-redesign-with-telemetry-gates`

[Pattern multi-process-mcp-server](https://github.com/mlorentedev/knowledge/blob/main/00_meta/patterns/pattern-multi-process-mcp-server.md) extended with primitives 5-7 (WAL drain, Outbox + Reconciler, hard-deadline supervisor).

Refs: #110 (partially — full close on PR-4), #114 (PR-2), #111 (PR-3).