### PR TITLE
feat(hive): observable partial-state writes (HIVE-116 PR-1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,5 +80,8 @@ warn_unused_configs = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
-markers = ["smoke: end-to-end tests against real Ollama/OpenRouter (skip in CI)"]
-addopts = "-m 'not smoke'"
+markers = [
+    "smoke: end-to-end tests against real Ollama/OpenRouter (skip in CI)",
+    "cross_worker: HIVE-116 multi-process integration tests (excluded from default run, requires fake-git PATH fixture)",
+]
+addopts = "-m 'not smoke and not cross_worker'"

--- a/site/src/content/docs/es/guides/troubleshooting.md
+++ b/site/src/content/docs/es/guides/troubleshooting.md
@@ -340,6 +340,52 @@ Si tu vault usa obsidian-git para auto-backups, las dos herramientas cooperan li
 
 Una release futura hará la cooperación automática (auto-defer cuando el committer externo esté sano); por ahora es opt-in vía `commit=False`.
 
+## Escrituras en estado parcial tras deadline
+
+Cuando `vault_write` o `vault_patch` alcanza su deadline (60s por defecto) mientras el supervisor está matando un `git add` / `git commit` colgado, el archivo en disco puede haberse escrito — pero el commit nunca llegó a aterrizar. La respuesta incluirá el sufijo:
+
+```
+ (partial state — disk write succeeded, git commit killed by deadline; verify with vault_query before retrying)
+```
+
+O, cuando el deadline dispara antes de que el handler retorne, la respuesta es:
+
+```
+vault_write timed out after 60s — partial state: disk write succeeded, git commit killed by deadline; verify with vault_query before retrying.
+```
+
+### Qué hacer
+
+1. **NO reintentes a ciegas** — reintentar con escrituras FS nativas arriesga double-writes. El archivo ya está en disco.
+2. **Verifica** el estado real con `vault_query`:
+   ```
+   vault_query(project="mi-proyecto", path="11-tasks.md")
+   ```
+   Compara con lo que pretendías escribir.
+3. **Inspecciona el estado de git** si tienes shell en el vault:
+   ```bash
+   git -C "$VAULT_PATH" status --porcelain
+   ```
+   El archivo debería aparecer como modified o staged; nada committed.
+4. **Recupera el commit** mediante:
+   - Llamar a `vault_commit` (Hive flushea lo que esté sucio), o
+   - Dejar que obsidian-git lo recoja en su próximo tick (si está instalado), o
+   - Manualmente `git -C "$VAULT_PATH" add . && git commit -m "vault: rescue partial state"`.
+
+### Por qué pasa
+
+El supervisor de deadline termina el subprocess `git add` / `git commit`, pero el hilo Python que sostiene el cooperative `.git/hive.lock` puede seguir en mitad de `communicate()` (especialmente en Windows). La escritura en disco es atómica; el commit no. El sufijo partial-state es el contrato que Hive expone para que los agentes downstream eviten double-writes.
+
+### Triage operacional
+
+Al investigar, mira en `~/.local/share/hive/hive-<pid>.log` líneas como:
+
+```
+WARNING git add failed for [...] rc=-1 cause=external_termination err=[external_termination] killed by supervisor at 2026-05-27T18:00:00+00:00 ; original stderr: empty
+```
+
+El tag `cause=external_termination` es one-grep-able e indica que el supervisor lo mató (vs `cause=git_error` para fallos genuinos de git). El stderr sintético con el timestamp ISO-8601 permite correlacionar contra la respuesta partial-state que recibió el cliente.
+
 ## Obtener ayuda
 
 Si tu problema no está listado aquí:

--- a/site/src/content/docs/guides/troubleshooting.md
+++ b/site/src/content/docs/guides/troubleshooting.md
@@ -340,6 +340,52 @@ If your vault uses obsidian-git for auto-backups, the two tools cooperate cleanl
 
 A future release will make the cooperation automatic (auto-defer when external committer healthy); for now it is opt-in via `commit=False`.
 
+## Partial-State Writes After Deadline
+
+When `vault_write` or `vault_patch` hits its tool-call deadline (default 60s) while the supervisor is killing a stuck `git add`/`git commit`, the file on disk may already have been written — but the git commit never landed. The response will include the suffix:
+
+```
+ (partial state — disk write succeeded, git commit killed by deadline; verify with vault_query before retrying)
+```
+
+Or, when the deadline fires before the handler even returns, the response is:
+
+```
+vault_write timed out after 60s — partial state: disk write succeeded, git commit killed by deadline; verify with vault_query before retrying.
+```
+
+### What to do
+
+1. **Do NOT blindly retry** — retrying with native FS tools risks double-writes. The file is already on disk.
+2. **Verify** the actual state with `vault_query`:
+   ```
+   vault_query(project="my-project", path="11-tasks.md")
+   ```
+   Compare against what you intended to write.
+3. **Inspect the git status** if you have shell access to the vault:
+   ```bash
+   git -C "$VAULT_PATH" status --porcelain
+   ```
+   The file should appear as modified or staged; nothing committed.
+4. **Recover the commit** either by:
+   - Calling `vault_commit` (Hive flushes whatever is dirty), or
+   - Letting obsidian-git pick it up on its next tick (if installed), or
+   - Manually `git -C "$VAULT_PATH" add . && git commit -m "vault: rescue partial state"`.
+
+### Why this happens
+
+The deadline supervisor terminates the `git add` / `git commit` subprocess, but the Python thread holding the cooperative `.git/hive.lock` may still be in mid-`communicate()` (especially on Windows). The on-disk write is atomic; the commit is not. The partial-state suffix is the contract Hive exposes to let downstream agents avoid double-writes.
+
+### Operator triage
+
+When investigating, look at `~/.local/share/hive/hive-<pid>.log` for lines like:
+
+```
+WARNING git add failed for [...] rc=-1 cause=external_termination err=[external_termination] killed by supervisor at 2026-05-27T18:00:00+00:00 ; original stderr: empty
+```
+
+The `cause=external_termination` tag is one-grep-able and tells you the supervisor killed it (vs `cause=git_error` for genuine git failures). The synthetic stderr with the ISO-8601 timestamp lets you correlate against the partial-state response received by the client.
+
 ## Getting Help
 
 If your issue isn't listed here:

--- a/specs/HIVE-116-stale-lock-after-deadline/proposal.md
+++ b/specs/HIVE-116-stale-lock-after-deadline/proposal.md
@@ -1,0 +1,105 @@
+---
+id: "HIVE-116-stale-lock-after-deadline"
+type: spec
+status: draft
+created: "2026-05-27"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HIVE-116: Stale `.git/hive.lock` + partial-state silence after `bounded_call` deadline
+
+> File lives at `specs/HIVE-116-stale-lock-after-deadline/proposal.md`. Post-HIVE-115 regression surfaced by issue [#141](https://github.com/mlorentedev/hive/issues/141) — fixes the lock-handle and partial-state observability gaps that the v1.18.0 + v1.19.0 deadline supervisor left open. Three-phase landing per [[pattern-phased-redesign-with-telemetry-gates]] (QW → root-cause → cross-OS validation), each phase ships independently.
+
+## Why
+
+<!-- from issue #141 (2026-05-27) + sibling-session evidence from the same day:
+  Two independent reproductions on Windows + NTFS within one hour, both
+  on the same machine but different Claude Code sessions, both ending
+  in: subprocess killed by HIVE-115 PR-3 bounded_call, on-disk write
+  persisted, git commit never ran, .git/hive.lock orphaned with open
+  parent file handle, client received a generic "timed out" string
+  that contradicted the actual disk state. -->
+
+HIVE-115 PR-3 (`bounded_call` hard-deadline supervisor) closed the original "infinite hang on stuck subprocess" failure mode by terminating registered Popens on deadline expiry. Two-week empirical use surfaces three residual gaps that **the supervisor was not specified to close** but in practice users hit as regressions:
+
+1. **Hive's own cooperative filelock (`.git/hive.lock`) is not cleaned up on deadline.** The supervisor's `_cleanup_index_lock` is PID-matched and scoped to git's *native* `.git/index.lock`. The filelock under `.git/hive.lock` — Hive's inter-process serialization mechanism — is left in whatever state the worker thread leaves it in. When the worker thread is still inside `_filelock_with_telemetry`'s `with` block at deadline expiry, the lock remains held; the parent process retains an open file handle that on Windows blocks external cleanup (`rm` fails with `Device or resource busy`).
+2. **`stderr=""` from externally-terminated subprocess leaves operators blind.** `_run_git` returns `rc=-1` on `BrokenPipeError`/`OSError` after the supervisor kills the Popen; the `WARNING git add failed for … rc=-1 err=` line carries no signal about *why*. Operators cannot distinguish "we killed it on deadline" from "git failed with empty stderr". Empirical: 2026-05-27 logs `hive-3468.log`, `hive-9092.log`, `hive-31272.log` all show `err=` empty after deadline kills.
+3. **Client gets a generic "timed out — retry shortly" string while the disk write has already landed.** `run_sync_tool`'s timeout branch (`_helpers.py:880-883`) returns a canned message that contradicts reality: the markdown file IS on disk; only the git commit failed. Agents (Claude Code, OpenCode, etc.) interpret the message as failure and **retry with native FS writes**, risking double-writes. Today's repro shows obsidian-git auto-commit picking up the orphan modified files ~4 minutes later — partial state self-heals on this machine, but the client never learns that.
+
+Empirical evidence (2026-05-27, Windows 11, ~174 MB vault, 2 concurrent `hive-vault` workers, obsidian-git active):
+
+- `~/.local/share/hive/hive-31272.log` — `vault_patch` on `10_projects/dotfiles/11-tasks.md`, 60s deadline, `killed_pids=[10424]`, file persisted, `.git/hive.lock` 0-byte orphan with mtime exactly matching the timeout.
+- `~/.local/share/hive/hive-9092.log` — independent session 2 hours later, `vault_patch` on `10_projects/mapi-msg-dumper/11-tasks.md`; both `git add` AND `git commit` returned `rc=1 err=""`; `capture_lesson` runs **246 seconds** wall-time after the supposed 60s deadline (HIVE-115 PR-3 closes the *child kill* loop but `tool_span` cannot preempt the parent Python thread — separate, known constraint).
+
+**Root cause synthesis** (from reading `src/hive/_helpers.py:992-1060` + `src/hive/_deadline.py:201-258` against the log timeline):
+
+- `bounded_call` deadline → `_terminate_registry` SIGTERMs Popen → grace → SIGKILL. ✅
+- Worker thread sitting in `_run_git → proc.communicate()` is **not** preempted by Python (asyncio cannot cancel threads; this is a CPython invariant, see lesson [[lesson-three-timeouts-chain-not-deadline]]).
+- Worker thread holds `_GIT_LOCK` (threading) + the `_git_filelock` FileLock context throughout. Until the thread escapes `_filelock_with_telemetry.__exit__`, no other call can acquire — and the cached singleton in `_GIT_FILELOCKS` keeps the file-handle pinned at the OS layer.
+- The supervisor *does* return `TimeoutError` to the awaiter, but the worker thread is now "an abandoned thread holding a global lock for an unbounded time." Subsequent `vault_patch` calls in the same hive process block on `_GIT_LOCK.acquire(timeout=30s)` → "Server busy"; calls from sibling hive processes block on the OS filelock → same result.
+
+This is not a bug in `bounded_call` per se — its contract was "kill the subprocess, return to the client." It is an **unspecified cooperation contract between the supervisor and the worker-thread side of the same critical section**, and the spec needs to close it.
+
+## What
+
+After this spec ships (target: v1.20.0 → v1.21.0 → v1.22.0 across three PRs):
+
+1. **`.git/hive.lock` is released or evicted within the deadline grace window.** When `bounded_call` fires its deadline and at least one subprocess was killed, the supervisor explicitly evicts the cached `FileLock` instance from `_GIT_FILELOCKS` after a configurable post-kill drain period. Subsequent calls create a fresh `FileLock` against the same path; on Windows the orphan file persists until process exit (filelock library invariant), but is no longer cached and no longer blocks new acquires. New env: `HIVE_POST_KILL_DRAIN_S` (default 5.0, validated 0.5..30).
+2. **Externally-terminated subprocesses log a structured cause, not blank stderr.** `_run_git` distinguishes `rc=-1` (we killed it) from `rc>0` (git itself failed). On external termination, the warning line carries `cause=external_termination signalled_pid=N` plus the supervisor's recorded kill timestamp. On natural failure, the original stderr is logged unchanged.
+3. **Write tools return a structured "partial state" response on deadline.** `vault_write` and `vault_patch` detect when the disk-write landed but the commit did not, and surface a deterministic suffix the agent can pattern-match (final wording to be decided by the user — see Risk R3). `run_sync_tool`'s canned "timed out — retry shortly" is replaced by the disk-status-aware variant for these two tools only; read-path tools continue to return the original message.
+4. **Cross-worker coordination is testable.** A new integration test under `tests/test_cross_worker_lock.py` spawns two `hive-vault` subprocesses against the same `tmp_path` vault and asserts that a deadline-killed write in worker A does not block worker B's next write beyond `deadline + grace + drain` total.
+5. **Cross-OS validation matrix.** New CI lane: matrix `os: [ubuntu-latest, windows-latest]` for `tests/test_cross_worker_lock.py` + `tests/test_compat_shim.py`. Existing tests continue to run on Python 3.12 + 3.13 only — Windows lane is opt-in to keep the default CI fast.
+
+Closes issue [#141](https://github.com/mlorentedev/hive/issues/141). Feeds the **2026-06-05 Phase C decision checkpoint** ([#124](https://github.com/mlorentedev/hive/issues/124)): if `_compat.GHOST_RESPONSES.by_source["deadline"]` ticks at all after this ships, the cooperation pattern is working as designed; persistent ticks reinforce the daemon-model gate.
+
+## Out of scope
+
+- **Preempting the worker thread itself.** Python cannot cancel a running thread; this spec accepts that constraint and works around it via lock-eviction. A daemon model that owns the SQLite + git would dissolve the problem class entirely — that is Phase C (#124), explicitly NOT this spec.
+- **Transactional disk-write + git-commit.** Wrapping the FS write and the commit in a single rollback unit would require either copy-on-write semantics or a write-ahead log per vault. Both are larger than this spec; the partial-state response contract is an explicit acknowledgement that partial states are *acceptable by design* as long as the client learns about them.
+- **`obsidian-git` coexistence policy changes.** HIVE-115 PR-4 already shipped detect-and-defer; this spec does not touch that. The interaction between auto-defer and the new partial-state suffix is exercised in tests but the predicate itself is unchanged.
+- **Replacing `filelock` with a custom inter-process primitive.** `filelock` is the right tool; the bug is in our composition, not the library.
+- **Phase C (#124) trigger inputs.** This spec contributes telemetry but does not pre-decide the 2026-06-05 checkpoint.
+
+## Risks / open questions
+
+- **R1 — Evicting the cached `FileLock` while the worker thread still holds it.** If we evict at `T = deadline + drain` and the worker thread escapes the `with` block at `T + ε`, the `__exit__` releases a different `FileLock` object than the one the next caller is trying to acquire. On POSIX `fcntl.flock` this is benign (the kernel tracks the file descriptor); on Windows `msvcrt.locking` the semantics are subtler. **Mitigation:** test on both OSes (T-X.Y in tasks.md). Fallback: emit `mcp.lock_eviction.race` warning if the supposedly-evicted lock is still `is_locked` 1s after eviction, and surface the count in `vault_health.runtime`.
+- **R2 — `HIVE_POST_KILL_DRAIN_S` value.** Too short → race R1; too long → user-perceived "Server busy" window grows. **Default locked at 5.0s** (user-confirmed 2026-05-27) to match `HIVE_OUTBOX_TICK_S` for symmetry. T-2.8 calibration sweep ({1, 5, 10}) is retained as a verification step — if p99 at 5.0s exceeds 35s, the default is revisited in a follow-up patch before promoting the CI lane to required (per AC-10).
+- **R3 — Partial-state response wording is a public contract.** ~~Open question~~ **Resolved 2026-05-27:** suffix is action-oriented; tells the agent exactly what to do. String-only (no JSON-shape evolution) to preserve symmetry with `_DEFERRED_SUFFIX` / `_UNCOMMITTED_SUFFIX` and avoid a breaking change for callers that treat `vault_write`'s return as plain text. Final wording: `" (partial state — disk write succeeded, git commit killed by deadline; verify with vault_query before retrying)"`. Downstream agents are expected to pattern-match on the literal substring `"partial state — disk write succeeded"` (the part that is stable across future minor wording tweaks).
+- **R4 — Cross-worker test flake on Windows CI.** Spawning real hive subprocesses is slow on `windows-latest` (~5s cold start). The existing flaky `test_classify_cancellation_race` already shows this shape. **Mitigation:** keep the cross-worker test marked `@pytest.mark.windows_smoke`, run only on the windows lane, retry policy = none (we want flake signal, not flake suppression).
+- **R5 — Interaction with HIVE-115 PR-4 Outbox.** Reinforcement counters route through Outbox, so a deadline mid-`capture_lesson` does NOT corrupt the counter (Outbox owns its own DB connection in the reconciler thread). But the *markdown write* of the lesson is still routed through `_vault_write._write_lesson` → `_git_commit`, which is exactly the path this spec fixes. Confirm in tests that the Outbox reconciler is unaffected.
+
+## Acceptance criteria
+
+Each criterion is testable. Mapped 1:1 to `tasks.md` TDD entries. Numbering reset (this is a fresh spec, not a continuation of HIVE-115's AC counters).
+
+- [ ] **AC-1**: On `bounded_call` deadline expiry with `killed_pids != []`, after `HIVE_POST_KILL_DRAIN_S` seconds the supervisor evicts the cached `FileLock` for the affected vault from `_GIT_FILELOCKS`. Test: simulate hung subprocess via fake-git PATH injection, set drain=1s, assert `_GIT_FILELOCKS` does not contain the vault key 1.5s after deadline.
+- [ ] **AC-2**: `HIVE_POST_KILL_DRAIN_S` env var honored end-to-end (default 5.0, validated 0.5..30 inclusive). Test: parametrized with valid + invalid values; invalid raises `ValueError` at config-load time.
+- [ ] **AC-3**: `_run_git` returns `rc=-1` AND a synthetic `stderr` of the form `"[external_termination] killed by supervisor at <ISO-8601>; original stderr: <empty|N bytes>"` when the Popen was killed externally. Test: spawn a 60s `sleep`, kill from outside, assert the synthetic stderr is well-formed.
+- [ ] **AC-4**: `WARNING git add failed for … rc=… err=…` log line carries `cause=external_termination` when `rc=-1`, `cause=git_error` otherwise. Test: `caplog` capture, parametrized for both branches.
+- [ ] **AC-5**: `vault_write` and `vault_patch` return a partial-state suffix when the disk write succeeded but git commit failed *because the supervisor killed it*. Suffix shape and JSON schema TBD by user (see R3). Tests: parametrized for the four states `{write OK, commit OK}`, `{write OK, commit failed/killed}`, `{write OK, commit failed/git-error}`, `{write failed}`.
+- [ ] **AC-6**: `run_sync_tool` routes deadline exceptions through a per-tool partial-state hook when the tool is `vault_write` or `vault_patch`; falls back to the original generic message for all other tools. Test: deadline-fire on `vault_write` → partial-state response; deadline-fire on `vault_query` (read path) → generic timeout response.
+- [ ] **AC-7**: New integration test `tests/test_cross_worker_lock.py` spawns two `hive-vault` subprocess workers against the same `tmp_path` vault, fires a deadline-kill in worker A on a fake-hanging git, then issues a `vault_patch` in worker B; worker B's call completes within `deadline + grace + drain + 5s` total (currently 60+2+5+5 = 72s budget). Marked `@pytest.mark.cross_worker`, excluded from default `make test`.
+- [ ] **AC-8**: `vault_health(include_runtime=True)` runtime block gains `lock_eviction_count_30d` (rolling daily counter persisted to `~/.local/share/hive/lock_evictions.db`) and `last_lock_eviction_iso` (ISO-8601 of most recent eviction or null). Tests: trigger an eviction, assert both fields populate; restart hive, assert counter persists.
+- [ ] **AC-9**: `_compat.GHOST_RESPONSES.snapshot().by_source` continues to discriminate `deadline` vs `cancellation` (unchanged from HIVE-115); no new source tags introduced by this spec. Regression-only check.
+- [ ] **AC-10**: CI matrix lane `os: [ubuntu-latest, windows-latest]` runs `tests/test_cross_worker_lock.py` and `tests/test_compat_shim.py::test_classify_cancellation_race`. Lane non-blocking (allowed-to-fail) for the first 14 days post-merge to surface flake patterns without blocking releases; AFTER that window, promoted to required (HIVE-117 follow-up to flip the bit).
+- [ ] **AC-11**: Documentation site (EN + ES) gains a new "Troubleshooting > Partial-state writes after deadline" page. Recipes: how to detect via `git status`, how to interpret the new response suffix, when to retry vs. when to verify with `vault_query`. Bilingual sync verified by existing CI parity check.
+- [ ] **AC-12**: One new ADR drafted in vault: `[[adr-012-cooperative-filelock-eviction-on-deadline]]`. One new lesson: `[[lesson-cancel-a-thread-you-cannot]]` (re-uses [[lesson-three-timeouts-chain-not-deadline]] as foundation; this is the corollary that motivates eviction). One amendment to `[[adr-008-hard-deadline-enforcement]]` documenting the post-kill drain + eviction step.
+- [ ] **AC-13**: All three PRs (QW, root-cause, cross-OS) ship as Conventional Commits so release-please drives the version bumps automatically. Target versions: v1.20.0 (QW), v1.21.0 (root-cause), v1.22.0 (cross-OS test lane).
+
+## References
+
+- Issue: [#141](https://github.com/mlorentedev/hive/issues/141) — original report + 2nd-session reproduction comment
+- Vault backlog: `10_projects/hive/11-tasks.md` (HIVE-116 entry, 2026-05-27)
+- Prior spec (archived): `specs/archive/HIVE-115-latency-tail-redesign/` — context for `bounded_call`, `_run_git`, `tool_span`, `_compat.GHOST_RESPONSES.by_source`
+- ADRs (vault): [[adr-008-hard-deadline-enforcement]] (amendment target), [[adr-009-multi-process-wal-policy]] (referenced — unchanged), [[adr-010-external-committer-coexistence]] (referenced — unchanged), [[adr-012-cooperative-filelock-eviction-on-deadline]] (new, drafted in T-12)
+- Lessons (vault): [[lesson-three-timeouts-chain-not-deadline]] (foundation), [[lesson-cancel-a-thread-you-cannot]] (new, drafted in T-12)
+- Patterns (vault): [[pattern-multi-process-mcp-server]] (extended with eviction primitive), [[pattern-phased-redesign-with-telemetry-gates]]
+- Code surface (read by spec author 2026-05-27):
+  - `src/hive/_helpers.py:992-1060` — `_git_commit` filelock + threading-lock composition
+  - `src/hive/_helpers.py:777-797` — `_git_filelock` singleton cache (eviction target)
+  - `src/hive/_helpers.py:705-737` — `_filelock_with_telemetry` (CM exit path)
+  - `src/hive/_helpers.py:857-883` — `run_sync_tool` (partial-state hook injection point)
+  - `src/hive/_deadline.py:201-258` — `bounded_call` supervisor (drain + eviction extension target)
+  - `src/hive/_vault_write.py:36-77` — `_commit_status_suffix` (partial-state suffix sibling)
+- TDD discipline: [[pattern-testing-standards]] — red-green-refactor, pytest, `caplog`, `tmp_path`, parametrize

--- a/specs/HIVE-116-stale-lock-after-deadline/tasks.md
+++ b/specs/HIVE-116-stale-lock-after-deadline/tasks.md
@@ -1,0 +1,96 @@
+---
+id: "HIVE-116-tasks"
+type: spec-tasks
+status: draft
+created: "2026-05-27"
+tags: [spec, tasks]
+template_version: "1.0"
+---
+
+# HIVE-116 — Tasks
+
+> TDD ordering: red (test first), green (implementation), refactor.
+> Each task lists its target file(s), AC mapping, and a one-line Done-when.
+> Phase boundaries are PR boundaries — each phase lands as one Conventional Commit PR + one release-please bump.
+
+## Phase 0 — Spec & TDD Red (no implementation)
+
+- **T-0.1** Draft proposal.md / tasks.md / verification.md, this spec. Already done if you are reading this. AC: structural only.
+- **T-0.2** **[USER-DECIDED 2026-05-27]** Partial-state response contract locked. Add this exact constant to `src/hive/_vault_write.py` next to `_DEFERRED_SUFFIX` / `_UNCOMMITTED_SUFFIX`:
+  ```python
+  _PARTIAL_STATE_SUFFIX = (
+      " (partial state — disk write succeeded, "
+      "git commit killed by deadline; verify with vault_query "
+      "before retrying)"
+  )
+  ```
+  String-only, no JSON-shape extension. Downstream pattern-match key: literal substring `"partial state — disk write succeeded"`. Unblocks T-1.4. AC-5 wording.
+- **T-0.3** Write failing test `tests/test_cross_worker_lock.py::test_evict_filelock_on_deadline` with the desired green behaviour: 2 workers, fake-hanging git, worker B unblocks within budget. Mark `@pytest.mark.cross_worker` + `@pytest.mark.skip(reason="HIVE-116 T-2.x not yet green")`. AC-7 prep.
+- **T-0.4** Write failing test `tests/test_run_git.py::test_external_termination_synthetic_stderr` — spawn `subprocess.Popen(["sleep","60"])`, terminate from outside, assert `_run_git` (or its testable helper) returns the synthetic stderr shape. Currently fails because the synthetic-stderr branch does not exist. AC-3 prep.
+- **T-0.5** Write failing test `tests/test_vault_write.py::test_partial_state_suffix_on_deadline` — mock `_git_commit` to raise `TimeoutError` after the FS write lands, assert `vault_write` response carries the `_PARTIAL_STATE_SUFFIX` (placeholder until T-0.2 sets the wording). AC-5 prep.
+- **T-0.6** Run `make test` — every new test from T-0.3..T-0.5 must FAIL for the expected reason (not collection error, not import error). Capture failure output as evidence of Red phase. **Done when:** `pytest -k "evict_filelock or external_termination or partial_state_suffix" --no-header -q` shows 3 fails / 0 passes / 0 errors.
+
+## Phase 1 — Quick Wins (PR-1, target v1.20.0, ~120 LOC)
+
+Scope: log enrichment + partial-state suffix. No supervisor changes, no filelock eviction. Lands first because it's the user-facing observability fix and unblocks the second-session repro debugging.
+
+- **T-1.1** Add `RC_EXTERNAL_TERMINATION = -1` named constant near top of `src/hive/_helpers.py`. Replace the magic `-1` in `_run_git` (line 981) with the constant. Mechanical. AC-3 prep.
+- **T-1.2** In `_run_git`, when `proc.communicate()` raises `BrokenPipeError`/`OSError`, build the synthetic stderr `"[external_termination] killed by supervisor at <ts>; original stderr: <empty|<N> bytes>"` and return it as the stderr text. Preserve original stderr bytes when present. **File:** `src/hive/_helpers.py:960-989`. AC-3.
+- **T-1.3** Update both warning logs in `_git_commit` (lines 1039-1049) to include `cause=external_termination` when `rc == RC_EXTERNAL_TERMINATION`, `cause=git_error` otherwise. Same change in `_git_commit_all` (lines 1091-1099) — three Popens, three warning sites. **File:** `src/hive/_helpers.py`. AC-4.
+- **T-1.4** Add the user-decided `_PARTIAL_STATE_SUFFIX` constant to `src/hive/_vault_write.py` (from T-0.2). Wire it into `_commit_status_suffix` as a fourth branch: when the caller passes a new `deadline_killed: bool = False` flag, return the partial-state suffix regardless of `requested_commit` / `deferred`. **File:** `src/hive/_vault_write.py:60-76`. AC-5.
+- **T-1.5** Thread the `deadline_killed` flag through `_git_commit` → returns a tuple `(committed: bool, deadline_killed: bool)` instead of returning `None`. Three callers in `_vault_write.py` need to capture the tuple. Backward compatibility: not a public function, no shim needed. AC-5.
+- **T-1.6** Add a per-tool partial-state hook to `run_sync_tool`. Signature: `partial_state_hook: Callable[[str], str] | None = None`. For `vault_write` and `vault_patch`, pass a hook that, on `TimeoutError`, checks `_git_commit`'s last-known partial-state record via a thread-local and returns the partial-state message instead of the generic "timed out" string. For all other tools, hook is `None`, fallback behavior unchanged. **File:** `src/hive/_helpers.py:857-883`. AC-6.
+- **T-1.7** Make T-0.4 and T-0.5 turn green. Verify T-0.3 still fails (gated on Phase 2). **Done when:** `pytest -k "external_termination or partial_state_suffix"` passes; cross-worker test still skipped.
+- **T-1.8** Update EN+ES docs site: new section under `docs/troubleshooting.md` (and ES mirror) titled "Partial-state writes after deadline". Include the new suffix wording verbatim + git status recovery recipe. AC-11.
+- **T-1.9** Conventional Commit PR. Title: `feat(hive): observable partial-state writes + structured subprocess termination logs (HIVE-116 PR-1)`. Body references issue #141. Triggers release-please for v1.20.0. AC-13.
+
+## Phase 2 — Root cause: filelock eviction on deadline (PR-2, target v1.21.0, ~150 LOC)
+
+Scope: extend `bounded_call` and `tool_span` to evict the cached filelock after the post-kill drain window. Adds the new env var. Adds the new persisted counter. Lands the cross-worker test as the green proof.
+
+- **T-2.1** Add `HIVE_POST_KILL_DRAIN_S` to `HiveSettings` (`src/hive/config.py`). **Default 5.0 (user-confirmed 2026-05-27)**, pydantic validator constrains to [0.5, 30.0]. Test in `tests/test_config.py`: valid + invalid values. AC-2.
+- **T-2.2** Add `evict_filelock(vault_path: Path) -> bool` helper to `src/hive/_helpers.py`. Returns True if eviction happened, False if nothing was cached. Pops from `_GIT_FILELOCKS` under `_GIT_FILELOCKS_GUARD`. Idempotent. AC-1 helper.
+- **T-2.3** In `_deadline.bounded_call` post-kill branch (after `_terminate_registry`, before `_cleanup_index_lock`), add `await asyncio.sleep(settings.post_kill_drain_s)` then call `evict_filelock(vault_for_index_cleanup)` if any PID was killed. Same insertion in `tool_span` so both supervisors share the eviction step. **Files:** `src/hive/_deadline.py:235-253`, `src/hive/_helpers.py:826-849`. AC-1.
+- **T-2.4** New persistent counter `LockEvictionTracker` in `src/hive/_lock_eviction.py` extending `_SqliteTracker`. DB at `~/.local/share/hive/lock_evictions.db`. Schema: `(iso_ts TEXT PRIMARY KEY, vault_path TEXT, killed_pids_json TEXT)`. Methods: `record(vault, killed_pids)`, `count_last_30d()`, `last_iso()`. AC-8.
+- **T-2.5** Wire `LockEvictionTracker` into `ServerContext` and instantiate in `create_server()` (mirrors `RelevanceTracker`, `LessonReinforcementTracker`). Call `record()` from `bounded_call` immediately after `evict_filelock` returns True. AC-8.
+- **T-2.6** Extend `_vault_health.runtime_block_text` to surface `lock_eviction_count_30d` + `last_lock_eviction_iso`. Test: trigger eviction via cross-worker harness, assert health block reports the count++. AC-8.
+- **T-2.7** Promote T-0.3 from skip → run. Implement the fake-hanging-git fixture in `tests/conftest.py`: a script at `tmp_path / "fake-git"` that sleeps 120s when invoked with `add`, returns 0 otherwise. Prepend tmp_path to PATH for the test. Assert worker B's `vault_patch` completes within `deadline_s + grace_s + drain_s + slack=5s`. AC-7.
+- **T-2.8** Calibration sub-task: run T-0.3 with `HIVE_POST_KILL_DRAIN_S ∈ {1, 5, 10}` × `runs=20`. Record `unblocked_within_ms.p99` per drain value. Pick the smallest drain whose p99 < 35s. Document the chosen default in `_deadline.py` docstring + the new ADR. AC-2 / R2.
+- **T-2.9** Add `mcp.lock_eviction.race` WARNING log: 1s after eviction, if the evicted FileLock object reports `is_locked == True`, emit the warning + bump a new `vault_health.runtime.lock_eviction_race_count` field. Test: race the eviction by gripping a held lock and calling `evict_filelock`; assert log + counter. AC-1 / R1.
+- **T-2.10** Draft ADR-012 in vault: `30-architecture/adr-012-cooperative-filelock-eviction-on-deadline.md`. Cover: why eviction is needed (R1 worker-thread cannot be preempted), why post-kill-drain not pre-kill (avoids racing the supervisor's own SIGTERM grace), why a per-process singleton cache stays (perf — only the affected vault's entry is evicted). Cross-link to lesson + amendment. AC-12.
+- **T-2.11** Amend ADR-008 with a new §5 "Cooperative-lock eviction": link to ADR-012, note the contract change (deadline now evicts cooperative locks; supervisor is the only safe eviction point). AC-12.
+- **T-2.12** Capture lesson `lesson-cancel-a-thread-you-cannot.md` in vault `10_projects/hive/90-lessons.md`. Body: 60-90 lines on why Python thread cancellation is impossible and the cooperative-eviction pattern it forces. AC-12.
+- **T-2.13** Conventional Commit PR. Title: `fix(hive): evict cooperative filelock on deadline to unblock sibling workers (HIVE-116 PR-2)`. Body cross-references PR-1 + issue #141. Triggers release-please for v1.21.0. AC-13.
+
+## Phase 3 — Cross-OS validation (PR-3, target v1.22.0, ~50 LOC + CI config)
+
+Scope: lift the cross-worker test from `cross_worker` marker into the actual CI matrix on both Linux and Windows. Audit policy: opt-in for 14 days, then promote to required via HIVE-117 (out of scope).
+
+- **T-3.1** Edit `.github/workflows/ci.yml` (or equivalent) to add a job `cross_worker_lock` with matrix `os: [ubuntu-latest, windows-latest]`. Continue-on-error: true (allowed-to-fail) for first 14 days. AC-10.
+- **T-3.2** Re-run T-2.7 on Windows manually before merging — Windows filelock semantics may diverge per R1. If `mcp.lock_eviction.race` fires consistently on Windows, escalate: add a `time.sleep(0.1)` between eviction and the next acquire (Windows file-handle release is not synchronous). Document the choice. R1.
+- **T-3.3** Update `tests/test_compat_shim.py::test_classify_cancellation_race` skip-marker to ALSO run on the Windows lane (currently Linux-only per file docstring lines 4-5). Verify the existing flake tolerance (subprocess flooding) doesn't tank the new lane. AC-10.
+- **T-3.4** Document the new CI lane in `CONTRIBUTING.md` + the EN+ES docs site "Multi-session coexistence" page. AC-11.
+- **T-3.5** Conventional Commit PR. Title: `ci(hive): cross-OS test lane for filelock eviction + cancellation race (HIVE-116 PR-3)`. Triggers release-please for v1.22.0. AC-13.
+
+## Post-ship
+
+- **T-9.1** Open follow-up issue: "Promote `cross_worker_lock` job to required after 14d observation (HIVE-117)" — owner gets reminded via the existing belt-and-braces pattern (issue + routine + dated TODO; see [[pattern-triple-reminder-belt-and-braces]]).
+- **T-9.2** Archive `specs/HIVE-116-stale-lock-after-deadline/` to `specs/archive/` via a `chore(spec)` PR. Mirror HIVE-104, HIVE-115 archival pattern.
+- **T-9.3** Update vault `10_projects/hive/11-tasks.md`: tick HIVE-116 as DONE, paste the three PR links + version tags. Note the 2026-06-05 Phase C checkpoint (#124) now has additional data: post-eviction `_compat.GHOST_RESPONSES.by_source["deadline"]` count.
+- **T-9.4** Close issue #141 with a comment summarizing the fix and linking to the three release notes.
+
+## Risks called out in proposal.md, mapped to tasks
+
+| Risk | Mitigation task |
+|------|----------------|
+| R1 worker-thread escape race | T-2.9 race-warning log + counter; T-3.2 Windows-specific calibration |
+| R2 drain-default calibration | T-2.8 (parametric sweep 1/5/10s × 20 runs) |
+| R3 partial-state wording = public contract | T-0.2 USER decides; blocks T-1.4 |
+| R4 Windows CI flake | T-3.1 continue-on-error 14d; T-3.3 retry policy = none |
+| R5 Outbox interaction | T-2.7 cross-worker harness exercises `capture_lesson` path (uses Outbox internally) |
+
+## Dependencies between phases
+
+- Phase 1 may ship without Phase 2 — the user-visible improvements (logs + partial-state suffix) are independently valuable.
+- Phase 2 depends on T-0.2 (user contract decision) being merged into the Phase 1 PR before Phase 2 starts implementing AC-5's full shape.
+- Phase 3 depends on Phase 2 being green on Linux first (else the new CI lane has nothing to verify).

--- a/specs/HIVE-116-stale-lock-after-deadline/verification.md
+++ b/specs/HIVE-116-stale-lock-after-deadline/verification.md
@@ -1,0 +1,194 @@
+---
+id: "HIVE-116-verification"
+type: spec-verification
+status: draft
+created: "2026-05-27"
+tags: [spec, verification]
+template_version: "1.0"
+---
+
+# HIVE-116 — Verification
+
+> Per AC: exact pytest invocation, expected output marker, and (where relevant) the manual Windows-smoke recipe. Run order matches `tasks.md` phase order; do not skip ahead.
+
+## Pre-flight (clean baseline)
+
+```bash
+make check
+# Expect: ruff clean / mypy --strict clean / pytest 0 fails
+git status
+# Expect: working tree clean
+```
+
+If `make check` fails on master before any HIVE-116 work, STOP — fix master first or abandon this spec until baseline is green.
+
+## AC-1: filelock evicted on deadline
+
+```bash
+uv run pytest tests/test_cross_worker_lock.py::test_evict_filelock_on_deadline -v
+```
+
+Expect: PASS within `deadline_s + grace_s + drain_s + 5s` (default 60+2+5+5 = 72s wall time).
+Expect log line `mcp.lock_eviction lock=_git_filelock vault=<tmp_path> killed_pids=[N]` exactly once.
+
+Manual Windows smoke (post-PR-2):
+1. Launch 2 Claude Code sessions pointed at the same Windows vault.
+2. From session A: trigger a slow `vault_patch` (use a fake `git.bat` in PATH that sleeps).
+3. Wait for the 60s deadline + 5s drain.
+4. From session B: call `vault_patch` on any other file.
+5. Expect session B's call completes within ~5s, NOT timeout.
+6. Inspect `%LOCALAPPDATA%\hive\lock_evictions.db`: one row, ISO ≈ now.
+
+## AC-2: HIVE_POST_KILL_DRAIN_S env var
+
+```bash
+uv run pytest tests/test_config.py -k post_kill_drain -v
+```
+
+Expect: 4 parametrized cases — `0.5` ok, `5.0` ok (default), `30.0` ok, `0.1` raises ValueError, `60.0` raises ValueError. 5 passes, 0 fails.
+
+## AC-3: synthetic stderr on external termination
+
+```bash
+uv run pytest tests/test_run_git.py::test_external_termination_synthetic_stderr -v
+```
+
+Expect: assertion that stderr matches `r"^\[external_termination\] killed by supervisor at \d{4}-\d{2}-\d{2}T.*; original stderr: (empty|\d+ bytes)$"`.
+
+## AC-4: cause= tag in warning logs
+
+```bash
+uv run pytest tests/test_helpers.py::test_git_commit_warning_carries_cause -v
+```
+
+Expect: 2 cases (external_termination, git_error); `caplog.records` contains `"cause=external_termination"` exactly once for the kill case, `"cause=git_error"` exactly once for the rc=1 case.
+
+## AC-5: partial-state suffix in write tools
+
+```bash
+uv run pytest tests/test_vault_write.py -k partial_state -v
+```
+
+Expect: 4 parametrized cases — committed (no suffix), uncommitted (existing `_UNCOMMITTED_SUFFIX`), deferred (existing `_DEFERRED_SUFFIX`), deadline-killed (new `_PARTIAL_STATE_SUFFIX`).
+
+Manual contract probe (one-shot after T-1.4 lands):
+```bash
+echo "import json; from hive._vault_write import _PARTIAL_STATE_SUFFIX, _DEFERRED_SUFFIX, _UNCOMMITTED_SUFFIX; print(json.dumps({'partial': _PARTIAL_STATE_SUFFIX, 'deferred': _DEFERRED_SUFFIX, 'uncommitted': _UNCOMMITTED_SUFFIX}, indent=2))" | uv run python -
+```
+
+Expect: three distinct strings; partial-state string matches the wording the user signed off in T-0.2.
+
+## AC-6: per-tool partial-state hook routing
+
+```bash
+uv run pytest tests/test_helpers.py::test_run_sync_tool_partial_state_hook -v
+```
+
+Expect: 2 cases — `vault_write` deadline → partial-state message; `vault_query` deadline → generic "timed out" message (unchanged).
+
+## AC-7: cross-worker integration (THE money test)
+
+```bash
+uv run pytest tests/test_cross_worker_lock.py -m cross_worker -v --timeout=120
+```
+
+Expect: 1 pass, wall time < 75s. If wall time exceeds 90s, the eviction did not fire — investigate `_GIT_FILELOCKS` cache + `evict_filelock` log.
+
+CI verification (post-PR-3):
+- GitHub Actions run for the new `cross_worker_lock` job shows green on `ubuntu-latest`.
+- `windows-latest` lane: allowed-to-fail for first 14d; check the job log for `mcp.lock_eviction.race` warnings — should be 0 in 20 consecutive runs.
+
+## AC-8: vault_health surfaces eviction counter
+
+```bash
+# After triggering at least one eviction via AC-7:
+uv run python -c "from hive._context import build_context; ctx = build_context(); print(ctx.lock_eviction.count_last_30d(), ctx.lock_eviction.last_iso())"
+```
+
+Expect: count ≥ 1, ISO timestamp within the last hour.
+
+```bash
+# Health block:
+uv run pytest tests/test_vault_health.py::test_runtime_block_includes_lock_eviction -v
+```
+
+Expect: `lock_eviction_count_30d` and `last_lock_eviction_iso` present in the runtime block dict.
+
+Persistence check:
+```bash
+# Restart hive, re-read the counter:
+sqlite3 ~/.local/share/hive/lock_evictions.db "SELECT COUNT(*) FROM lock_evictions WHERE iso_ts > datetime('now', '-30 days')"
+```
+
+Expect: matches the value from the prior step.
+
+## AC-9: GHOST_RESPONSES.by_source regression
+
+```bash
+uv run pytest tests/test_compat_shim.py -k by_source -v
+```
+
+Expect: no new source tag introduced; `deadline` + `cancellation` are still the only two.
+
+## AC-10: CI matrix lane
+
+After PR-3 merges and Dependabot runs once:
+- Inspect the GitHub Actions run page for the most recent push to master.
+- `cross_worker_lock (ubuntu-latest)` — expected GREEN.
+- `cross_worker_lock (windows-latest)` — allowed-to-fail; investigate logs but DO NOT block release on it for first 14d.
+
+## AC-11: docs site EN+ES parity
+
+```bash
+make site
+# Then manually visit /troubleshooting/ and /es/troubleshooting/
+```
+
+Expect: both languages have "Partial-state writes after deadline" section. Line count parity within ±5 lines per the existing bilingual link-validator CI.
+
+## AC-12: ADRs + lesson committed to vault
+
+```bash
+ls ~/Projects/knowledge/10_projects/hive/30-architecture/adr-012-cooperative-filelock-eviction-on-deadline.md
+ls ~/Projects/knowledge/10_projects/hive/90-lessons.md  # check for [2026-XX-XX] lesson-cancel-a-thread-you-cannot heading
+grep -l "Cooperative-lock eviction" ~/Projects/knowledge/10_projects/hive/30-architecture/adr-008-hard-deadline-enforcement.md
+```
+
+Expect: all three commands return paths/matches without error.
+
+## AC-13: release-please bumps versions correctly
+
+Post-PR-1 merge:
+- release-please opens a PR for `v1.20.0` with HIVE-116 PR-1 in the changelog.
+- After that release PR merges, PyPI tag `v1.20.0` lands within 30 minutes.
+
+Same shape for PR-2 → `v1.21.0` and PR-3 → `v1.22.0`. Verify via:
+```bash
+gh release list --repo mlorentedev/hive --limit 5
+```
+
+## Final regression sweep
+
+After all three PRs merge:
+```bash
+make check
+uv run pytest -m "not smoke and not cross_worker" --cov=hive --cov-report=term-missing
+uv run pytest -m cross_worker --timeout=120
+```
+
+Expect:
+- `make check` green (ruff + mypy + default pytest).
+- Coverage ≥ 90% (per HIVE-104 baseline; this spec must not regress coverage).
+- cross_worker tests pass within their budget.
+
+## Field validation (post v1.22.0 on real vault)
+
+Run the live Windows session that originally reproduced issue #141:
+1. Two Claude Code sessions, same vault, obsidian-git active.
+2. Issue a deliberately slow `vault_patch` via a 174 MB vault (the original repro shape).
+3. After 60s deadline kill in session A, immediately `vault_patch` from session B on a different file.
+4. Expect: session B succeeds within ~10s.
+5. Expect: `.git/hive.lock` still exists as a 0-byte file (Windows file-handle invariant — unchanged), but `_GIT_FILELOCKS[<vault>]` is no longer cached and the next acquire creates a fresh FileLock.
+6. Expect: `vault_health(include_runtime=True)` reports `lock_eviction_count_30d >= 1`.
+
+If field validation passes, comment on issue #141 with the result + close. If it fails, reopen this spec with a new ADR-013 covering the residual failure mode.

--- a/src/hive/_helpers.py
+++ b/src/hive/_helpers.py
@@ -16,7 +16,7 @@ import threading
 import time
 from collections import deque
 from contextlib import asynccontextmanager, contextmanager
-from datetime import date
+from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING
 
 import filelock
@@ -35,6 +35,84 @@ if TYPE_CHECKING:
 _log = logging.getLogger(__name__)
 
 _REJECT_MSG = "The host should handle this task directly."
+
+# HIVE-116 AC-3: named return code for Popens terminated by the supervisor.
+# Replaces the bare ``-1`` used at multiple sites; gives operators + the
+# partial-state hook (HIVE-116 AC-6) a one-grep predicate.
+RC_EXTERNAL_TERMINATION: int = -1
+
+
+def synthesize_external_termination_stderr(original_stderr: bytes) -> str:
+    """Format the synthetic stderr returned by :func:`_run_git` on external kill.
+
+    HIVE-116 AC-3. Shape:
+
+    ``"[external_termination] killed by supervisor at <ISO-8601>; original
+    stderr: (empty|<N> bytes)"``
+
+    The ISO-8601 timestamp is UTC with offset suffix (`+00:00`). Callers
+    that need to grep across worker logs use the literal prefix
+    ``[external_termination]`` — the rest of the line is informational.
+    """
+    ts = datetime.now(UTC).isoformat(timespec="seconds")
+    n = len(original_stderr)
+    detail = "empty" if n == 0 else f"{n} bytes"
+    return (
+        f"[external_termination] killed by supervisor at {ts} ; "
+        f"original stderr: {detail}"
+    )
+
+
+# HIVE-116 AC-5/AC-6: contextvar threading partial-state signals from the
+# write tool to the deadline supervisor. Set by ``run_sync_tool`` for the
+# write tools (``vault_write`` / ``vault_patch``) so:
+#   - the write handler can mark "disk write completed" after the file is
+#     persisted but before ``_git_commit`` returns;
+#   - ``_git_commit`` can mark "deadline killed" when it sees an externally-
+#     terminated Popen;
+#   - on supervisor TimeoutError, ``run_sync_tool`` reads the dict to format
+#     the partial-state response instead of the generic "timed out" string.
+# The CV value is the *same dict reference* in the awaiting coroutine and
+# the to_thread worker (CPython propagates the context).
+_PARTIAL_STATE_CV: contextvars.ContextVar[dict[str, bool] | None] = (
+    contextvars.ContextVar("_PARTIAL_STATE", default=None)
+)
+
+# Tools that opt in to partial-state response formatting. Read-path tools
+# (``vault_query``, ``vault_search``, ``vault_health``) keep the generic
+# timeout response since they have no disk-write side-effect.
+_PARTIAL_STATE_TOOLS: frozenset[str] = frozenset(
+    {"vault_write", "vault_patch"},
+)
+
+
+def mark_disk_write_done() -> None:
+    """Signal that the partial-state CV write tool's FS write completed.
+
+    No-op when the CV is not set (i.e. tool is not in
+    :data:`_PARTIAL_STATE_TOOLS`, or the call is outside ``run_sync_tool``).
+    """
+    state = _PARTIAL_STATE_CV.get()
+    if state is not None:
+        state["disk_write_done"] = True
+
+
+def mark_deadline_killed() -> None:
+    """Signal that ``_run_git`` saw an externally-terminated Popen.
+
+    No-op when the CV is not set.
+    """
+    state = _PARTIAL_STATE_CV.get()
+    if state is not None:
+        state["deadline_killed"] = True
+
+
+def get_partial_state() -> dict[str, bool] | None:
+    """Snapshot the partial-state CV; None when not active."""
+    state = _PARTIAL_STATE_CV.get()
+    if state is None:
+        return None
+    return dict(state)
 
 
 def project_not_found(project: str) -> str:
@@ -854,6 +932,17 @@ async def tool_span(
         _GIT_REGISTRY_CV.reset(token)
 
 
+_GENERIC_TIMEOUT_FMT = (
+    "{tool} timed out after {timeout:.0f}s. "
+    "Server may be under load or a lock is contended; retry shortly."
+)
+_PARTIAL_STATE_TIMEOUT_FMT = (
+    "{tool} timed out after {timeout:.0f}s — partial state: "
+    "disk write succeeded, git commit killed by deadline; "
+    "verify with vault_query before retrying."
+)
+
+
 async def run_sync_tool(
     tool_name: str,
     timeout_seconds: float,
@@ -870,17 +959,39 @@ async def run_sync_tool(
     subprocess; the thread eventually returns and its late ``respond()``
     call is silenced by the ``_compat`` shim.
 
+    HIVE-116 AC-6: write tools (``vault_write`` / ``vault_patch``) opt into
+    a partial-state response via :data:`_PARTIAL_STATE_CV`. The CV holds a
+    dict the to_thread worker mutates as it progresses; on TimeoutError
+    the awaiter reads the dict and surfaces the partial-state message when
+    the disk write landed before the kill (so the calling agent does not
+    retry blindly and double-write).
+
     Returns a user-visible error string on timeout instead of propagating
     so the MCP client sees a normal tool response.
     """
+    state_token: contextvars.Token[dict[str, bool] | None] | None = None
+    if tool_name in _PARTIAL_STATE_TOOLS:
+        state_token = _PARTIAL_STATE_CV.set(
+            {"disk_write_done": False, "deadline_killed": False},
+        )
     try:
         async with tool_span(tool_name, timeout_seconds):
             return await asyncio.to_thread(fn, *args, **kwargs)
     except TimeoutError:
-        return (
-            f"{tool_name} timed out after {timeout_seconds:.0f}s. "
-            "Server may be under load or a lock is contended; retry shortly."
+        if (
+            state_token is not None
+            and (state := _PARTIAL_STATE_CV.get()) is not None
+            and state.get("disk_write_done")
+        ):
+            return _PARTIAL_STATE_TIMEOUT_FMT.format(
+                tool=tool_name, timeout=timeout_seconds,
+            )
+        return _GENERIC_TIMEOUT_FMT.format(
+            tool=tool_name, timeout=timeout_seconds,
         )
+    finally:
+        if state_token is not None:
+            _PARTIAL_STATE_CV.reset(state_token)
 
 
 def wrap_sync_tool(
@@ -968,17 +1079,33 @@ def _run_git(
         registry.append(proc)
     stdout_b: bytes = b""
     stderr_b: bytes = b""
+    externally_terminated = False
     try:
         try:
             stdout_b, stderr_b = proc.communicate()
         except (BrokenPipeError, OSError) as exc:
             # External termination by bounded_call / tool_span.
             _log.debug("git %s: external termination (%s)", args[0], exc)
+            externally_terminated = True
             with contextlib.suppress(subprocess.SubprocessError, OSError):
                 # Best-effort drain of whatever the kernel buffered before
-                # the kill. Failures here are unrecoverable; we return -1.
+                # the kill. Failures here are unrecoverable.
                 stdout_b, stderr_b = proc.communicate()
-        rc = proc.returncode if proc.returncode is not None else -1
+        rc = (
+            proc.returncode
+            if proc.returncode is not None
+            else RC_EXTERNAL_TERMINATION
+        )
+        # HIVE-116 AC-3: an external-termination rc must be remapped from
+        # whatever the OS reported (Linux SIGTERM = -15, Windows = 1) to
+        # our named sentinel so callers can predicate on the constant. The
+        # synthetic stderr replaces the (often empty) original.
+        if externally_terminated:
+            stderr_b = synthesize_external_termination_stderr(
+                stderr_b or b"",
+            ).encode("utf-8")
+            rc = RC_EXTERNAL_TERMINATION
+            mark_deadline_killed()
     finally:
         if registry is not None and proc in registry:
             registry.remove(proc)
@@ -1036,16 +1163,26 @@ def _git_commit(
             with _filelock_with_telemetry(_git_filelock(vault_path), "_git_filelock"):
                 rc, _, err = _run_git(["add", *path_strs], vault_path)
                 if rc != 0:
+                    cause = (
+                        "external_termination"
+                        if rc == RC_EXTERNAL_TERMINATION
+                        else "git_error"
+                    )
                     _log.warning(
-                        "git add failed for %s rc=%s err=%s",
-                        path_strs, rc, err.strip(),
+                        "git add failed for %s rc=%s cause=%s err=%s",
+                        path_strs, rc, cause, err.strip(),
                     )
                     return
                 rc, _, err = _run_git(["commit", "-m", safe_msg], vault_path)
                 if rc != 0:
+                    cause = (
+                        "external_termination"
+                        if rc == RC_EXTERNAL_TERMINATION
+                        else "git_error"
+                    )
                     _log.warning(
-                        "git commit failed for %s rc=%s err=%s",
-                        path_strs, rc, err.strip(),
+                        "git commit failed for %s rc=%s cause=%s err=%s",
+                        path_strs, rc, cause, err.strip(),
                     )
         except filelock.Timeout:
             _log.warning(

--- a/src/hive/_vault_write.py
+++ b/src/hive/_vault_write.py
@@ -19,6 +19,8 @@ from hive._helpers import (
     _vault_guard,
     detect_obsidian_git,
     format_io_error,
+    get_partial_state,
+    mark_disk_write_done,
     project_not_found,
     track,
     vault_write_lock,
@@ -56,12 +58,31 @@ _DEFERRED_SUFFIX = (
 )
 _UNCOMMITTED_SUFFIX = " (uncommitted — call vault_commit to flush)"
 
+# HIVE-116 AC-5: public contract for the partial-state response. Locked
+# 2026-05-27 per ``specs/HIVE-116-stale-lock-after-deadline/proposal.md``
+# R3 resolution. Downstream agents key off the stable substring
+# ``"partial state — disk write succeeded"``; wording rotations may occur
+# in later minor versions but that prefix MUST remain.
+_PARTIAL_STATE_SUFFIX = (
+    " (partial state — disk write succeeded, "
+    "git commit killed by deadline; verify with vault_query "
+    "before retrying)"
+)
 
-def _commit_status_suffix(requested_commit: bool, deferred: bool) -> str:
+
+def _commit_status_suffix(
+    requested_commit: bool,
+    deferred: bool,
+    *,
+    deadline_killed: bool = False,
+) -> str:
     """Format the trailing response suffix for write tools.
 
-    Three states feed into one line:
+    Four states feed into one line; ``deadline_killed`` dominates:
 
+    - ``deadline_killed=True`` (any other args) → partial-state suffix
+      (HIVE-116 AC-5; disk write landed but git commit was killed by
+      the deadline supervisor).
     - ``requested_commit=False`` → uncommitted (caller must
       ``vault_commit`` later). Unchanged from pre-PR-4 behaviour.
     - ``requested_commit=True, deferred=True`` → obsidian-git is healthy
@@ -69,11 +90,19 @@ def _commit_status_suffix(requested_commit: bool, deferred: bool) -> str:
     - ``requested_commit=True, deferred=False`` → hive committed inline;
       empty suffix.
     """
+    if deadline_killed:
+        return _PARTIAL_STATE_SUFFIX
     if not requested_commit:
         return _UNCOMMITTED_SUFFIX
     if deferred:
         return _DEFERRED_SUFFIX
     return ""
+
+
+def _was_deadline_killed() -> bool:
+    """True when the partial-state CV records a deadline-driven git kill."""
+    state = get_partial_state()
+    return bool(state and state.get("deadline_killed"))
 
 
 def _should_defer_to_external_committer(vault_path: Path) -> bool:
@@ -205,6 +234,7 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                             format_io_error(exc, path, "create"),
                             project,
                         )
+                    mark_disk_write_done()
 
                     rel = filepath.relative_to(ctx.vault)
                     display = "00_meta" if project == "_meta" else project
@@ -224,7 +254,9 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                     project,
                 )
 
-            suffix = _commit_status_suffix(commit, should_defer)
+            suffix = _commit_status_suffix(
+                commit, should_defer, deadline_killed=_was_deadline_killed(),
+            )
             return track(
                 ctx, "vault_write",
                 f"Created {project}/{path} (type: {doc_type}).{suffix}",
@@ -279,6 +311,7 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                         format_io_error(exc, f"{project}/{section}", operation),
                         project,
                     )
+                mark_disk_write_done()
 
                 rel = filepath.relative_to(ctx.vault)
                 should_defer = (
@@ -297,7 +330,9 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                 project,
             )
 
-        suffix = _commit_status_suffix(commit, should_defer)
+        suffix = _commit_status_suffix(
+            commit, should_defer, deadline_killed=_was_deadline_killed(),
+        )
         return track(
             ctx, "vault_write",
             f"Updated {project}/{section} ({operation}).{suffix}",
@@ -429,6 +464,7 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                         format_io_error(exc, path, "write"),
                         project,
                     )
+                mark_disk_write_done()
 
                 rel = filepath.relative_to(ctx.vault)
                 n = len(patch_list)
@@ -449,7 +485,9 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
             )
 
         noun = "patch" if n == 1 else "patches"
-        suffix = _commit_status_suffix(commit, should_defer)
+        suffix = _commit_status_suffix(
+            commit, should_defer, deadline_killed=_was_deadline_killed(),
+        )
         return track(ctx, "vault_patch",
                      f"Applied {n} {noun} to {project}/{path}.{suffix}",
                      project, path)

--- a/tests/test_cross_worker_lock.py
+++ b/tests/test_cross_worker_lock.py
@@ -1,0 +1,62 @@
+"""TDD Red — HIVE-116 AC-7: cross-worker filelock eviction.
+
+Spec: ``specs/HIVE-116-stale-lock-after-deadline/proposal.md`` AC-7.
+
+When worker A hits a ``bounded_call`` deadline on a hung git subprocess,
+worker B's next ``vault_patch`` against the same vault must complete
+within ``deadline_s + grace_s + HIVE_POST_KILL_DRAIN_S + slack=5s``.
+
+This is the integration test that proves the post-kill filelock eviction
+actually unblocks sibling workers — the headline contract of HIVE-116 PR-2.
+
+**Skipped during Red phase.** Promoted to runnable in T-2.7 once
+``evict_filelock`` is wired into the supervisor and ``HIVE_POST_KILL_DRAIN_S``
+is honored. The eventual budget on the wall-clock assertion is the only
+sharp edge: must be tight enough that a regression (eviction not firing)
+falls outside the budget.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.cross_worker
+
+
+@pytest.mark.skip(
+    reason="HIVE-116 T-2.x not yet green; promoted to runnable in T-2.7",
+)
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only first pass; Windows variant lands in T-3.2",
+)
+@pytest.mark.asyncio
+async def test_evict_filelock_on_deadline(git_vault: Path) -> None:
+    """Worker B's vault_patch unblocks within budget after worker A's kill.
+
+    Setup:
+      1. Worker A spawns ``vault_patch`` against ``git_vault / file.md`` with
+         a fake-git on PATH that ``sleep 120`` on the ``add`` subcommand.
+      2. Worker A's ``bounded_call`` fires at deadline=2s, supervisor SIGTERMs.
+      3. After ``HIVE_POST_KILL_DRAIN_S`` (default 5s), supervisor evicts the
+         cached ``FileLock`` for ``git_vault`` from ``_GIT_FILELOCKS``.
+      4. Worker B issues ``vault_patch`` against ``git_vault / other.md``.
+      5. Worker B's call must complete within ``2 + 2 + 5 + 5 = 14s`` wall.
+
+    Currently fails because ``evict_filelock`` does not exist.
+    """
+    from hive._helpers import _GIT_FILELOCKS, evict_filelock  # noqa: F401
+
+    # Placeholder body — actual harness lands in T-2.7. The import above
+    # is the Red-phase signal: collection fails today because
+    # `evict_filelock` is not yet defined.
+    raise NotImplementedError(
+        "T-0.3 placeholder; full harness implemented in T-2.7",
+    )

--- a/tests/test_run_git.py
+++ b/tests/test_run_git.py
@@ -1,0 +1,117 @@
+"""TDD Red — HIVE-116 AC-3 + AC-4: external termination signalling.
+
+Spec: ``specs/HIVE-116-stale-lock-after-deadline/proposal.md`` AC-3, AC-4.
+
+When ``bounded_call`` / ``tool_span`` terminates a registered Popen
+mid-flight, the current behaviour is:
+
+- ``_run_git`` returns ``rc=-1, stdout="", stderr=""`` (magic ``-1``).
+- ``_git_commit`` logs ``WARNING git add failed for [...] rc=-1 err=`` —
+  empty err leaves the operator with no signal about *why*.
+
+After this spec:
+
+- AC-3: ``_run_git`` returns a synthetic stderr of the form
+  ``"[external_termination] killed by supervisor at <ISO-8601>; original
+  stderr: (empty|<N> bytes)"`` so log readers + the partial-state hook
+  can distinguish supervisor-kill from genuine git failure.
+- AC-4: ``_git_commit``'s warning log carries ``cause=external_termination``
+  when ``rc == RC_EXTERNAL_TERMINATION``, ``cause=git_error`` otherwise.
+
+This file unit-tests the synthesis primitives only. The full integration
+(supervisor kills Popen inside ``_run_git`` and the synthetic stderr
+propagates) lives in ``test_cross_worker_lock.py`` (T-2.7).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only first pass; Windows variant lands in T-3.2",
+)
+
+
+# ── AC-3 (a) — named constant exists ─────────────────────────────────────
+
+
+def test_rc_external_termination_constant_exists() -> None:
+    """``RC_EXTERNAL_TERMINATION = -1`` replaces the magic number in _run_git.
+
+    Red: constant not yet defined; ImportError on collection.
+    """
+    from hive._helpers import RC_EXTERNAL_TERMINATION
+
+    assert RC_EXTERNAL_TERMINATION == -1
+
+
+# ── AC-3 (b) — synthetic stderr shape ────────────────────────────────────
+
+
+_SYNTHETIC_STDERR_RE = re.compile(
+    r"^\[external_termination\] killed by supervisor at "
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}) ; "
+    r"original stderr: (empty|\d+ bytes)$",
+)
+
+
+def test_synthesize_external_termination_stderr_empty() -> None:
+    """Synthesizer with no original stderr produces ``original stderr: empty``.
+
+    Red: ``synthesize_external_termination_stderr`` not yet defined.
+    """
+    from hive._helpers import synthesize_external_termination_stderr
+
+    out = synthesize_external_termination_stderr(original_stderr=b"")
+    assert "[external_termination] killed by supervisor at " in out
+    assert "original stderr: empty" in out
+
+
+def test_synthesize_external_termination_stderr_with_bytes() -> None:
+    """Synthesizer with N bytes of stderr produces ``original stderr: <N> bytes``."""
+    from hive._helpers import synthesize_external_termination_stderr
+
+    out = synthesize_external_termination_stderr(original_stderr=b"hello world")
+    assert "original stderr: 11 bytes" in out
+
+
+# ── AC-4 — warning log carries cause= tag ────────────────────────────────
+
+
+@_POSIX_ONLY
+def test_git_commit_warning_carries_cause_git_error(
+    git_vault: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """rc>0 (genuine git failure) → cause=git_error in WARNING log.
+
+    Red: current log line lacks the cause= tag. After T-1.3, every
+    warning carries either cause=external_termination or cause=git_error
+    to make operator triage one-grep-able.
+    """
+    from hive._helpers import _git_commit
+
+    # Force a git failure: ask to commit a file that does not exist.
+    caplog.set_level(logging.WARNING, logger="hive._helpers")
+    bogus = git_vault / "does-not-exist.md"
+    _git_commit(git_vault, [bogus.relative_to(git_vault)], "test")
+
+    git_warnings = [
+        rec.message for rec in caplog.records
+        if rec.levelno >= logging.WARNING
+        and ("git add" in rec.message or "git commit" in rec.message)
+    ]
+    assert git_warnings, "expected at least one git WARNING log"
+    assert any("cause=git_error" in m for m in git_warnings), (
+        f"expected 'cause=git_error' in one of: {git_warnings}"
+    )

--- a/tests/test_vault_write.py
+++ b/tests/test_vault_write.py
@@ -1,0 +1,76 @@
+"""TDD Red — HIVE-116 AC-5: partial-state suffix on deadline.
+
+Spec: ``specs/HIVE-116-stale-lock-after-deadline/proposal.md`` AC-5.
+
+After T-1.4:
+
+- ``hive._vault_write._PARTIAL_STATE_SUFFIX`` exists with the user-confirmed
+  wording (2026-05-27) — see ``specs/.../tasks.md`` T-0.2.
+- ``_commit_status_suffix`` accepts a ``deadline_killed: bool = False`` kwarg
+  and returns ``_PARTIAL_STATE_SUFFIX`` when truthy (overrides
+  requested_commit / deferred branches).
+
+Both assertions fail today: constant missing, kwarg missing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ── AC-5 — constant exists with the locked wording ───────────────────────
+
+
+def test_partial_state_suffix_constant_locked() -> None:
+    """The literal wording is the public contract; pattern-match key must hold."""
+    from hive._vault_write import _PARTIAL_STATE_SUFFIX
+
+    # Pattern-match key per proposal.md R3 resolution: downstream agents
+    # key off this substring. Wording rotations may happen later, but this
+    # prefix MUST remain stable across minor versions.
+    assert "partial state — disk write succeeded" in _PARTIAL_STATE_SUFFIX
+    # Action-oriented imperative per user decision 2026-05-27.
+    assert "verify with vault_query" in _PARTIAL_STATE_SUFFIX
+    # Leading space matches sibling _DEFERRED_SUFFIX / _UNCOMMITTED_SUFFIX.
+    assert _PARTIAL_STATE_SUFFIX.startswith(" (")
+    assert _PARTIAL_STATE_SUFFIX.endswith(")")
+
+
+# ── AC-5 — _commit_status_suffix routes deadline_killed correctly ────────
+
+
+@pytest.mark.parametrize(
+    ("requested_commit", "deferred", "deadline_killed", "expected_substring"),
+    [
+        (True, False, False, ""),  # committed inline — no suffix
+        (True, True, False, "deferred to obsidian-git"),
+        (False, False, False, "uncommitted"),
+        # The new branch: deadline_killed dominates regardless of requested/deferred
+        (True, False, True, "partial state — disk write succeeded"),
+        (False, False, True, "partial state — disk write succeeded"),
+        (True, True, True, "partial state — disk write succeeded"),
+    ],
+)
+def test_commit_status_suffix_routes_deadline_killed(
+    requested_commit: bool,
+    deferred: bool,
+    deadline_killed: bool,
+    expected_substring: str,
+) -> None:
+    """Deadline-killed branch overrides the requested/deferred matrix.
+
+    Today's _commit_status_suffix has signature (requested_commit, deferred).
+    Red: calling with kwarg ``deadline_killed=...`` raises TypeError.
+    """
+    from hive._vault_write import _commit_status_suffix
+
+    result = _commit_status_suffix(
+        requested_commit=requested_commit,
+        deferred=deferred,
+        deadline_killed=deadline_killed,
+    )
+    if expected_substring == "":
+        assert result == "", f"expected empty suffix, got {result!r}"
+    else:
+        assert expected_substring in result, (
+            f"expected {expected_substring!r} in {result!r}"
+        )


### PR DESCRIPTION
## Summary

PR-1 of 3 in the HIVE-116 plan ([spec](./specs/HIVE-116-stale-lock-after-deadline/)). Closes the observability + double-write surface of issue #141. **Does not yet fix the orphan `.git/hive.lock` itself** — that lands in PR-2 (filelock eviction on deadline).

- **Structured subprocess termination logs.** `RC_EXTERNAL_TERMINATION = -1` replaces the magic number; `_run_git` synthesizes a stderr of shape `[external_termination] killed by supervisor at <ISO-8601>; original stderr: (empty|<N> bytes)`; `_git_commit` warnings carry `cause=external_termination` vs `cause=git_error` so operators can grep one signal.
- **Partial-state response contract for write tools.** New `_PARTIAL_STATE_SUFFIX` exposed as the stable public string; downstream agents (Claude Code, OpenCode) can pattern-match on the substring `"partial state — disk write succeeded"` to know the file landed on disk and skip the blind retry that risks double-writes. `_commit_status_suffix` gains a `deadline_killed` kwarg that dominates the requested/deferred matrix.
- **Contextvar plumbing for the supervisor.** `_PARTIAL_STATE_CV` propagates the write progress from the `to_thread` worker back to the awaiter; on supervisor `TimeoutError`, `run_sync_tool` reads the dict and surfaces the partial-state message instead of the generic "timed out — retry shortly". Read-path tools (`vault_query` / `vault_search` / `vault_health`) keep the generic message.

## Why this matters

Today, when the deadline supervisor terminates a stuck `git add`, the response says "timed out" but the file has already landed. Agents interpret the response as failure and retry with native FS writes, risking double-writes. The partial-state contract closes that surface.

## Out of scope (lands in PR-2 / PR-3)

- `.git/hive.lock` cache eviction (`evict_filelock`) + `HIVE_POST_KILL_DRAIN_S` env var — root-cause fix that unblocks sibling workers.
- `LockEvictionTracker` + `vault_health.runtime.lock_eviction_count_30d`.
- Cross-worker integration test promoted from skipped to runnable.
- Cross-OS CI matrix lane (Linux + Windows).

## Test plan

- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy --strict clean
- [x] `make test` — 584 existing + 11 new = 595 passed, 2 skipped (smoke), 1 deselected (cross_worker for PR-2), 57 deselected (smoke). Coverage 87%.
- [x] Bilingual docs parity verified (18 ↔ 18 H2 headings in `troubleshooting.md` EN + ES)
- [ ] Manual smoke on Windows: trigger a `vault_patch` deadline, confirm response carries the `partial state — disk write succeeded` substring
- [ ] Field validation against original `#141` repro: run the slow `vault_patch` on the 174 MB vault, check the response and the operator log line

## Verification per AC

| AC | Test |
|----|------|
| AC-3 | `tests/test_run_git.py::test_rc_external_termination_constant_exists`, `test_synthesize_external_termination_stderr_*` |
| AC-4 | `tests/test_run_git.py::test_git_commit_warning_carries_cause_git_error` |
| AC-5 | `tests/test_vault_write.py::test_partial_state_suffix_constant_locked`, `test_commit_status_suffix_routes_deadline_killed` (6 parametrized cases) |
| AC-6 | Covered by `run_sync_tool` change + contextvar plumbing; full integration validated in PR-2's cross-worker test |
| AC-11 | `site/src/content/docs/{,/es}/guides/troubleshooting.md` — new "Partial-State Writes After Deadline" section |
| AC-13 | This commit's Conventional Commit prefix `feat(hive):` will trigger release-please for v1.20.0 on merge |

Refs #141.