### PR TITLE
docs: migrate build/operate knowledge into docs/ (KPM-009)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,6 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 > **Hive** — vault-native AI orchestration: a unified MCP server giving AI coding assistants on-demand access to an Obsidian vault plus delegation to local/cheap workers.
 
+Project-bound knowledge lives in [`docs/`](../docs/) (docs-as-code): [`docs/adr/`](../docs/adr/) (architecture decisions + `sequence-diagrams.md`), [`docs/runbooks/`](../docs/runbooks/), [`docs/troubleshooting/`](../docs/troubleshooting/), [`docs/lessons.md`](../docs/lessons.md) (gotchas and post-mortems). The strategic/decide layer and session memory live in the maintainer's cross-project knowledge store (not committed here).
+
 ## Big-picture architecture
 
 Hive is an MCP server (stdio transport, FastMCP framework) with three responsibilities:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Hive degrades gracefully — every recommended or optional dependency reveals mo
 
 ### Recommended configuration
 
-Per [ADR-006 (commit policy)](https://github.com/mlorentedev/hive/blob/master/docs/architecture/adr-006-commit-policy.md), the recommended pairing for write-heavy flows is:
+Per [ADR-006 (commit policy)](docs/adr/adr-006-commit-policy.md), the recommended pairing for write-heavy flows is:
 
 1. Install and enable the **obsidian-git** plugin in your vault.
 2. Set its **auto-commit interval** to 5 or 10 minutes.
@@ -75,7 +75,7 @@ Per [ADR-006 (commit policy)](https://github.com/mlorentedev/hive/blob/master/do
 
 `vault_health` reports a `## external_committer` block when it detects obsidian-git in the vault. The `commit=False` durability contract is explicit: files are persisted to disk regardless; only the *commit* is deferred. A crash before the next flush loses the commit, not the content.
 
-When a tool call is cancelled mid-flight (slow worker, client timeout), the server may have already mutated the disk before the cancel ack reaches the wire. `vault_health` surfaces a `## ghost_responses` counter and emits a `mcp.ghost_response.suppressed_after_cancel_ack` WARNING for each event — verify state via `vault_query` rather than retrying, since the ErrorData ack does **not** imply rollback ([ADR-007](https://github.com/mlorentedev/hive/blob/master/docs/architecture/adr-007-mcp-cancellation-response.md)).
+When a tool call is cancelled mid-flight (slow worker, client timeout), the server may have already mutated the disk before the cancel ack reaches the wire. `vault_health` surfaces a `## ghost_responses` counter and emits a `mcp.ghost_response.suppressed_after_cancel_ack` WARNING for each event — verify state via `vault_query` rather than retrying, since the ErrorData ack does **not** imply rollback ([ADR-007](docs/adr/adr-007-mcp-cancellation-response.md)).
 
 ## Tools
 
@@ -131,6 +131,13 @@ Full documentation at **[mlorentedev.github.io/hive](https://mlorentedev.github.
 - [Use Cases](https://mlorentedev.github.io/hive/guides/use-cases/) — real-world workflows
 - [Architecture](https://mlorentedev.github.io/hive/reference/architecture/) — module map and design decisions
 - [Troubleshooting](https://mlorentedev.github.io/hive/guides/troubleshooting/) — common issues and fixes
+
+Project-bound knowledge (docs-as-code) lives in [`docs/`](docs/):
+
+- [`docs/adr/`](docs/adr/) — Architecture Decision Records
+- [`docs/runbooks/`](docs/runbooks/) — operational procedures
+- [`docs/troubleshooting/`](docs/troubleshooting/) — known issues and root-cause write-ups
+- [`docs/lessons.md`](docs/lessons.md) — accumulated gotchas and post-mortems
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Documentation
+
+Project-bound knowledge for `hive`, kept in-repo (docs-as-code). The *operate/build* layer lives here so it is versioned with the code and readable by any agent in-context — no external knowledge store required.
+
+- [`adr/`](adr/) — Architecture Decision Records (the *why* behind decisions), plus [`adr/sequence-diagrams.md`](adr/sequence-diagrams.md) for the end-to-end flow diagrams
+- [`runbooks/`](runbooks/) — operational procedures (e.g. the architecture audit checklist)
+- [`troubleshooting/`](troubleshooting/) — known issues, root-cause write-ups, and fixes
+- [`lessons.md`](lessons.md) — accumulated gotchas and post-mortems
+
+The *decide/position* layer (roadmap, prestudy, strategy) and session memory live in the maintainer's cross-project knowledge store and are intentionally not committed here.

--- a/docs/adr/adr-001-orchestration-model.md
+++ b/docs/adr/adr-001-orchestration-model.md
@@ -1,0 +1,64 @@
+---
+id: "ADR-001-orchestration-model"
+type: adr
+status: accepted
+date: "2026-03-01"
+tags: [architecture, decision, orchestration, mcp]
+owner: manu
+created: "2026-03-28"
+---
+
+# ADR-001: Claude Code as Orchestrator with MCP Extension Layer
+
+## Context
+Need a multi-model AI orchestration system that:
+- Fixes context window saturation in Claude Code sessions (5h→3h due to static vault loading)
+- Routes low-complexity tasks to cheaper/local models (Ollama, Qwen)
+- Uses Obsidian vault as single source of truth (read-write by agents)
+- Stays under $100-110/mo budget
+- Benefits from ongoing Claude Code ecosystem improvements (plugins, hooks, skills)
+- Scales from solo dev to small team
+
+## Options Considered
+
+1. **Custom orchestrator (CrewAI / LangGraph / AutoGen)**
+    * *Pros:* Full control over routing, mature frameworks, multi-model native
+    * *Cons:* API-based (pay-per-token, no plan cap), replaces Claude Code (lose ecosystem), heavy dependency, no Obsidian vault integration
+
+2. **Claude Code + MCP extension servers**
+    * *Pros:* Rides Claude Code improvements for free, minimal custom code (~650 lines), flat-rate billing, MCP is a standard protocol, vault access on-demand instead of upfront
+    * *Cons:* Limited to Claude Code's orchestration capabilities, MCP SDK maturity varies by language
+
+3. **Multi-tool setup (Claude Code + separate Qwen CLI + shared vault)**
+    * *Pros:* Each tool runs independently, no custom code
+    * *Cons:* No coordination between tools, duplicate context loading, manual task routing, vault conflict risk
+
+## Decision
+We chose **Option 2: Claude Code + MCP extension servers** because:
+- Claude Code already has parallel subagents, hooks, and skills — it IS an orchestrator
+- MCP servers are the minimal extension point (typed tools, protocol-based, language-agnostic)
+- Only 2 custom servers to maintain: vault (read/write vault) and worker (delegate to Ollama/Qwen)
+- Upstream Claude Code improvements flow through automatically
+- Total cost stays at $100 Claude plan + $10 Qwen API cap = $110/mo
+
+## Architecture
+
+```
+Claude Code (brain + orchestrator)
+    ├── Vault MCP Server (Python/FastMCP)
+    │   └── On-demand vault access replaces static CLAUDE.md loading
+    ├── Worker MCP Server (Python/FastMCP)
+    │   ├── Ollama (homelab VPN) → primary, free
+    │   └── Qwen API (OpenRouter) → fallback, $10/mo cap
+    └── Existing MCP servers (drawio, context7, sequential-thinking)
+```
+
+## Consequences
+- **Positive:** 60-70% reduction in static context. Parallel grunt work capacity. Self-improving over time. Existing dotfiles/vault work fully preserved.
+- **Negative:** Dependent on Claude Code's MCP implementation quality. Worker output needs Claude review (no autonomous deployment). Python MCP servers add a runtime dependency.
+
+## References
+- [Model Context Protocol spec](https://modelcontextprotocol.io/)
+- [FastMCP Python SDK](https://github.com/jlowin/fastmcp)
+
+<!-- Provenance: the related dotfiles MCP-persistence decision lives in the maintainer's cross-project knowledge store. Not linked here to preserve repo->store independence (knowledge-placement directionality invariant). -->

--- a/docs/adr/adr-002-system-architecture-phase5.md
+++ b/docs/adr/adr-002-system-architecture-phase5.md
@@ -1,0 +1,154 @@
+---
+id: adr-002-system-architecture-phase5
+type: adr
+status: active
+created: "2026-03-03"
+owner: manu
+---
+
+# ADR-002: System Architecture — Post-Phase 5 Snapshot
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-03
+
+## Context
+
+Phases 1–5 are shipped. The system has grown from a single vault query tool to a full context platform with 10 tools, 5 resources, and 4 prompts across two MCP servers. This ADR documents the architecture as-built, including component inventory, data flow, and known failure modes.
+
+ADR-001 established Claude Code as orchestrator with MCP extensions. This ADR does not change that decision — it captures the concrete implementation that resulted.
+
+## Decision
+
+Document the system architecture at the Phase 5 milestone for future reference, onboarding, and audit purposes.
+
+## Component Inventory
+
+### Vault MCP Server (`hive-vault`)
+
+**Purpose:** On-demand Obsidian vault access, replacing static CLAUDE.md context loading.
+
+| Primitive | Name | Purpose |
+|---|---|---|
+| Tool | `vault_query` | Read vault content by project/section/path |
+| Tool | `vault_search` | Full-text search with metadata filters |
+| Tool | `vault_smart_search` | Ranked search (status weight + recency) |
+| Tool | `vault_summarize` | Small files inline, large files → delegation prompt |
+| Tool | `vault_update` | Write to vault with frontmatter validation + git commit |
+| Tool | `vault_create` | New file with auto-generated frontmatter + git commit |
+| Tool | `vault_health` | Project health metrics + stale file detection |
+| Tool | `vault_list_projects` | Enumerate all vault projects |
+| Tool | `session_briefing` | One-call cold-start: tasks + lessons + git log + health |
+| Tool | `vault_recent` | Files changed in last N days (git + frontmatter) |
+| Resource | `hive://projects` | Static: project listing |
+| Resource | `hive://health` | Static: vault health report |
+| Resource | `hive://projects/{project}/context` | Template: project context doc |
+| Resource | `hive://projects/{project}/tasks` | Template: project task backlog |
+| Resource | `hive://projects/{project}/lessons` | Template: project lessons |
+| Prompt | `retrospective` | End-of-session lesson extraction protocol |
+| Prompt | `delegate` | Structured worker delegation protocol |
+| Prompt | `vault_sync` | Post-sprint vault synchronization |
+| Prompt | `benchmark` | Session token savings estimation |
+
+### Worker MCP Server (`hive-worker`)
+
+**Purpose:** Delegate low-complexity tasks to cheaper/local models.
+
+| Primitive | Name | Purpose |
+|---|---|---|
+| Tool | `delegate_task` | Send task to worker model with routing |
+| Tool | `list_models` | Enumerate available models + pricing |
+| Tool | `worker_status` | Budget usage, model availability |
+
+### Shared Infrastructure
+
+| Component | Technology | Location |
+|---|---|---|
+| Configuration | pydantic-settings (`HiveSettings`) | `src/hive/config.py` |
+| Budget tracker | SQLite (WAL mode) | `src/hive/budget.py` |
+| HTTP clients | httpx (async) | `src/hive/clients.py` |
+| Frontmatter | PyYAML + custom parser | `src/hive/frontmatter.py` |
+| Vault storage | Obsidian (markdown + git) | `~/Projects/knowledge/` |
+| Local LLM | Ollama (qwen2.5-coder:7b) | `ollama.kubelab.live:11434` |
+| Cloud LLM | OpenRouter (Qwen3 Coder free) | API with $5/mo cap |
+
+## Data Flow
+
+### Read Path (vault query)
+```
+Claude Code → MCP call → vault_server.py
+  → _resolve_file(vault_path, project, section, path)
+  → Path.read_text() → _truncate() → return text
+```
+
+### Write Path (vault update)
+```
+Claude Code → MCP call → vault_server.py
+  → validate_frontmatter(content) [replace only]
+  → Path.write_text()
+  → _git_commit(vault_path, rel_path, message)
+  → return confirmation
+```
+
+### Worker Delegation Path
+```
+Claude Code → MCP call → worker_server.py
+  → route_task(): Ollama → OpenRouter free → OpenRouter paid → reject
+  → budget.can_spend() check [paid only]
+  → httpx POST to model endpoint
+  → budget.record() [if cost > 0]
+  → return result
+```
+
+### Discovery Path (resources)
+```
+MCP Client (Cursor/Windsurf/Claude) → list_resources()
+  → 2 static URIs + 3 templates
+MCP Client → read_resource("hive://projects/hive/context")
+  → _resolve_file() → read + truncate → return ResourceResult
+```
+
+## Failure Modes
+
+| Failure | Impact | Mitigation |
+|---|---|---|
+| Vault path missing | All vault tools return error strings | Config validation at startup; clear error messages |
+| Git not initialized in vault | Write tools fail at `_git_commit` | `git_vault` fixture ensures git in tests; error propagates clearly |
+| Ollama unreachable | Worker falls back to OpenRouter free | `is_available()` health check; 3-tier routing |
+| OpenRouter API key missing | Worker limited to Ollama only | `OPENROUTER_API_KEY` alias for compat; clear error on paid route |
+| Budget exhausted ($5/mo) | Paid worker requests rejected | `can_spend()` guard before every paid call |
+| Malformed frontmatter on write | `vault_update` rejects with validation error | `validate_frontmatter()` checks required fields before write |
+| File not found | Tool returns descriptive error string | `_resolve_file()` returns error string, not exception |
+| Large output | Truncated with `[... truncated, N more lines]` notice | `_truncate()` applied consistently; `max_lines` param |
+| Concurrent vault writes | Last write wins (no locking) | Acceptable for single-user; git history preserves all versions |
+
+## Metrics (measured)
+
+- **Token savings:** 67–82% reduction vs static CLAUDE.md loading
+- **Test coverage:** 190 tests, 90% line coverage, mypy --strict clean
+- **Code size:** ~760 statements across 7 modules
+- **Smart search scoring:** `score = match_count × status_weight + recency_bonus`
+
+## Consequences
+
+### Positive
+
+- Complete component inventory enables onboarding and audit
+- Failure modes documented — no hidden assumptions
+- MCP Resources enable non-Claude clients to discover vault content
+- Session briefing eliminates cold-start friction
+
+### Negative
+
+- Architecture doc requires maintenance as features evolve
+- No locking for concurrent writes (acceptable for single-user)
+
+## References
+
+- [adr-001-orchestration-model.md](adr-001-orchestration-model.md): Foundation decision (Claude Code as orchestrator)
+- [MCP Specification](https://modelcontextprotocol.io/)
+- [FastMCP 3.x docs](https://github.com/jlowin/fastmcp)

--- a/docs/adr/adr-003-rag-evaluation.md
+++ b/docs/adr/adr-003-rag-evaluation.md
@@ -1,0 +1,104 @@
+---
+id: adr-003-rag-evaluation
+type: adr
+status: active
+created: "2026-03-03"
+owner: manu
+---
+
+# ADR-003: RAG Evaluation — Embeddings Not Yet Needed
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-03
+
+## Context
+
+Phase 3.2 required an evaluation of whether the vault needs Retrieval Augmented Generation (embeddings + vector store) to maintain search quality as the vault grows.
+
+Current vault state:
+- ~50-80 markdown files across ~10 projects
+- Full-text search (`vault_search`) scans all files in <100ms
+- Smart search (`vault_smart_search`) adds ranking with O(N) file scan
+- Session profiling (`vault_usage`) now tracks which queries are useful
+
+The question: when does linear scan become too slow, and what should replace it?
+
+## Analysis
+
+### Current Performance (N ≈ 80 files)
+
+| Operation | Approach | Latency |
+|---|---|---|
+| `vault_search` | `rglob("*.md")` + string match | <100ms |
+| `vault_smart_search` | Same scan + scoring | <100ms |
+| `vault_query` | Direct file read | <5ms |
+
+At 80 files, there is no performance problem. The bottleneck is context window tokens, not search speed — and that's already solved by `_truncate` and `max_lines`.
+
+### Projected Growth
+
+| Timeframe | Estimated files | Search latency (projected) |
+|---|---|---|
+| Current | ~80 | <100ms |
+| 6 months | ~150 | <200ms |
+| 1 year | ~300 | <400ms |
+| 2 years | ~500+ | ~800ms (threshold) |
+
+The vault grows ~5-10 files/month. At this rate, 500 files is 2+ years away.
+
+### When Embeddings Become Necessary
+
+1. **Search latency >500ms** — user-perceptible delay on every query
+2. **Semantic search needed** — "find architecture decisions about caching" when no file contains the word "caching" but discusses TTL, Redis, memoization
+3. **Cross-reference discovery** — "what's related to this file?" without explicit links
+
+Currently none of these are pain points. Frontmatter metadata (`type`, `status`, `tags`) already provides structured filtering that embeddings would not improve.
+
+### Technology Options (for future reference)
+
+| Option | Pros | Cons |
+|---|---|---|
+| **sqlite-vec** | Zero new deps (SQLite extension), local, fast | Requires compilation, Python bindings limited |
+| **chromadb** | Pure Python, well-documented, local | Heavy dependency (~200MB), overkill for <500 files |
+| **sentence-transformers + FAISS** | Best quality, battle-tested | GPU preferred, large models, complex setup |
+| **Ollama embeddings** | Already have Ollama infra | 8GB mini PC may struggle with embedding model + LLM |
+
+## Decision
+
+**Do not implement RAG/embeddings now.** Revisit when:
+1. Vault exceeds 500 files, OR
+2. `vault_usage` data shows frequent "no matches" results (semantic gap), OR
+3. Search latency consistently exceeds 500ms
+
+The `vault_usage` tool (Phase 3.2) provides the instrumentation to detect condition #2 automatically.
+
+## Consequences
+
+### Positive
+
+- No new dependencies or infrastructure complexity
+- No embedding model resource contention on 8GB mini PC
+- Full-text search remains deterministic and debuggable
+- Decision is data-driven (usage tracking in place to trigger revisit)
+
+### Negative
+
+- No semantic search capability (must match exact keywords)
+- No "related files" discovery beyond manual tags
+
+### Neutral
+
+- Technology evaluation is documented for when the threshold is reached
+- `sqlite-vec` is the most likely choice given existing SQLite usage
+
+## References
+
+- [adr-001-orchestration-model.md](adr-001-orchestration-model.md): Infrastructure constraints (8GB mini PC)
+- [adr-002-system-architecture-phase5.md](adr-002-system-architecture-phase5.md): Current search implementation details
+- [sqlite-vec](https://github.com/asg017/sqlite-vec): SQLite vector extension
+- [chromadb](https://www.trychroma.com/): Embedding database

--- a/docs/adr/adr-004-thread-safety-model.md
+++ b/docs/adr/adr-004-thread-safety-model.md
@@ -1,0 +1,84 @@
+---
+id: adr-004-thread-safety-model
+type: adr
+status: active
+created: "2026-03-12"
+owner: manu
+---
+
+# ADR-004: Thread-Safety Model for MCP Tool Handlers
+
+## Status
+Accepted (2026-03-12)
+
+## Context
+
+FastMCP dispatches **synchronous** tool handlers to a thread pool via `anyio.to_thread.run_sync`. When an MCP client sends N tool calls in parallel, they execute in N separate threads — all sharing the same `ServerContext` instance.
+
+This means every shared resource in `ServerContext` (SQLite connections, HTTP clients, file I/O) is subject to concurrent access from multiple threads.
+
+### Problem discovered (Issue #59)
+
+`RelevanceTracker` and `UsageTracker` created SQLite connections with `check_same_thread=False`, which disables Python's thread-origin check but does **not** make the connection thread-safe. Concurrent `execute()` + `commit()` calls caused `SQLITE_MISUSE (error 21)`.
+
+`BudgetTracker` lacked even the `check_same_thread=False` flag, causing `ProgrammingError` on cross-thread access.
+
+`vault_write` and `vault_patch` had TOCTOU (time-of-check-time-of-use) race conditions: two threads could both pass the `exists()` check, then both write, with the second silently overwriting the first. The append mode had a classic lost-write race: Thread A reads "X", Thread B reads "X", Thread A writes "X+A", Thread B writes "X+B" (losing A).
+
+`_git_commit` had no serialization, allowing interleaved `git add` / `git commit` from concurrent threads to corrupt the git index.
+
+## Decision
+
+### 1. SQLite Trackers: `threading.Lock` per instance
+
+Each SQLite-backed class (`RelevanceTracker`, `UsageTracker`, `BudgetTracker`) gets a `threading.Lock` initialized in `__init__`. All public methods that touch `self._conn` acquire the lock.
+
+**Key design choice: `Lock` over `RLock`.**
+
+`BudgetTracker` has reentrant call chains: `can_spend()` → `month_remaining()` → `month_spent()`. Using `RLock` would silently allow reentrancy but mask design issues. Instead, we extract internal `_method()` versions (no lock) and have public methods acquire the lock exactly once:
+
+```python
+def _month_spent(self) -> float:
+    """Internal — caller MUST hold self._lock."""
+    ...
+
+def month_spent(self) -> float:
+    with self._lock:
+        return self._month_spent()
+
+def month_stats(self, budget: float) -> dict[str, Any]:
+    with self._lock:
+        spent = self._month_spent()  # no deadlock
+        ...
+```
+
+This makes the locking boundary explicit: public methods acquire, internal methods assume. A future developer who accidentally calls a public method from inside the lock gets an immediate deadlock (fail-fast), not silent reentrancy.
+
+### 2. Vault File I/O: Module-level `_WRITE_LOCK`
+
+A single `threading.Lock` in `_vault_write.py` serializes all vault write operations (file I/O + git commit). This eliminates TOCTOU on `exists()` checks, lost writes on append, and stale reads on patch.
+
+Coarse-grained by design: vault writes are infrequent (seconds between calls), so serialization has zero practical impact on throughput.
+
+### 3. Git Operations: Module-level `_GIT_LOCK`
+
+A `threading.Lock` in `_helpers.py` wraps the entire `git add` + `git commit` sequence. This prevents index corruption from interleaved git operations.
+
+Separate from `_WRITE_LOCK` because `capture_lesson` (in `_workers.py`) also calls `_git_commit` outside of vault write paths. Lock ordering is always `_WRITE_LOCK` → `_GIT_LOCK` (never reversed), so no deadlock is possible.
+
+### 4. Async Tool Handlers (not affected)
+
+`capture_lesson` and `delegate_task` are `async def` — they run in the event loop, not the thread pool. Synchronous file I/O inside them (`_write_lesson`) blocks the event loop but is effectively serialized. If these are ever refactored to use `aiofiles`, the file I/O will need its own lock.
+
+## Consequences
+
+- **Thread-safe by default**: All shared mutable state is now protected.
+- **Fail-fast on mistakes**: `Lock` (not `RLock`) means accidental reentrancy deadlocks immediately in dev, not silently in production.
+- **Minimal performance impact**: All locks are uncontended in typical usage (sequential tool calls). Under parallel load, serialization adds microseconds — SQLite is the bottleneck regardless.
+- **Future work**: If Hive ever needs true concurrent SQLite writes, migrate to `aiosqlite` with connection pooling. Current `Lock` pattern is a bridge, not a ceiling.
+
+## References
+
+- Issue: https://github.com/mlorentedev/hive/issues/59
+- FastMCP thread dispatch: `fastmcp/server/dependencies.py:590`
+- SQLite threading docs: https://www.sqlite.org/threadsafe.html

--- a/docs/adr/adr-005-transport-and-scale.md
+++ b/docs/adr/adr-005-transport-and-scale.md
@@ -1,0 +1,207 @@
+---
+id: adr-005-transport-and-scale
+type: adr
+status: proposed
+created: "2026-05-18"
+owner: manu
+tags: [architecture, scalability, mcp, transport, concurrency]
+---
+
+# ADR-005: Transport Model and Multi-Process Scalability
+
+## Status
+Proposed (2026-05-18) — written after diagnosing inter-process hangs (see [lessons.md](../lessons.md), "Multi-process MCP server contention surfaces").
+
+## Context
+
+[adr-001-orchestration-model.md](adr-001-orchestration-model.md) established Hive as an MCP server with on-demand vault access. [adr-004-thread-safety-model.md](adr-004-thread-safety-model.md) addressed **intra**-process concurrency (multiple MCP tool calls within one server process). This ADR addresses **inter**-process concurrency — the gap that surfaced once Claude Code users started running 2–5 parallel sessions against the same vault.
+
+### The current model (stdio, multi-process)
+
+```
+Claude Code session A  ─►  uvx hive-vault (PID 22768)  ─┐
+Claude Code session B  ─►  uvx hive-vault (PID 29000)  ─┼─►  ~/Projects/knowledge/ (shared git)
+Claude Code session C  ─►  uvx hive-vault (PID 31504)  ─┘    ~/.local/share/hive/*.db (shared SQLite)
+```
+
+The MCP spec assumes stdio transport = one server subprocess per client. When a user runs N parallel Claude Code sessions, they get N hive-vault subprocesses. All N share:
+
+- The vault git repo (`git add` / `git commit`).
+- Three SQLite databases (`worker.db`, `relevance.db`, usage tracker).
+- Optionally Ollama / OpenRouter quotas (less interesting).
+
+The patches that became PR-after-this-ADR (filelock, busy_timeout, tool_span on vault tools, respond-after-cancel shim) make this model **correct but not unlimited**. There is a ceiling.
+
+### What we just fixed and what remains
+
+| Bug | Fix shipped | Residual risk |
+|---|---|---|
+| Vault tool calls had no timeout | `wrap_sync_tool` decorator → `tool_span` on all 7 vault tools | None |
+| Multi-process git races (5+ historical 30s timeouts in log) | `filelock` at `vault/.git/hive.lock` | Serializes writes — throughput ceiling, see below |
+| SQLite `OperationalError: database is locked` | `PRAGMA busy_timeout=10s` + connect `timeout=10` | Same — serializes writers |
+| `AssertionError: Request already responded to` killed the server after cancel | `_compat.py` patches `respond` to short-circuit when `_completed=True` | None; self-gated, removable when upstream fixes |
+| Log line did not identify the hung tool | `LifecycleMiddleware` now logs `tool=<name>` | None |
+
+The serialization fixes mean operations **wait** instead of failing. Waiting has a budget.
+
+## Scale analysis
+
+Numbers below are order-of-magnitude estimates; they would need a benchmark to validate. They are good enough to make a decision.
+
+### Per-operation cost (warm vault, SSD, Windows 11)
+
+| Operation | Time | Bottleneck |
+|---|---|---|
+| `vault_query` (one file, ≤1k lines) | 5–20 ms | filesystem read |
+| `vault_search` (full text, ~200 files) | 200 ms – 2 s | rglob + per-file read |
+| `vault_write` + git commit | 100–400 ms | `git add` + `git commit` subprocess |
+| `vault_patch` + git commit | 150–500 ms | same |
+| `session_briefing` | 50–300 ms | rglob (count_stale) + SQLite + git log |
+| SQLite tracker write | 1–5 ms | WAL append |
+
+### Sessions vs sustained write throughput
+
+Writes are now serialized inter-process via the filelock. A `vault_write` releases the lock when the git commit returns. So the system's write throughput is roughly **1 / mean(write_duration)** = ~3–5 writes/second across all sessions combined, regardless of how many sessions are open.
+
+| Sessions | Reads (parallel) | Writes (serialized) | User-perceived behavior |
+|---|---|---|---|
+| **1–3** | Fine | Fine — collisions are rare | Indistinguishable from single-user |
+| **5** | Fine | Occasional 200–500 ms wait on `vault_write` | Imperceptible unless capturing many lessons in a burst |
+| **10** | Mostly fine; `vault_search` may slow if disk is shared | Writes start queuing — bursts can add 1–3 s tail latency | Noticeable in capture_lesson-heavy sessions |
+| **25** | OK if vault stable | Write tail latency hits 5–10 s during bursts | Users start to perceive lag; risk of filelock timeout (30s) |
+| **50+** | Read pressure on rglob | Writes near the filelock timeout; some commits skipped | Architecture wall |
+
+For Manu's actual usage (1–5 parallel Claude Code sessions on a single machine), the current architecture **after the fixes** is sufficient indefinitely. The interesting questions only arise if Hive is shared across a team or if a single user runs >10 sessions.
+
+### Where the wall is
+
+Three independent ceilings, hit at different scales:
+
+1. **Filelock serialization (~5 writes/s)** — the binding constraint. Comes from `git commit` being inherently single-writer per repo.
+2. **SQLite WAL write serialization (~50 writes/s)** — only a constraint if a tool does many small SQLite writes per call. Currently never the bottleneck.
+3. **Vault git repo size (~10k files? gut estimate)** — `git status` and `count_stale` scale with file count; not a concurrency problem but does affect per-operation latency, which compounds the above.
+
+## Alternatives
+
+### Option A — stay on stdio multi-process (current, post-fix)
+
+**Code change to ship:** what we just landed.
+
+**Pros**
+- Zero deploy complexity; works in every MCP client without configuration.
+- Process isolation: a hive crash takes down one session, not all.
+- Matches how every Claude Code user already runs Hive.
+
+**Cons**
+- Inter-process coordination via filelock + SQLite busy_timeout is correct but adds latency under contention.
+- Each session pays the `uvx hive-vault` cold-start cost (~1 s on Windows).
+- Hard ceiling at ~5 sustained writes/s across the machine.
+
+**Best when:** ≤10 parallel sessions per machine, single user or trusted small team sharing a vault.
+
+### Option B — HTTP transport + single hive-daemon
+
+**Code change:** add `hive serve --http` mode that runs one persistent daemon on `localhost:NNNN`; each Claude Code client connects via FastMCP's HTTP transport instead of spawning a subprocess. The daemon holds the SQLite connections and the git repo, so locks become intra-process again ([adr-004-thread-safety-model.md](adr-004-thread-safety-model.md)'s model applies directly).
+
+**Pros**
+- Eliminates inter-process contention entirely — back to one process owning all state.
+- No per-session cold start.
+- Single observable process: logs, metrics, profiling, OOMs all consolidate.
+- Throughput ceiling rises to ~50 writes/s (SQLite + threading, not git serial — git can stay serial via the existing `_GIT_LOCK`).
+- Natural place to add features that need shared state across sessions: cross-session activity feed, shared inflight queue, cross-session deduplication of expensive worker calls.
+
+**Cons**
+- HTTP transport in MCP is **less universally supported**. Claude Code supports it; Gemini CLI, Codex CLI, Cursor, Windsurf vary. Some clients support only stdio. This would split the user base unless we offer **both** transports.
+- Single point of failure: daemon crash kills all sessions simultaneously. Mitigated by supervisor (systemd unit / Windows service / Caddy reverse proxy with restart-on-fail).
+- New deploy surface: users need to start the daemon (manually or via launchd/systemd/Task Scheduler).
+- Auth becomes a real concern. localhost-only with a per-machine token is straightforward but new.
+- Logs across sessions become harder to attribute without request_id correlation.
+
+**Best when:** ≥10 parallel sessions per machine, team sharing a vault, or any deployment where a server admin owns the host.
+
+### Option C — pivot to event sourcing / outbox
+
+Defer git commits to a background worker. Writes touch only SQLite (the outbox); a single dedicated background goroutine drains the outbox into git at its own pace.
+
+**Pros**
+- Removes git from the hot path entirely. `vault_write` returns in <50ms regardless of git contention.
+- Outbox naturally serializes commits without filelock.
+
+**Cons**
+- Writes are no longer immediately visible to other sessions reading from git (they would have to read from outbox + git).
+- Materially more code: outbox schema, drain worker, failure handling, replay semantics.
+- Loses the "every write is a commit you can `git log`" property that makes the current vault model legible.
+
+**Best when:** sustained write-heavy workloads where git commit latency dominates. Not justified at current scale.
+
+## Decision tree
+
+```
+                ┌─ ≤10 parallel sessions / machine? ──── yes ──► STAY (Option A)
+                │
+   How many ───┤
+                │                                       ┌── all clients support HTTP? ── yes ──► MIGRATE (Option B)
+                └─ 10 – 50 sessions ─────────────────┤
+                                                        └── mixed clients? ──────────────────► OFFER BOTH (A + B)
+
+   >50 sessions / machine ────────────────────────────────────────────────► Option C or rethink (multi-tenant
+                                                                            hive backend, not single-machine MCP)
+```
+
+## Recommendation
+
+**Stay on Option A.** Ship the six fixes (filelock, busy_timeout, tool_span on vault tools, respond-after-cancel patch, tool_name in log, catch-all in `_try_worker`). This is the right level of investment for the current usage envelope (1–5 parallel sessions per developer).
+
+**Plan Option B as a v2 milestone** if either of these triggers fire:
+- Sustained complaints about write tail latency from teams or power users.
+- A real use case for shared-cross-session state (e.g. a "what is every Claude session in this org working on right now?" feature).
+
+Add `hive serve --http` as a second transport mode rather than replacing stdio — keeps single-user friction at zero, opens the door for the team-shared model. The investment is bounded: FastMCP already supports HTTP transport natively, and the existing intra-process threading model from [adr-004-thread-safety-model.md](adr-004-thread-safety-model.md) applies unchanged to the daemon.
+
+**Do not pursue Option C** unless we see write-latency regressions that the daemon model alone cannot fix.
+
+## Consequences
+
+- Inter-process coordination becomes part of Hive's contract. The lock files (`vault/.git/hive.lock` and SQLite WAL/SHM) must be respected by any tool that touches the same backing store outside Hive (a user manually running `git commit` in the vault while a `vault_write` is in flight will block, not corrupt).
+- The 6-fix bundle is the **last** patch this architecture should need at small scale. The next architectural decision (Option B vs. growing complexity in Option A) should be driven by measured contention, not by intuition.
+- Telemetry needs to improve before we can confidently make that decision: the new `tool=` log line is a start, but we want a `--show-stats` mode that surfaces filelock acquire-wait time and SQLite busy-time so contention is visible without log diving.
+
+## Amendments
+
+### 2026-05-21 — HIVE-115 telemetry gates triggered + baseline re-dimensioned
+
+Empirical evidence collected during HIVE-115 investigation invalidates the optimistic scale projections in §"Scale analysis" of this ADR:
+
+- **Actual baseline is N=3-5 concurrent sessions per user, not the "1-3 = fine" projection.** Local lsof snapshot 2026-05-21 confirms 3 simultaneous hive-vault processes holding open handles to all 3 SQLite DBs. The system is operating at the codo of this ADR's own scale table during normal daily use.
+- **`relevance.db-wal` reaches 4.1 MB vs 53 KB steady-state DB (77× ratio)** under N=3-5. `worker.db-wal` was last checkpointed 2 months ago.
+- **838s `capture_lesson` outlier observed (issue #111)** — `tool_span` non-preemption confirmed; the "defense in depth" of §"What we just fixed" is correct at each layer but does not compose into a global deadline.
+- **Anticipated future state**: agent-driven hive workloads at N=10-15 concurrent clients per machine. The current stdio multi-process model has a hard architectural ceiling well below that even with all 4 primitives of the multi-process-mcp-server pattern applied.
+
+### Gates invoked
+
+**Option C (event sourcing / outbox) gate condition** was: *"Re-evaluate only if write-latency regressions that the daemon model alone cannot fix."* Telemetry above satisfies the gate. Option C is no longer rejected — see [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) v1 (Phase A defensive, shipping v1.16.0) and ADR-009 v2 amendment (Phase B Outbox + Reconciler, same bundle).
+
+**Option B (HTTP daemon) gate conditions** were: *"Sustained complaints about write tail latency from teams or power users"* + *"a real use case for shared-cross-session state."* The agent-driven future state satisfies both prospectively. Option B is re-affirmed as the inevitable v1.17.0 / v2.0 target, tracked as ADR-011 (daemon model, forthcoming). The decision tree's "≥10 sessions" trigger is recognized as a near-term inevitability, not a far-future contingency.
+
+### Companion changes in v1.16.0 bundle
+
+- [adr-008-hard-deadline-enforcement.md](adr-008-hard-deadline-enforcement.md) — `bounded_call` supervisor replacing `tool_span`'s asyncio-only enforcement
+- [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) — periodic WAL checkpoint + telemetry + tunable lock
+- [adr-010-external-committer-coexistence.md](adr-010-external-committer-coexistence.md) — obsidian-git detection promoted to first-class
+- [adr-006-commit-policy.md](adr-006-commit-policy.md) §C gate also triggered (see ADR-006 amendments)
+- the multi-process-mcp-server pattern extended with primitives 5-7
+
+This ADR's §"Recommendation" remains: stay on stdio for v1.16.0, ship A+B together, observe under real load, then make the Option B (daemon) call with data — for what is now an inevitable destination, not a contingent one.
+
+## References
+
+- [adr-001-orchestration-model.md](adr-001-orchestration-model.md) — original Hive orchestration model
+- [adr-004-thread-safety-model.md](adr-004-thread-safety-model.md) — intra-process locking (still in force; this ADR extends it)
+- [adr-006-commit-policy.md](adr-006-commit-policy.md) — companion commit-policy ADR; co-amended in this release
+- [adr-008-hard-deadline-enforcement.md](adr-008-hard-deadline-enforcement.md) — Phase B deadline supervisor
+- [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) — Phase A WAL drain + telemetry
+- [adr-010-external-committer-coexistence.md](adr-010-external-committer-coexistence.md) — Phase A obsidian-git coordination
+- [transport-closed-after-reject.md](../troubleshooting/transport-closed-after-reject.md) — issue #75, the prior cancellation race
+- Log incident `2026-05-18 10:43` — first observed `AssertionError('Request already responded to')` killing a hive process after a 39-min hang
+
+<!-- Provenance (maintainer's cross-project knowledge store; not linked to preserve repo->store independence): pattern-phased-redesign-with-telemetry-gates (the meta-pattern guiding HIVE-115). HIVE-115 backlog tracked in the forge (GitHub issues / milestones). -->

--- a/docs/adr/adr-006-commit-policy.md
+++ b/docs/adr/adr-006-commit-policy.md
@@ -1,0 +1,181 @@
+---
+id: adr-006-commit-policy
+type: adr
+status: active
+created: "2026-05-20"
+---
+
+## Status
+Accepted (2026-05-20) — written after user reports of MCP slowness and ghost responses during write-heavy flows on a vault with 315 lessons across 17 projects.
+
+## Context
+
+[adr-005-transport-and-scale.md](adr-005-transport-and-scale.md) established that filelock serialization (~5 writes/s) is the binding throughput constraint of the current architecture, and explicitly considered an **Option C — pivot to event sourcing / outbox** that would defer git commits to a background worker. ADR-005 rejected Option C: *"Not justified at current scale… Do not pursue Option C unless we see write-latency regressions that the daemon model alone cannot fix."*
+
+This ADR revisits the commit-batching question 2 days later, after the user reported real UX pain (slowness, occasional MCP crashes, ghost responses during write-heavy flows). The analysis on 2026-05-20 concluded that ADR-005's rejection of Option C was correct, but the underlying problem — per-write commit cost — can be addressed with a **much smaller incremental change** that preserves ADR-005's spirit (avoid in-process background lifecycle complexity).
+
+### Problem surface
+
+Per `_helpers._git_commit` (`src/hive/_helpers.py:702-753`), every successful `vault_write` / `vault_patch` / `capture_lesson(inline)` invokes **two sequential `subprocess.run` calls** under both `_GIT_LOCK` (in-process) and the cross-process `filelock`:
+
+1. `git add <rel_path>` — fork+exec, index read/write, ~30–100 ms on healthy SSD
+2. `git commit -m <msg>` — fork+exec, pack lookup, ~30–100 ms
+
+Total: 50–200 ms healthy / 500 ms – several seconds under contention. Already-batched call sites (`vault_patch` multi-section, `capture_lesson(text=...)` batch mode) only do this **once per tool call**, so they are fine. The remaining hot path is **multiple sequential `vault_write` calls in one logical user-level operation** — e.g. an agent writing 5 sections of a doc as 5 separate tool calls.
+
+### Discovery: vault already has an external committer
+
+The vault (`~/Projects/knowledge`) is an Obsidian vault with **obsidian-git plugin** configured to auto-commit every 10 minutes. This is a strong signal:
+
+- The user already pays the cost of an external batcher.
+- Adding a Hive-internal background flusher would race with obsidian-git for `.git/index`, produce interleaved commits, and break the user's existing setup.
+- The lateral analysis on 2026-05-20 surfaced this as the single biggest risk of building Option C.
+
+### Failure modes observed
+
+- Multi-write user flows (e.g. spec scaffolding that creates `proposal.md` + `tasks.md` + `verification.md` in sequence): linear slowdown, occasional client-side timeout.
+- Ghost responses (see [adr-007-mcp-cancellation-response.md](adr-007-mcp-cancellation-response.md)): the >200 ms write window is long enough that client-side tool-call timeouts fire before `respond()` is called, exposing the upstream SDK cancellation race.
+
+### Constraint
+
+ADR-005's invariant **"successful `vault_write` returns committed state"** is load-bearing for:
+
+- Multi-process safety: callers in other processes can `git pull` or read HEAD and see the write.
+- Crash recovery: there is nothing to recover — every successful return is durable in git.
+- Debuggability: `git log` is a faithful timeline of vault operations.
+
+We preserve this invariant by default and **only relax it opt-in**.
+
+## Decision
+
+### 1. Default semantics unchanged — `write ⇒ commit`
+
+`vault_write` / `vault_patch` / `capture_lesson` continue to commit synchronously by default. The invariant from ADR-005 is preserved as a feature, not removed.
+
+### 2. Add opt-in `commit: bool = True` parameter
+
+Both `vault_write` and `vault_patch` accept an optional `commit` parameter. When `commit=False`:
+
+- File is written to disk (under `_WRITE_LOCK` — atomicity preserved).
+- `_git_commit` is **not** called.
+- Response payload includes `{"committed": false}` so the client knows.
+- No background task is started; the user (or an external committer like obsidian-git) is responsible for the eventual commit.
+
+This is the **minimum viable change** to unblock write-heavy flows without owning the lifecycle complexity that ADR-005 rejected.
+
+### 3. Add explicit `vault_commit(message: str = "")` tool
+
+A new MCP tool that runs `git add -A && git commit -m <message>` against the vault, returning the commit SHA. Provides an escape hatch for clients that opted out of auto-commit and want to flush explicitly without involving an external committer.
+
+### 4. Coalescer in `_git_commit`
+
+When `_git_commit` receives multiple paths in a single invocation (already happens in `vault_patch` multi-section and `capture_lesson(text=...)` batch mode), it issues **one `git add path1 path2 …` + one `git commit`** instead of looping. Free win. Zero callers need to change. ~40% reduction in per-batch-call subprocess cost.
+
+### 5. Recommend obsidian-git as the canonical batcher
+
+The README and the bilingual docs site (EN + ES) gain a **"Recommended configuration"** section that explicitly recommends the obsidian-git plugin (auto-commit interval 5–10 min) for users with write-heavy flows, paired with `commit=False` on Hive tool calls. This is the operational answer to ADR-005's Option C without building Option C.
+
+### 6. Detection + soft warning
+
+If Hive detects `<vault>/.obsidian/plugins/obsidian-git/data.json` on startup with `commitInterval > 0`, `vault_health` surfaces an INFO line: *"Detected obsidian-git auto-commit (every Nm). `commit=False` on vault_write/vault_patch is safe."*
+
+This is a hint, not enforcement — the user still controls everything.
+
+## Alternatives considered
+
+### A) Per-call coalescer only (decision §4 alone)
+
+**Pros:** zero new surface, ~40% improvement for already-batched call sites.
+**Cons:** does nothing for the dominant hot path (sequential `vault_write` calls).
+**Outcome:** included as part of this decision, but not sufficient alone.
+
+### B) **Chosen: A + opt-in `commit=False` + external committer delegation + recommendation**
+
+**Pros:**
+- Preserves ADR-005's invariant by default.
+- Delegates batching complexity to a well-tested external tool (obsidian-git) that the user already runs.
+- Reversible: opt-in nature means no break for existing clients.
+- Test surface grows modestly (~5–10 new tests).
+
+**Cons:**
+- Two committers in the ecosystem (Hive opt-in + obsidian-git) means the user has to think about which owns commits. Mitigated by §6 detection + docs.
+- Does not help users without obsidian-git unless they invoke `vault_commit` explicitly.
+
+### C) Background flusher inside Hive (Option C from ADR-005)
+
+**Rejected, second time.** Reasons:
+
+- Race with obsidian-git for `.git/index` is a real and severe failure mode (interleaved commits, broken index, user data integrity at risk).
+- Crash recovery semantics are bug-prone: distinguishing "files we wrote and didn't commit yet" from "files the user edited manually in vim" requires a `pending_writes` SQLite table + reconciliation logic, all of which is new code we'd have to maintain forever.
+- Multi-process flusher coordination (single-elected flusher via filelock) adds ~80 LOC of async lifecycle code that is notoriously hard to get right.
+- ADR-005's gate condition — *"write-latency regressions that the daemon model alone cannot fix"* — is not met. Option B in this ADR is the smaller answer.
+
+Re-evaluate only if measurements after Option B ship show sustained dolor that obsidian-git + `commit=False` cannot resolve.
+
+### D) Migrate to `pygit2` native bindings
+
+**Deferred.** Would reduce per-write cost from ~150 ms to ~10 ms by eliminating fork+exec. But:
+
+- Adds a C-dependency (libgit2) to a previously pure-Python wheel.
+- Multi-process safety with `pygit2`'s in-memory index needs careful verification — does not automatically inherit the filelock semantics.
+- Strictly orthogonal to this ADR: a future PR could land this without touching the decision here.
+
+Reconsider if Option B + obsidian-git proves insufficient at higher scale (>10 sessions/machine per ADR-005 §"Scale analysis").
+
+## Consequences
+
+- **Invariant preserved by default**: existing clients and tests see no behavior change. The "write success ⇒ git committed" property continues to hold unless the caller explicitly opts out.
+- **Free perf win for already-batched callers**: `vault_patch` and `capture_lesson(text=...)` get the coalescer for free.
+- **Opt-in batching unblocks write-heavy flows**: agents that issue many sequential writes can pass `commit=False` and either call `vault_commit` at the end or rely on obsidian-git.
+- **New documentation responsibility**: README + site docs (EN + ES) must surface the obsidian-git recommendation prominently. This is part of the same PR as the code change — not a follow-up.
+- **`vault_health` gains a "pending uncommitted writes" signal** when `commit=False` is in active use, so drift is observable.
+- **Test surface grows modestly**: ~5–10 new tests covering `commit=False`, `vault_commit`, coalescer behavior, obsidian-git detection.
+- **No new background tasks**, no new SQLite tables, no new lifecycle complexity. We stay on the simpler end of the architecture space that ADR-005 chose.
+- **Shrinks the ghost-response race window** ([adr-007-mcp-cancellation-response.md](adr-007-mcp-cancellation-response.md)): with `commit=False`, write duration drops from ~150 ms to ~5 ms. Client-side cancellation timeouts become very unlikely to fire during writes.
+- **Not addressed here**: reads under contention (e.g. `vault_search` on a large corpus with the HIVE-97 lesson tracker under WAL pressure) can still trigger the ghost-response race. That is ADR-007's territory.
+
+## Amendments
+
+### 2026-05-21 — §C gate triggered (HIVE-115)
+
+§C of this ADR rejected the background-flusher / Option C pattern with the gate condition: *"Re-evaluate only if measurements after Option B ship show sustained dolor that obsidian-git + commit=False cannot resolve."*
+
+Measurements collected after Option B's 2026-05-20 ship (v1.14.0) confirm sustained dolor:
+
+- **838s `capture_lesson` outlier** vs configured `tool_timeout=60` (issue #111, Windows user repro)
+- **`relevance.db-wal` = 4.1 MB vs `.db` = 53 KB** (77× ratio) under N=3-5 concurrent baseline (issue #110)
+- **Silent 30-second freezes per call** coinciding with obsidian-git auto-commit ticks (issue #110)
+- **3 simultaneous hive-vault processes holding handles to all 3 SQLite DBs** locally — multi-reader pattern blocks WAL checkpoint indefinitely
+
+The re-evaluation is documented in [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) v2 (Phase B Outbox + Reconciler amendment, shipping in v1.16.0 bundle alongside Phase A defensive work). The Outbox-in-Hive design carefully avoids the "race with obsidian-git for `.git/index`" failure mode that §C identified — by **detecting** obsidian-git presence and **deferring** to it when healthy (probe-based health check), with **automatic fallback** to a hive-internal reconciler when external committer is stale or absent. See [adr-010-external-committer-coexistence.md](adr-010-external-committer-coexistence.md) for the cooperation pattern.
+
+### Decisions §1-§5 unchanged
+
+- §1 (default semantics `write ⇒ commit`) — unchanged
+- §2 (opt-in `commit=False`) — unchanged; auto-defer in Phase B is additive, not replacing
+- §3 (`vault_commit` MCP tool) — unchanged
+- §4 (coalescer in `_git_commit`) — unchanged
+- §5 (recommend obsidian-git in docs) — unchanged; cooperation pattern made more explicit in [adr-010-external-committer-coexistence.md](adr-010-external-committer-coexistence.md)
+
+### §6 detection promoted
+
+§6's "INFO line in `vault_health`" was informational only. [adr-010-external-committer-coexistence.md](adr-010-external-committer-coexistence.md) promotes `detect_obsidian_git()` to first-class design concept: the boolean drives auto-defer behavior in Phase B, and `last_git_lock_wait_ms` + `mcp.lock_contention` structured logs surface contention with the external committer.
+
+### §C retracted as rejection
+
+§C is no longer a "rejected alternative" — it is a **deferred decision now unblocked by data**, formally implemented in [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) v2. The original concerns (race with obsidian-git, crash recovery, multi-process flusher coordination) are addressed by the cooperation-not-competition design of ADR-010.
+
+## References
+
+- [adr-001-orchestration-model.md](adr-001-orchestration-model.md) — original Hive orchestration model
+- [adr-004-thread-safety-model.md](adr-004-thread-safety-model.md) — `_GIT_LOCK` and `_WRITE_LOCK` remain in force; this ADR does not change their semantics
+- [adr-005-transport-and-scale.md](adr-005-transport-and-scale.md) — established the throughput ceiling and rejected Option C; **co-amended in this release** (HIVE-115)
+- [adr-007-mcp-cancellation-response.md](adr-007-mcp-cancellation-response.md) — interrelated; the ghost-response race is shrunk by §2 here and handled by ADR-007
+- [adr-008-hard-deadline-enforcement.md](adr-008-hard-deadline-enforcement.md) — Phase B deadline supervisor (companion ADR)
+- [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) — Phase A WAL policy + v2 amendment (Outbox + Reconciler, the §C re-evaluation)
+- [adr-010-external-committer-coexistence.md](adr-010-external-committer-coexistence.md) — Phase A obsidian-git cooperation pattern (operationalizes §6 detection)
+- [lessons.md](../lessons.md) — "Cooperative external committer needs explicit coordination" (load-bearing rationale)
+- obsidian-git plugin: https://github.com/Vinzent03/obsidian-git
+- Per-write cost analysis: `src/hive/_helpers.py:702-753` (`_git_commit` — the two `subprocess.run` calls at lines 727 and 734)
+- HIVE-104 spec (archived): `specs/archive/HIVE-104-write-throughput/`
+- HIVE-115 spec: `specs/HIVE-115-latency-tail-redesign/` (forthcoming)

--- a/docs/adr/adr-007-mcp-cancellation-response.md
+++ b/docs/adr/adr-007-mcp-cancellation-response.md
@@ -1,0 +1,143 @@
+---
+id: adr-007-mcp-cancellation-response
+type: adr
+status: active
+created: "2026-05-20"
+---
+
+## Status
+Accepted (2026-05-20) — written after diagnosing a "ghost response" failure mode reported by the user on 2026-05-20 during write-heavy MCP flows.
+
+**Amended 2026-05-20** (same day, post-investigation during HIVE-104 spec drafting): a Sonnet subagent located the upstream framing utility `BaseSession._send_response` at `mcp/shared/session.py:337-349` AND surfaced that `RequestResponder.cancel()` already calls `_send_response` with an `ErrorData` payload at `session.py:148-150` BEFORE `_patched_respond` fires. This means the "best-effort raw send" decision in §1 below is **duplicate-unsafe** under the scenario where the cancellation ErrorData reaches the wire — sending our success after it would create two responses for the same `request_id`, which some MCP clients treat as a protocol error (worse than the current silent-suppress state). An empirical integration test in HIVE-104 (AC-3) will deterministically classify the actual cancellation behavior; if the ErrorData-wins scenario is observed, this ADR's §1 needs a follow-up amendment (best-effort send → conditional suppression with observability counter, possibly via out-of-band notification). §2 (observability), §3 (was emergency opt-out, now removed), and §4 (upstream tracking) stand unchanged.
+
+**Amended 2026-05-20 (#2)** — empirical test resolved: `tests/test_compat_shim.py::test_classify_cancellation_race` ran 20 iterations against a real hive subprocess on Linux. **All 20 iterations showed scenario (a)** — `RequestResponder.cancel()`'s `_send_response(ErrorData)` always wins the race; the wire response is invariably `{"id": N, "error": {"code": 0, "message": "Request cancelled"}}`. **Decision §1 is therefore retracted**: "best-effort raw send" would produce a duplicate response in 100% of cases (protocol violation worse than the status quo). The revised Fase C plan is **observability-only**: keep silent suppression as the delivery behavior, add WARNING `mcp.ghost_response.suppressed_after_cancel_ack` with tool name and request id, increment counter exposed in `vault_health` as `ghost_responses: {total, last_seen, last_tool}`, and document the semantic mismatch in README + docs site (the cancellation ack reaches the wire but the operation may have completed on disk; correct client behavior is `vault_query` to verify state, not retry). §2 (observability) and §4 (upstream tracking) stand unchanged and now carry the full Fase C decision. The `pyproject.toml` minimum-`mcp` pin recommended in Amendment #1 is no longer necessary — Hive does not call `_send_response` directly.
+
+## Context
+
+[adr-005-transport-and-scale.md](adr-005-transport-and-scale.md) documented the original fix in `src/hive/_compat.py`: a monkey-patch on `mcp.shared.session.RequestResponder.respond` that short-circuits when `_completed=True`, preventing the upstream SDK's `AssertionError: Request already responded to` from killing the stdio receive loop after a client cancellation. ADR-005 marked this fix as "Residual risk: None; self-gated, removable when upstream fixes."
+
+After 2 days of operation (and previously 2 months in earlier form), a **new user-visible failure mode** has emerged that ADR-005 did not anticipate.
+
+### The ghost response
+
+User-reported behavior (2026-05-20):
+
+1. Client (Claude Code) sends `vault_write` tool call.
+2. Hive handler completes successfully: file is written, git commit succeeds.
+3. **No JSON-RPC response reaches the client.**
+4. Client tool-call timeout fires (~30–60 s depending on transport config).
+5. Client retries the write via a different mechanism (e.g. filesystem MCP) and discovers the file is already at the desired state.
+6. User experiences: long inexplicable wait + redundant retry + confusion.
+
+### Root cause
+
+The path from handler return to stdio write (`src/hive/_compat.py:75-90`, `_patched_respond`):
+
+```python
+async def _patched_respond(self, response):
+    if not self._entered:
+        raise RuntimeError("RequestResponder must be used as a context manager")
+    if self._completed:                              # ← here
+        _log.debug("Suppressed respond() on already-completed responder %s ...")
+        return                                       # ← bytes never written
+    await original_respond(self, response)
+```
+
+`self._completed` is set by the upstream `RequestResponder` when the client sends `notifications/cancelled`. The sequence that produces a ghost response:
+
+1. Client issues `tools/call`. Handler starts. Write window opens (50–500 ms typical).
+2. Client-side tool-call timeout fires (or user cancels). Client emits `notifications/cancelled`.
+3. Upstream `_received_notification` sets `_completed = True` on the responder.
+4. Handler returns successfully. FastMCP awaits `responder.respond(result)`.
+5. Patched `respond` sees `_completed=True`, logs a DEBUG line, and **returns silently**.
+6. JSON-RPC response is never framed and never written to stdio.
+7. Client never sees a response → its retry path activates.
+
+The DEBUG log is below the default INFO level (`src/hive/server.py:435`), so the suppression is **invisible to operators**.
+
+### Why this matters now
+
+The original silent-suppress decision in ADR-005 traded a hard crash (AssertionError kills the receive loop, all subsequent calls hang) for a soft failure (one response is silently dropped). At the time, this was correct — a single dropped response is recoverable; a dead server is not.
+
+But the soft failure has compounded into a real UX problem:
+
+- It is invisible in logs (DEBUG-level log; default level INFO).
+- The "phantom retries" by the client are not free — each retry costs another round-trip and another write window.
+- It interacts badly with the per-write commit cost addressed in [adr-006-commit-policy.md](adr-006-commit-policy.md): longer writes widen the race window, more cancellations fire, more responses are dropped.
+- Multi-process load (per ADR-005's table at >5 sessions) makes it worse.
+
+### The trade-off space
+
+Three options for `_patched_respond` when `_completed=True`:
+
+| Option | Behavior | Failure mode |
+|---|---|---|
+| **A — Silent suppress** (status quo) | Drop the response, log DEBUG. | Ghost responses; invisible to operators. |
+| **B — Fail-loud** | Re-raise the `CancelledError` so FastMCP surfaces an error. | Risks regressing to the original AssertionError if upstream SDK still strict in some code path. |
+| **C — Best-effort raw send** | Attempt a direct stdio write of the framed JSON-RPC response, bypassing the upstream `respond()` machinery; on failure, fall back to A. | Best-of-both: client gets the response when possible, falls back safely otherwise. |
+
+## Decision
+
+### 1. Switch to best-effort raw send (Option C)
+
+`_patched_respond` is modified to attempt a direct stdio write of the JSON-RPC response when `self._completed` is `True`, **before** silently returning. Specifically:
+
+- Serialize the response to the wire format (JSON-RPC + framing) using the same encoder upstream uses.
+- Write to the underlying stdio writer with a short timeout (e.g. 1 s) to avoid hanging if the writer is itself broken.
+- On success: log **INFO** with `tool_name`, `request_id`, write duration. Increment a counter in `ServerContext`.
+- On any exception: log **WARNING** with full context (`tool_name`, `request_id`, exception type), then return silently — preserving the ADR-005 crash-prevention guarantee.
+
+### 2. Make suppressions observable
+
+Two visibility changes regardless of whether the raw send succeeds:
+
+- A WARNING-level log line with the prefix `mcp.ghost_response` so users can grep for it.
+- `vault_health` surfaces a counter: `ghost_responses: { total: N, last_seen: <timestamp>, last_tool: <name> }`.
+
+Without observability, this failure mode regresses to invisible.
+
+### 3. Document the upstream dependency
+
+Until [modelcontextprotocol/python-sdk#2610](https://github.com/modelcontextprotocol/python-sdk/issues/2610) ships, this shim is load-bearing. The check-in routine `trig_01WQwBTKu9zUDfiobrJn2pyk` (scheduled 2026-05-24, per current operational memory) continues. When the upstream fix lands, **both** `_patched_respond` and `_patched_exit` are candidates for removal — the existing routine covers this.
+
+## Alternatives considered
+
+### A) Status quo (silent suppress)
+
+Rejected. The failure mode is real, user-reported, and invisible. Even if we could not recover the response, making the suppression observable (decision §2 above) is non-negotiable.
+
+### B) Fail-loud — re-raise `CancelledError`
+
+Rejected. The original AssertionError that ADR-005 fixed was load-bearing: it killed the receive loop and froze the server. Re-raising any exception from `respond()` risks the same outcome if the upstream session handling has not changed since ADR-005 was written. The cost of a regression here (server hang) is much higher than the cost of a ghost response (client retry).
+
+### C) **Chosen: Best-effort raw send + observable fallback**
+
+Rejected nothing here. See decision §1.
+
+### D) Wait for upstream SDK fix
+
+Rejected as a sole strategy. We have no control over the upstream timeline. The user pain is real now. This ADR is a bridge until upstream lands, after which both shims can be removed (per ADR-005's "removable when upstream fixes" note).
+
+### E) Buffer responses in a queue, send on next idle tick
+
+Rejected. Adds asyncio lifecycle complexity that is exactly the kind of thing ADR-005 and [adr-006-commit-policy.md](adr-006-commit-policy.md) explicitly avoid. The raw-send path is simpler and addresses the same problem.
+
+## Consequences
+
+- **Most ghost responses recovered**: when the client cancellation arrives after the handler completed but before the response was framed, the raw send should succeed and the client receives a normal response. No retry needed, no user-visible hang.
+- **Residual ghost responses become observable**: any case the raw send cannot handle is logged at WARNING with a recognizable prefix, and `vault_health` exposes the count. Future regressions are visible without DEBUG-level logging.
+- **Crash-prevention guarantee preserved**: the silent-suppress fallback for raw-send failures keeps the original ADR-005 contract — no upstream AssertionError can kill the receive loop.
+- **Marginal new failure mode**: if the raw stdio writer itself is in a bad state (e.g. partially closed, broken pipe), the raw-send attempt could log a WARNING + fall back. This is strictly more observable than the status quo, not less reliable.
+- **No new lifecycle**: zero background tasks, zero SQLite changes. Touches `_compat.py` and `vault_health` only.
+- **Pairs well with [adr-006-commit-policy.md](adr-006-commit-policy.md)**: once writes are fast (5–15 ms via `commit=False`), the race window shrinks dramatically and ghost responses become much rarer in practice. ADR-007 is the safety net; ADR-006 is the prevention. They are complementary, not redundant.
+- **Upstream removal path stays clean**: when `python-sdk#2610` ships, both `_patched_respond` and `_patched_exit` can be deleted together. This ADR does not add anything that prevents that.
+
+## References
+
+- [adr-005-transport-and-scale.md](adr-005-transport-and-scale.md) — documented the original shim; this ADR refines its behavior based on observed failure mode
+- [adr-006-commit-policy.md](adr-006-commit-policy.md) — interrelated; ADR-006 shrinks the race window, ADR-007 handles whatever race remains
+- Upstream issue: https://github.com/modelcontextprotocol/python-sdk/issues/2610
+- Current shim: `src/hive/_compat.py:75-90` (`_patched_respond`)
+- Default log level: `src/hive/server.py:435`
+- Per-PID logs (introduced PR #92): `~/.local/share/hive/hive-{pid}.log`
+- HIVE-104 spec (forthcoming): `specs/HIVE-104-write-throughput/`

--- a/docs/adr/adr-008-hard-deadline-enforcement.md
+++ b/docs/adr/adr-008-hard-deadline-enforcement.md
@@ -1,0 +1,233 @@
+---
+id: adr-008-hard-deadline-enforcement
+type: adr
+status: active
+created: "2026-05-21"
+---
+
+# ADR-008: Hard Deadline Enforcement via `bounded_call` Supervisor
+
+## Status
+
+Proposed (2026-05-21) — Phase B piece of HIVE-115, shipping in the v1.16.0 release bundle alongside [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) v1 + [adr-010-external-committer-coexistence.md](adr-010-external-committer-coexistence.md) + the Outbox + Reconciler (ADR-009 v2 amendment). Closes issue #111.
+
+## Context
+
+[adr-005-transport-and-scale.md](adr-005-transport-and-scale.md) introduced `tool_span`: an `asyncio.timeout(ctx.tool_timeout)` context manager wrapping every async tool handler. It was the first defense-in-depth layer of a four-tier model (documented in the maintainer's cross-project async-threading pattern):
+
+1. `asyncio.timeout()` on async tool handlers — this ADR's predecessor.
+2. `Lock.acquire(timeout=30)` on thread-blocking points.
+3. `subprocess.run(..., timeout=30)` on child processes.
+4. `httpx` per-request timeouts.
+
+Each layer enforces its own deadline correctly at its own execution model. The model was thought to provide an end-to-end deadline contract: `HIVE_TOOL_TIMEOUT=60` should bound any tool call to 60 seconds.
+
+Two months of production revealed that **the composition does not enforce a global deadline**.
+
+### Empirical evidence (issue #111)
+
+```text
+2026-05-21 19:10:48,690 INFO  Processing request of type CallToolRequest
+2026-05-21 19:24:47,047 WARNING git commit timed out for ['10_projects\hive\90-lessons.md']
+2026-05-21 19:24:47,047 INFO  mcp ok method=tools/call tool=capture_lesson id=11 elapsed_ms=838360
+```
+
+`capture_lesson` returned successfully after **838 seconds** while `ctx.tool_timeout = 60`. 14× over contract.
+
+Additional repro cases from a 2026-05-22 follow-up session attached to the same issue:
+
+| Tool | Configured `tool_timeout` | Observed elapsed | Client-visible result |
+|---|---|---|---|
+| `capture_lesson` (worker path) | 60s | 838s | hive.log shows "ok" 14m later; client got no reply or treated as rejection |
+| `capture_lesson` (inline path) | 60s | >60s (write completed) | client interpreted silence as user-rejection |
+| `vault_commit` | 60s | >60s (commit eventually succeeded via obsidian-git tick) | client got canned "Server busy" string |
+| `vault_patch` | 60s | 60s | hive's outer envelope returned the "timeout" message correctly |
+
+Only `vault_patch` exits cleanly at 60s. Every other path runs longer than the deadline and produces a different visible failure mode (silent, rejected-by-user, canned-busy).
+
+### Root cause: `asyncio.timeout` cannot interrupt non-async work
+
+`asyncio.timeout(60)` cancels at `await` points. Once execution enters:
+
+- `asyncio.to_thread(...)` → asyncio cancels the future, but Python has no portable way to interrupt the running thread. The thread continues until its own loop reaches a yield point that observes the cancellation.
+- `Lock.acquire(timeout=30)` → enforces only its own 30s deadline. Composed with retries, can chain to 60+ seconds.
+- `subprocess.run(..., timeout=30)` → enforces only its own 30s. Once the subprocess is started, the asyncio cancel cannot stop it; only the subprocess's own timeout can. If the subprocess respawns or chains, the budget compounds.
+- `httpx.AsyncClient` calls without per-request timeout → inherit client `http_timeout` (default 60s in hive). Cancellation propagates but only at next yield point.
+
+So a single tool call can chain: Ollama probe (cached, ~ms) → OpenRouter HTTP probe (60s) → `vault_write` (sync) → `_git_commit` (30s filelock + 30s subprocess) → repeat. Total wall time bounded only by the union of individual layer timeouts, not the global 60s envelope.
+
+### Why this is the riskiest fix of HIVE-115
+
+Killing a subprocess mid-flight is platform-specific and can leave shared state in inconsistent positions:
+
+- **`.git/index.lock` stale state**: if hive's git subprocess holds the lock and we `SIGTERM` it mid-commit, the lock file remains on disk. Future git invocations (hive AND obsidian-git AND user manual) see a phantom lock until cleanup.
+- **SQLite mid-transaction**: WAL guarantees rollback on next open, but the writer must wait for the WAL replay. Negligible most cases.
+- **Partial subprocess output**: `Popen.terminate()` does not flush stdout/stderr buffers. Captured output may be truncated.
+- **Windows specifics**: `Popen.terminate()` calls `TerminateProcess`, which is NOT graceful — no opportunity for child process cleanup. Subprocess descendants (git → git-add → git-pack) may orphan.
+
+The decision must be robust against all of these.
+
+## Decision
+
+### 1. Introduce `bounded_call(fn, deadline_s, ...)` supervisor
+
+A new helper in `src/hive/_helpers.py` (or `src/hive/_deadline.py` as standalone module). Signature roughly:
+
+```python
+async def bounded_call(
+    fn: Callable[..., T],
+    *args,
+    deadline_s: float,
+    process_registry: list[subprocess.Popen] | None = None,
+    **kwargs,
+) -> T:
+    """Run fn with hard deadline. Terminates registered subprocesses on expiry."""
+```
+
+Behavior on deadline expiry:
+
+1. Cancel the running future (asyncio mechanism, best-effort signal to worker thread).
+2. For each `Popen` in `process_registry`: `terminate()` (POSIX `SIGTERM`, Windows `TerminateProcess`). Sleep 2s (grace period).
+3. Any Popen still running: `kill()` (POSIX `SIGKILL`, Windows `TerminateJobObject` if `CREATE_NEW_PROCESS_GROUP` was set on creation).
+4. Drain stdout/stderr buffers (best-effort).
+5. Cleanup `.git/index.lock` **only if** our Popen.pid wrote it (verified by reading the PID in the lock file). Never touch another process's lock.
+6. Raise `mcp.protocol.TimeoutError` with structured payload `{tool, deadline_s, elapsed_s, subprocess_killed: N}`.
+
+The registry is passed **explicitly** as a parameter (not via `contextvars`), because `asyncio.to_thread` boundary makes contextvar propagation fragile across the async/sync layer.
+
+### 2. Migrate `subprocess.run → subprocess.Popen` in all git callsites
+
+`subprocess.run` is a one-shot helper that does not expose the Popen handle. The supervisor needs the handle. Refactor:
+
+```python
+# Before
+result = subprocess.run(
+    ["git", "add", *paths], capture_output=True, text=True, timeout=30, cwd=vault,
+)
+
+# After
+with subprocess.Popen(
+    ["git", "add", *paths], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    text=True, cwd=vault,
+    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if IS_WINDOWS else 0,
+) as proc:
+    process_registry.append(proc)
+    try:
+        stdout, stderr = proc.communicate(timeout=30)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        try:
+            proc.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+        raise
+    finally:
+        process_registry.remove(proc)
+```
+
+Affected sites (5 in `_helpers.py` per HIVE-104 audit):
+
+- `_git_commit(paths, message)` — `git add` + `git commit`
+- `_git_commit_all(message)` — `git add -A` + `git commit`
+- `_git_log_recent(...)` — `git log`
+- `_current_head_sha()` — `git rev-parse` (probably fast enough to skip, but consistent)
+- `git_status` callers in `vault_health` and `session_briefing`
+
+### 3. Cross-OS termination chain
+
+| OS | Step | Mechanism |
+|---|---|---|
+| POSIX | terminate() | `SIGTERM` |
+| POSIX | grace | 2s sleep |
+| POSIX | kill() | `SIGKILL` |
+| Windows | Popen creation | `creationflags=CREATE_NEW_PROCESS_GROUP` (lets terminate() reach child tree) |
+| Windows | terminate() | `TerminateProcess` |
+| Windows | grace | 2s sleep |
+| Windows | kill() | re-terminate (TerminateProcess is non-graceful by definition; second call ensures descendants drop) |
+
+On Windows, `subprocess.Popen.terminate()` calls `TerminateProcess` on the immediate child. Without `CREATE_NEW_PROCESS_GROUP`, git's spawned helpers (`git-add.exe`, `git-pack.exe`) may orphan. With it, the entire process group goes down together.
+
+### 4. `.git/index.lock` ownership check
+
+```python
+def _cleanup_index_lock(vault: Path, our_pid: int) -> None:
+    lock_path = vault / ".git" / "index.lock"
+    if not lock_path.exists():
+        return
+    try:
+        lock_contents = lock_path.read_text().strip()
+        if str(our_pid) == lock_contents:
+            lock_path.unlink()
+            log.info(f"Cleaned up own index.lock from pid={our_pid}")
+        else:
+            log.info(f"Skipping index.lock cleanup; owner is {lock_contents}, not us ({our_pid})")
+    except OSError as e:
+        log.warning(f"Could not check index.lock ownership: {e}")
+```
+
+Never touches a lock written by another PID. obsidian-git's lock is safe.
+
+### 5. Client-visible error surface
+
+On deadline expiry, the tool returns an `mcp.protocol.TimeoutError` (or hive-specific structured error string) — NOT silence, NOT a canned "Server busy" message, NOT a fake-success. The client gets a recognizable, retriable error within `deadline_s + grace_s` of the call start.
+
+### 6. Wrap all tool handlers (replace `tool_span`)
+
+`tool_span` (the current `asyncio.timeout`-only wrapper) is replaced by `bounded_call`. `wrap_sync_tool` decorator and all 7 vault tools + `delegate_task` + `capture_lesson` route through the new supervisor.
+
+Backward compatibility: the env var `HIVE_TOOL_TIMEOUT` (default 60) is honored; only the enforcement mechanism changes. Tools see no API change.
+
+## Alternatives considered
+
+### A) Keep `asyncio.timeout`-only `tool_span`
+
+**Rejected.** Empirical evidence shows it does not enforce the contract. 14× over deadline is a contract violation, not a slow path.
+
+### B) Re-raise `CancelledError` aggressively in workers
+
+**Rejected.** Pattern would require every worker function to check a cancellation token on every iteration / before every blocking call. Massively invasive across the codebase. Does not solve subprocess hangs (cannot check inside subprocess.run).
+
+### C) Per-step timeouts only (status quo, abandon global deadline contract)
+
+**Rejected.** Means `HIVE_TOOL_TIMEOUT` is meaningless documentation. Users have explicitly relied on it. Removing the contract is worse than enforcing it.
+
+### D) Move to an out-of-process timeout watchdog (separate Python process)
+
+**Rejected.** Inverts the orchestration model. Same cross-OS termination problem at a different layer. Phase C's daemon model (ADR-011) is a cleaner way to introduce a long-running supervisor; for Phase B, in-process supervisor is correct.
+
+### E) Use `signal.SIGALRM` on POSIX for thread interruption
+
+**Rejected.** SIGALRM is async-signal-safe but interacts badly with asyncio (handler runs in main thread regardless of which thread blocked). Windows has no equivalent. Not portable.
+
+## Consequences
+
+- **Positive**: `HIVE_TOOL_TIMEOUT` becomes a hard contract. 14× violations of the 60s deadline disappear structurally. Users see deterministic behavior or recognizable errors, not silent hangs.
+- **Positive**: client retry behavior becomes correct. With `mcp.protocol.TimeoutError` surfaced, retries are intentional, not "the host thinks the user rejected the call".
+- **Positive**: Phase B Outbox + Reconciler ([adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) v2) gains preemption authority over its reconciler thread. Without `bounded_call`, the reconciler itself becomes a new hang surface.
+- **Positive**: structured timeout events feed Phase B/C decision-making (`tool_timeout_exceeded` count is a gate signal).
+- **Negative**: `subprocess.run → Popen` refactor across 5 callsites is invasive. ~150 LOC of mechanical migration + careful testing.
+- **Negative**: cross-OS termination behavior is not perfectly symmetric (POSIX SIGTERM is graceful, Windows TerminateProcess is not). Documented and tested per-OS.
+- **Negative**: 2-second grace period on terminate is added latency for already-overflowing cases. Acceptable: a 62s response beats an 838s response by a margin large enough that the grace is invisible.
+- **Marginal**: regression risk in git interactions. Heavy test coverage in PR (regression tests per #111 ACs, plus subprocess hang termination, plus partial-commit prevention).
+
+## §5 — Cooperative-lock eviction (HIVE-116 amendment, 2026-05-28)
+
+The hard-deadline mechanism specified in §§1–4 closes the "stuck subprocess" failure mode by terminating registered Popens on expiry. Empirical use surfaced a residual gap: when the worker thread holding the in-process `.git/hive.lock` filelock is stuck in `proc.communicate()` after the kill (Windows-specific stdio drain on terminated children), the lock object stays cached and sibling workers block on subsequent acquires.
+
+[adr-012-cooperative-filelock-eviction-on-deadline.md](adr-012-cooperative-filelock-eviction-on-deadline.md) extends the supervisor's deadline branch with a post-kill drain (default `HIVE_POST_KILL_DRAIN_S=5.0`s) followed by eviction of the cached `FileLock` from `_GIT_FILELOCKS`. This is cooperation, not preemption — Python cannot cancel a thread; the eviction lets new acquires bypass the runaway holder.
+
+The amendment does not modify §§1–4; existing termination semantics (SIGTERM→grace→SIGKILL on POSIX, TerminateProcess×2 on Windows) stand. The new step inserts between `_cleanup_index_lock` and `GHOST_RESPONSES.record`, with telemetry persisted via `LockEvictionTracker` for the 2026-06-05 Phase C decision input.
+
+## References
+
+- [adr-005-transport-and-scale.md](adr-005-transport-and-scale.md) — original `tool_span` introduction; superseded for enforcement mechanism by this ADR (defense-in-depth model preserved)
+- [adr-007-mcp-cancellation-response.md](adr-007-mcp-cancellation-response.md) — `_compat.py` ghost-response handling; orthogonal but interacts (this ADR shrinks the ghost-response race window further)
+- [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) — companion ADR (SQLite half); shares the `mcp.lock_contention` telemetry surface
+- [adr-010-external-committer-coexistence.md](adr-010-external-committer-coexistence.md) — companion ADR (git half); same release bundle
+- [lessons.md](../lessons.md) — "Three timeouts in a chain aren't a deadline" (load-bearing rationale)
+- Spec: `specs/HIVE-115-latency-tail-redesign/` (forthcoming)
+- Issue #111: https://github.com/mlorentedev/hive/issues/111
+- Python subprocess docs: https://docs.python.org/3/library/subprocess.html#subprocess.Popen.terminate
+
+<!-- Provenance (maintainer's cross-project knowledge store; not linked to preserve repo->store independence): pattern-async-threading §1 (four-layer defense-in-depth; this ADR refines it — ONE layer must own preemption). HIVE-115 backlog tracked in the forge (GitHub issues / milestones). -->

--- a/docs/adr/adr-009-multi-process-wal-policy.md
+++ b/docs/adr/adr-009-multi-process-wal-policy.md
@@ -1,0 +1,152 @@
+---
+id: adr-009-multi-process-wal-policy
+type: adr
+status: active
+created: "2026-05-21"
+---
+
+# ADR-009: SQLite WAL Checkpoint Policy Under Multi-Process Orchestration
+
+## Status
+
+Proposed (2026-05-21) — Phase A v1 of HIVE-115. Will be **amended (v2)** by Phase B Outbox + Reconciler design once Phase A telemetry validates the contention model. v2 amendment is pre-scheduled in the same release bundle (v1.16.0); v1 is the standalone defensive policy.
+
+## Context
+
+[adr-004-thread-safety-model.md](adr-004-thread-safety-model.md) established intra-process SQLite safety via `threading.Lock` + `PRAGMA journal_mode=WAL` + `PRAGMA busy_timeout=10000`. [adr-005-transport-and-scale.md](adr-005-transport-and-scale.md) established the inter-process orchestration model (stdio, one MCP server subprocess per Claude Code session) and dimensioned the scale envelope as "1-3 sessions = fine, 5 = occasional waits, 10+ = visible lag". The maintainer's multi-process-mcp-server pattern codified primitives 1-4 for this orchestration.
+
+Two months of production use revealed that **the actual baseline daily usage is N=3-5 concurrent Claude Code sessions per user, not the edge of the scale table**. At that N, the WAL behavior under stress is not what ADR-005's table predicted.
+
+### Empirical evidence (2026-05-21 local snapshot)
+
+Local Linux session of hive maintainer, mid-day with 3 Claude Code windows open:
+
+```text
+$ ps -eo pid,etime,cmd | grep hive-vault
+ 475646       25:45 .../hive-vault    ← 25 min old
+ 529429        6:45 .../hive-vault    ←  7 min old
+ 540650        3:39 .../hive-vault    ←  4 min old
+
+$ lsof ~/.local/share/hive/*.db
+hive-vault 475646  ... worker.db  relevance.db  lesson_reinforcement.db
+hive-vault 529429  ... worker.db  relevance.db  lesson_reinforcement.db
+hive-vault 540650  ... worker.db  relevance.db  lesson_reinforcement.db
+
+$ ls -lah ~/.local/share/hive/*.db*
+12K   lesson_reinforcement.db
+157K  lesson_reinforcement.db-wal   ← 13× ratio
+53K   relevance.db
+4.1M  relevance.db-wal              ← 77× ratio
+8.2K  worker.db
+91K   worker.db-wal                 ← 11× ratio, last modified 2026-03-13 (2 months ago)
+```
+
+**Every concurrent hive process holds open file handles to ALL three SQLite databases**, regardless of which trackers a given tool call needs. The reader snapshots never release because the processes never exit. `relevance.db-wal` reaches 77× the size of the steady-state DB; `worker.db-wal` was last checkpointed 2 months ago.
+
+Reported on Windows by an independent user (issue #110): identical pattern, plus contention with obsidian-git (10-min `autoSaveInterval` + `pullBeforePush=true`) producing 838s `capture_lesson` outliers (issue #111).
+
+### Why the prior plan is insufficient
+
+PRAGMA `journal_mode=WAL` + `wal_autocheckpoint=200` (multi-process-mcp-server pattern §2) does **not** mean "WAL stays small". Any concurrent reader holding a snapshot blocks checkpoint advancement past the frame it's reading. With process-per-client orchestration at N=3-5 baseline, there is virtually always a snapshot holder; the WAL grows unboundedly.
+
+A naive mitigation — "call `PRAGMA wal_checkpoint(TRUNCATE)` on shutdown" — is **virtually inert at N=3-5 baseline** because there is rarely a "last process to shut down". A user always has at least one Claude Code window open. The shutdown drain never fires; the WAL grows indefinitely.
+
+Future state (per HIVE-115 backlog): agent-driven hive workloads may reach N=10-15 concurrent clients per machine. The current architecture must scale at least to N=3-5 baseline without growth pathology; the eventual daemon pivot (ADR-011) addresses the higher tail.
+
+### Constraint: cannot break ADR-005's stay-on-stdio invariant
+
+Phase A is **defensive**, not architectural. Whatever this ADR decides must work within the current stdio multi-process orchestration model. Changes that require a new transport, a new lifecycle, or breaking the per-session subprocess contract belong in ADR-011 (Phase C daemon model), not here.
+
+## Decision
+
+### 1. PRIMARY: Periodic `PRAGMA wal_checkpoint(PASSIVE)` thread per hive process
+
+Each `_SqliteTracker` subclass starts a `threading.Thread(daemon=True)` on init. The thread runs an infinite loop with a 30-second sleep, executing `PRAGMA wal_checkpoint(PASSIVE)` against the tracker's connection on each tick. PASSIVE does NOT block readers and advances checkpoint as far as the current frame state allows.
+
+This is the **primary drain mechanism** under N>1 baseline. PASSIVE is cooperative: it advances what it can without disturbing concurrent reads, so it never causes contention. At N=3-5 over multiple hours, even partial advancement drains the steady-state WAL growth.
+
+Thread is `daemon=True` so it dies with the parent process — does not leak as zombie. Sleep interval is tunable via `HIVE_WAL_CHECKPOINT_INTERVAL_S` (default 30).
+
+### 2. SECONDARY: `PRAGMA wal_checkpoint(TRUNCATE)` on graceful shutdown
+
+Each `_SqliteTracker.close()` invokes `PRAGMA wal_checkpoint(TRUNCATE)` before closing the connection. TRUNCATE only fully succeeds when no other connection holds a snapshot — under N=3-5 it usually degrades to PASSIVE-equivalent behavior. Wrapped in a 2-second wall-clock guard via `threading.Timer` so a hung checkpoint cannot block shutdown.
+
+When N IS 0 (the last hive process shuts down), TRUNCATE truncates the WAL fully — the only opportunity for full drain. Not the primary mechanism, but valuable when it fires.
+
+### 3. Observability via `vault_health(include_runtime=True)`
+
+The runtime block surfaces:
+
+- `wal_size_bytes`: sum of `*.db-wal` file sizes in `~/.local/share/hive/` (cheap stat call).
+- `competing_pid_count`: distinct PIDs (excluding self) holding open file handles on our DBs, via `psutil.process_iter(['name','pid','open_files'])`. Filtered strictly by `name() == "hive-vault"` (cross-OS stem match) + same UID + LRU-cached 30s to amortize `process_iter` cost (~100ms on Windows).
+- `last_git_lock_wait_ms`: rolling N=100 ring buffer of `_GIT_LOCK.acquire()` wait times. Mean + p99.
+- `obsidian_git_present`: boolean from `detect_obsidian_git()` (already implemented in HIVE-104).
+
+These metrics directly inform the Phase B gate (when to ship Outbox + Reconciler) and the Phase C trigger (when to ship daemon).
+
+### 4. Tunable lock timeout + structured logging
+
+`HiveSettings.lock_timeout_s` (env: `HIVE_LOCK_TIMEOUT_S`, default 30) replaces the hardcoded `30` in `_helpers.py`. Capped at 600 to prevent foot-guns.
+
+Every `_GIT_LOCK.acquire(timeout=...)` attempt emits a structured log:
+
+```json
+{"event": "mcp.lock_contention", "tool": "...", "lock": "_GIT_LOCK",
+ "waited_ms": 12345, "abandoned": false}
+```
+
+Phase B gating consumes these events; ops users can grep them.
+
+### 5. New dependency: `psutil`
+
+Added to `pyproject.toml` runtime deps. ~750KB pure-Python wheel + small C extension. Cross-platform process introspection. Already a standard MCP-server dep elsewhere. Filtered strictly to avoid antivirus / backup-tool false positives in `competing_pid_count`.
+
+## Alternatives considered
+
+### A) `?mode=ro` for non-writer connections
+
+**Rejected.** Initial Phase B design assumed `?mode=ro` connections would not block checkpoints. **This is wrong:** read-only SQLite connections still hold WAL snapshots that block `wal_checkpoint` from advancing past their frame. `?mode=ro` only prevents accidental writes — it does not reduce contention. The real fix is **short transactions** (open → query → close per call), which is the Phase B (ADR-009 v2) refinement.
+
+### B) `PRAGMA wal_checkpoint(TRUNCATE)` on shutdown alone
+
+**Rejected as PRIMARY mechanism, kept as fallback (§2).** At N=3-5 baseline there is rarely a "last process to shut down", so the drain virtually never fires. PASSIVE periodic (§1) is the actual drain.
+
+### C) Outbox + Reconciler pattern (Phase B preview)
+
+**Deferred to ADR-009 v2 amendment.** Outbox + Reconciler is the structural fix that lets us OPEN-CLOSE-PER-CALL connections (short transactions), eliminates the long-lived snapshot problem at source, and unifies SQLite + git coordination. But it is a larger semantic change with risk surface; it belongs in its own design pass after Phase A telemetry validates the contention model.
+
+Importantly: ADR-006 §C explicitly considered an outbox/event-sourcing pattern and rejected it twice (2026-05-18, 2026-05-20) with the gate condition: "Re-evaluate only if measurements after Option B ship show sustained dolor that obsidian-git + commit=False cannot resolve." The empirical evidence collected for HIVE-115 (4.1 MB WAL, 838s outliers, 3-5 baseline N) formally invokes that gate. ADR-009 v2 will document the re-evaluation and supersede ADR-006 §C's rejection.
+
+### D) HTTP daemon transport (Phase C, ADR-011)
+
+**Deferred.** [adr-005-transport-and-scale.md](adr-005-transport-and-scale.md) explicitly listed this as Option B and proposed it as a v2 milestone. The user's future state (agent-driven N=10-15) makes it inevitable, but it is a transport pivot that requires its own ADR and its own validation cycle. Phase A+B telemetry under real load is the input to Phase C's design. Tracked as ADR-011 (forthcoming).
+
+### E) Per-tracker dedicated writer process (CQRS variant)
+
+**Rejected** in the user-conversation phase of HIVE-115 (2026-05-21). CQRS-style write/read DB split would solve the WAL bloat for write-DBs (single writer, no contention) but only moves the problem to the read-DB. Eventual-consistency cost is high (breaks "write-then-read" contract for `capture_lesson` → `vault_search`), and the data is KB-scale (worker.db=8KB, relevance.db=53KB) so the complexity is not justified at current size. Worth revisiting only at GB-scale data or N>20 baseline. See ADR-009 v2 (forthcoming) "Alternatives considered" for the long-form rejection.
+
+## Consequences
+
+- **Positive**: WAL bloat is observable (via `vault_health`) and drained periodically (via PASSIVE thread). At N=3-5 baseline, steady-state WAL size stays bounded instead of growing 77×. `worker.db-wal`'s 2-month-stale state self-resolves on next checkpoint tick. `last_git_lock_wait_ms` distribution becomes input to Phase B parameter sizing.
+- **Positive**: ADR-006 §C gate is formally invoked with data, not intuition. Phase B (ADR-009 v2 amendment) has clean rationale for re-evaluating prior rejection of outbox.
+- **Positive**: `psutil` dep enables future telemetry (per-tracker contention, slow query detection) without re-arch.
+- **Neutral**: Added background thread per tracker (3 threads per hive process). All `daemon=True`, ~negligible CPU (sleep 30s, ~ms work per tick). No new zombie classes.
+- **Negative**: New runtime dep (psutil). ~750KB. Acceptable for the observability value.
+- **Negative**: `HIVE_LOCK_TIMEOUT_S` foot-gun risk if user sets it too low (5s) → hive abandons every commit during obsidian-git ticks. Mitigated by documented recommended range in troubleshooting.md.
+- **Marginal failure mode**: PASSIVE checkpoint thread could theoretically race with a concurrent SQLite operation if both target the same WAL frame. SQLite documentation explicitly states PASSIVE is safe to run concurrently with readers/writers — verified by `PRAGMA wal_checkpoint` documentation. No new failure mode in practice.
+
+## References
+
+- [adr-001-orchestration-model.md](adr-001-orchestration-model.md) — original Hive orchestration model (unchanged by this ADR)
+- [adr-004-thread-safety-model.md](adr-004-thread-safety-model.md) — intra-process SQLite safety; this ADR adds inter-process drain mechanism
+- [adr-005-transport-and-scale.md](adr-005-transport-and-scale.md) — established stdio multi-process model; **amended in this release** to re-baseline scale table for N=3-5 daily usage + acknowledge agent-driven future
+- [adr-006-commit-policy.md](adr-006-commit-policy.md) — **amended in this release**; ADR-006 §C "Re-evaluate" gate is invoked formally with HIVE-115 telemetry
+- [adr-007-mcp-cancellation-response.md](adr-007-mcp-cancellation-response.md) — ghost-response handling; unchanged
+- [adr-010-external-committer-coexistence.md](adr-010-external-committer-coexistence.md) — companion ADR for git lock contention (the other half of the same systemic issue)
+- [adr-008-hard-deadline-enforcement.md](adr-008-hard-deadline-enforcement.md) — `bounded_call` supervisor; orthogonal but ships in same bundle (v1.16.0)
+- [lessons.md](../lessons.md) — "SQLite WAL doesn't auto-checkpoint when N processes hold readers" (load-bearing rationale)
+- Spec: `specs/HIVE-115-latency-tail-redesign/` (forthcoming)
+
+<!-- Provenance (maintainer's cross-project knowledge store; not linked to preserve repo->store independence): pattern-multi-process-mcp-server (extended with primitives 5-7 in this release); pattern-phased-redesign-with-telemetry-gates (meta-pattern guiding HIVE-115). HIVE-115 backlog tracked in the forge (GitHub issues / milestones). -->
+- `psutil` docs: https://psutil.readthedocs.io/
+- SQLite WAL checkpoint modes: https://www.sqlite.org/pragma.html#pragma_wal_checkpoint

--- a/docs/adr/adr-010-external-committer-coexistence.md
+++ b/docs/adr/adr-010-external-committer-coexistence.md
@@ -1,0 +1,139 @@
+---
+id: adr-010-external-committer-coexistence
+type: adr
+status: active
+created: "2026-05-21"
+---
+
+# ADR-010: External Committer Coexistence (obsidian-git, pre-commit hooks)
+
+## Status
+
+Proposed (2026-05-21) — Phase A of HIVE-115. Companion to [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) (the SQLite half of the same systemic issue). Will be amended by [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) v2 (Outbox + Reconciler) with the detect-and-defer pattern, in the same release bundle (v1.16.0).
+
+## Context
+
+[adr-006-commit-policy.md](adr-006-commit-policy.md) established Hive's commit policy as "best-effort, never fail the write" and introduced the opt-in `commit: bool = True` parameter + `vault_commit` MCP tool + obsidian-git auto-detection (HIVE-104, ADR-006 §6). The detection was treated as **informational only**: surface presence in `vault_health`, no behavioral consequence.
+
+Two months of production use revealed that the informational stance is insufficient. The vault under Hive's care is the same vault under obsidian-git's care — they share `.git/index.lock` and there is no coordination between them.
+
+### Empirical evidence (issue #110, 2026-05-21)
+
+Local obsidian-git plugin config in `~/Projects/knowledge/.obsidian/plugins/obsidian-git/data.json`:
+
+```json
+{
+  "autoSaveInterval": 10,        // minutes
+  "autoPullInterval": 10,
+  "autoPullOnBoot": true,
+  "pullBeforePush": true,
+  "syncMethod": "merge"
+}
+```
+
+Operational implications:
+
+1. obsidian-git fires a backup every 10 minutes. Each backup is `pull → commit → push` (because `pullBeforePush=true`), holding `.git/index.lock` for ~5-15 seconds. The "10-minute interval" is the inter-trigger gap, NOT the lock-hold duration.
+2. `autoPullOnBoot=true` extends the lock window at session start.
+3. Hive's `_GIT_LOCK.acquire(timeout=30)` (`_helpers.py:551`, hardcoded `_LOCK_TIMEOUT=30`) blocks during the obsidian-git window. When it abandons after 30s, hive logs a WARNING and proceeds without a commit — silent data trail loss in `git log`.
+
+Reported as issue #110 with Windows repro: silent 30-second freezes per call coinciding with obsidian-git ticks, propagating into the 838s `capture_lesson` outlier of issue #111 (combined with `tool_span` non-preemption; see [adr-008-hard-deadline-enforcement.md](adr-008-hard-deadline-enforcement.md)).
+
+### Why "best-effort" is now a bug
+
+ADR-006's "best-effort, never fail the write" was correct in isolation: if git is busy, hive should not fail the user's `vault_write`. But:
+
+- The user expects "I wrote it, it's in git". Silent commit abandonment violates that contract subtly.
+- The 30-second wait BEFORE the abandonment is itself a UX failure.
+- Without telemetry, there is no signal to operators that the coexistence is contentious.
+- The pre-existing `detect_obsidian_git()` informational surface (HIVE-104) is unused — its data should DRIVE behavior, not just describe it.
+
+### Constraint: cannot bypass `.git/index.lock`
+
+Hive must not bypass git's filelock — that would risk index corruption visible to all parties (Obsidian UI, hive, user's manual git commands). The fix lives in cooperation, not circumvention.
+
+## Decision
+
+### 1. Promote `detect_obsidian_git()` from informational to first-class design concept
+
+`obsidian_git_present: bool` is surfaced in `vault_health(include_runtime=True)` alongside other runtime telemetry from [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md). This is the foundation; subsequent ADRs (v2 amendments) use this signal to drive behavioral changes.
+
+In Phase A (this ADR), the promotion is observability-only — `detect_obsidian_git()` is read at every `vault_health` call (cached 30s) and its presence is exposed. Behavioral coupling is deferred to Phase B ([adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) v2 amendment, detect-and-defer pattern).
+
+### 2. `HIVE_LOCK_TIMEOUT_S` env-tunable
+
+Hive's `_LOCK_TIMEOUT` (currently hardcoded 30 in `_helpers.py:551`) becomes `HiveSettings.lock_timeout_s` (env: `HIVE_LOCK_TIMEOUT_S`, default 30, capped at 600). Users with large vaults experiencing extended obsidian-git windows (e.g. large pull on a slow network) can raise the value. Users wanting fail-fast can lower it.
+
+Capped at 600 to prevent foot-guns (a 1-hour timeout would freeze the user's entire session).
+
+### 3. Structured logging per `_GIT_LOCK` acquire attempt
+
+Every call to `_GIT_LOCK.acquire(timeout=ctx.lock_timeout_s)` emits exactly one structured log:
+
+```json
+{"event": "mcp.lock_contention", "tool": "<tool_name>", "lock": "_GIT_LOCK",
+ "waited_ms": 12345, "abandoned": false, "obsidian_git_present": true}
+```
+
+- `waited_ms` is captured with `time.monotonic()` brackets around the acquire call.
+- `abandoned=true` indicates the timeout fired and the write was not committed (best-effort behavior preserves).
+- `obsidian_git_present` correlates the contention with the suspected source.
+
+These events are the input data for the Phase B gate decision (when to ship Outbox + Reconciler) and for ops users grepping their logs.
+
+### 4. README + docs update: cooperation pattern is the recommended setup
+
+The bilingual docs site (EN + ES) gets an updated section under Configuration:
+
+> **Recommended pairing: obsidian-git + hive**
+>
+> If your vault uses the obsidian-git plugin for automatic backups, the two cooperate cleanly when configured properly:
+>
+> - Set obsidian-git's `autoSaveInterval` to 5-10 minutes.
+> - Use `commit=False` on `vault_write` / `vault_patch` for write-heavy flows. Hive writes to disk; obsidian-git commits on its next tick.
+> - Watch `vault_health(include_runtime=True)` → `last_git_lock_wait_ms`. If p99 stays above 5 seconds, raise `HIVE_LOCK_TIMEOUT_S` to 60 to absorb longer windows.
+> - Phase B of HIVE-115 (forthcoming) will make this cooperation automatic.
+
+This is the operational answer to ADR-006's recommended setup, with concrete numbers.
+
+## Alternatives considered
+
+### A) Status quo (informational detection only)
+
+**Rejected.** The detection exists but drives no behavior. At N=3-5 baseline with obsidian-git active, the silent contention is reported as user pain (issue #110). Telemetry + tunable is the minimum responsible response.
+
+### B) Auto-defer to obsidian-git when detected (skip ahead to Phase B behavior)
+
+**Deferred to [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) v2 amendment.** Conditionally rewriting hive's commit path based on external committer presence is a semantic change with risk surface (what if obsidian-git is paused, broken, or removed mid-session?). Phase A keeps behavior unchanged; Phase B introduces the conditional defer with health-probe fallback.
+
+### C) Bypass `.git/index.lock` (force-acquire)
+
+**Rejected categorically.** Bypassing the lock would risk index corruption visible to Obsidian UI and user's manual git commands. Never compete-blindly — always cooperate-or-fallback.
+
+### D) Disable hive's commits entirely when obsidian-git detected
+
+**Rejected.** Loses crash-recovery semantics (each write was a commit you could `git log`). Loses the `vault_commit` escape hatch for clients that need an explicit flush. ADR-006's "preserve invariant by default" stance still applies in Phase A.
+
+### E) Backoff + retry on lock contention (3s → 6s → 12s)
+
+**Deferred to Phase B ([adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) v2).** Useful when the external committer is NOT present and hive's reconciler must keep trying. In Phase A, the simpler `HIVE_LOCK_TIMEOUT_S` tunable covers the common case without introducing retry-loop complexity.
+
+## Consequences
+
+- **Positive**: contention with obsidian-git becomes observable via structured logs + `vault_health` metrics. Operators can grep `mcp.lock_contention` to investigate slowness. The data informs Phase B gate decisions.
+- **Positive**: `HIVE_LOCK_TIMEOUT_S` gives users a quick escape hatch for large-vault or slow-network situations without code changes.
+- **Positive**: docs site cooperation pattern reduces user confusion about "why is hive slow when Obsidian is also running".
+- **Neutral**: zero behavior change for users without obsidian-git (or with `commitInterval=0`). The promotion is gated on detection.
+- **Negative**: `HIVE_LOCK_TIMEOUT_S` foot-gun (too-low = constant abandons, too-high = long freezes). Mitigated by documented recommended ranges and the 600s cap.
+- **Marginal**: every `_GIT_LOCK.acquire` now produces a log line. Volume is bounded by write frequency (~1-5/min at N=3-5). Negligible disk impact; not paginated to a log file because there's already a per-PID file.
+- **Forward path**: ADR-009 v2 takes the `obsidian_git_present` + recency probe + lock-wait telemetry from this ADR and turns them into automatic detect-and-defer behavior. Phase A is the foundation; Phase B is the closure.
+
+## References
+
+- [adr-006-commit-policy.md](adr-006-commit-policy.md) — original commit policy + first introduction of `detect_obsidian_git()`; **amended in this release** to acknowledge §C "Re-evaluate" gate triggered
+- [adr-009-multi-process-wal-policy.md](adr-009-multi-process-wal-policy.md) — companion ADR (SQLite half); shares the `HIVE_LOCK_TIMEOUT_S` + `mcp.lock_contention` infrastructure
+- [adr-008-hard-deadline-enforcement.md](adr-008-hard-deadline-enforcement.md) — `bounded_call` supervisor; the deadline-enforcement piece that lets reconciler operations have a hard ceiling
+- [lessons.md](../lessons.md) — "Cooperative external committer needs explicit coordination" (load-bearing rationale) + "Telemetry IS the design" (instrumentation discipline)
+- Spec: `specs/HIVE-115-latency-tail-redesign/` (forthcoming)
+- obsidian-git plugin: https://github.com/Vinzent03/obsidian-git
+- Issue #110: https://github.com/mlorentedev/hive/issues/110

--- a/docs/adr/adr-012-cooperative-filelock-eviction-on-deadline.md
+++ b/docs/adr/adr-012-cooperative-filelock-eviction-on-deadline.md
@@ -1,0 +1,116 @@
+---
+id: adr-012-cooperative-filelock-eviction-on-deadline
+type: adr
+status: active
+created: "2026-05-27"
+---
+
+# ADR-012: Cooperative Filelock Eviction on Deadline
+
+## Status
+
+Accepted — 2026-05-28. Ships with HIVE-116 PR-2 / v1.21.0.
+
+## Context
+
+HIVE-115 PR-3 introduced `bounded_call` and `tool_span` as the deadline supervisors that terminate registered `subprocess.Popen` instances on wall-clock expiry. The supervisor cleans `.git/index.lock` (git's native cooperative lock) when the killed PID matches one we spawned, via `_cleanup_index_lock`.
+
+Empirical evidence collected 2026-05-27 from two independent Windows sessions (issue #141, hive logs `hive-31272.log` + `hive-9092.log`) showed a residual failure mode: when the worker thread holding the `_filelock_with_telemetry` context is stuck in `proc.communicate()` after the subprocess is killed (Windows `subprocess` stdio drain on terminated children can block indefinitely), the in-process `.git/hive.lock` filelock object is never released. Sibling workers block on subsequent acquires; one user-visible session showed `capture_lesson` running for 246 seconds while the client had long since received a "timeout" response.
+
+Three constraints converge:
+
+1. **Python cannot cancel a thread.** `asyncio.timeout` cancels only the awaiting coroutine. The worker thread inside `asyncio.to_thread` continues until the body returns. This is a CPython invariant — see [lessons.md](../lessons.md), "Three timeouts in a chain aren't a deadline".
+2. **`filelock` is a cooperative library.** It does not expose a "force-release-from-outside-the-holder" primitive because the underlying `fcntl.flock` (POSIX) and `msvcrt.locking` (Windows) attach the lock to the file descriptor of the holder; a non-holder cannot release.
+3. **`_GIT_FILELOCKS` caches a singleton per vault.** This was the right call for HIVE-104 — re-entrant acquires from nested `_git_commit` calls reuse the same `FileLock` object cleanly. But the cache extends the lifetime of the orphan file handle past the runaway worker's natural completion.
+
+## Decision
+
+The deadline supervisor evicts the cached `FileLock` for the affected vault from `_GIT_FILELOCKS` after a post-kill drain window. The next `_git_filelock(vault)` call constructs a fresh `FileLock` against the same path.
+
+Order of operations on deadline expiry:
+
+1. `_terminate_registry` — SIGTERM → grace → SIGKILL → drain stdio.
+2. `_cleanup_index_lock` — remove `.git/index.lock` if PID-owned.
+3. **NEW: `await asyncio.sleep(post_kill_drain_s)`** — give the worker thread time to escape `_filelock_with_telemetry.__exit__` naturally on the happy path.
+4. **NEW: `evict_filelock(vault)`** — pop the cached `FileLock` from `_GIT_FILELOCKS` under `_GIT_FILELOCKS_GUARD`.
+5. **NEW: record event** to `LockEvictionTracker` (SQLite) for `vault_health.runtime.lock_eviction.count_30d` telemetry.
+6. Record `GHOST_RESPONSES.record(source="deadline")`.
+7. Raise `TimeoutError` to the caller.
+
+Default `HIVE_POST_KILL_DRAIN_S = 5.0` seconds (validated [0.5, 30.0]). Matches `HIVE_OUTBOX_TICK_S` for symmetry — both windows represent "give cooperative state a chance to settle naturally before forcing it." A calibration sweep at {1, 5, 10} on the cross-worker integration harness chose 5s as the smallest value that never trips a race-warning in 20 consecutive runs on Linux.
+
+## Consequences
+
+### Positive
+
+- **Sibling workers unblock within `deadline + grace + drain + slack`.** The cache eviction means new `_git_filelock(vault)` acquires get a fresh `FileLock` object; on POSIX the kernel resolves the underlying `fcntl` lock the moment the runaway thread eventually releases its FD; on Windows the orphan file persists but no longer blocks new acquires (filelock library invariant).
+- **Telemetry feeds the Phase C decision gate.** `lock_eviction.count_30d` is a new input to the 2026-06-05 checkpoint (issue #124). Sustained eviction frequency is evidence that the cooperation pattern is reaching its limit; sustained low frequency justifies further deferral of the daemon model.
+- **Cross-OS symmetric.** No platform-specific eviction logic. The cache is process-local Python state; popping it works identically on POSIX and Windows.
+- **Idempotent.** `evict_filelock` returns `False` when nothing is cached, allowing the supervisor to call it unconditionally without per-call gating.
+
+### Negative
+
+- **R1 race window.** If the worker thread escapes `__exit__` between the eviction and a new acquire from a sibling, the sibling acquires a fresh `FileLock` while the old object is in mid-release. On POSIX `fcntl.flock` this is benign (kernel-tracked per fd). On Windows `msvcrt.locking` the semantics are subtler — empirically clean on 20-run validation, but a `mcp.lock_eviction.race` WARNING log is a planned PR-2.5 safety net.
+- **Adds `post_kill_drain_s` to the supervisor's tail latency.** A deadline-killed `vault_write` now responds in `deadline + grace + drain + ε` instead of `deadline + grace + ε`. With defaults that is 60 + 2 + 5 = 67s instead of 62s. The trade-off is correctness (sibling unblock) for 5s of additional perceived latency on the affected call.
+- **The orphan `.git/hive.lock` file persists on Windows.** Eviction releases the cached *object*; it does NOT delete the *file*. Users still see the 0-byte file in `.git/` until the parent `hive-vault` process exits. This is documented in `docs/troubleshooting.md` as a known cosmetic artifact.
+- **Not a substitute for Phase C (ADR-011).** This decision closes the operational gap but does not change the architectural fact that Python cannot preempt threads. When telemetry shows sustained eviction frequency, the daemon model becomes mandatory; ADR-012 buys time, not absolution.
+
+## Alternatives considered
+
+### A. `Popen.wait(timeout=N)` inside `_run_git`
+
+Adds an inner timeout to the worker thread so it escapes `__exit__` voluntarily within N seconds of SIGKILL. Rejected: violates HIVE-115 audit B1 — `bounded_call` is the SSOT for deadlines, inner timeouts race the supervisor's external termination. Different error semantics, harder to reason about.
+
+### B. Drop the `_GIT_FILELOCKS` singleton cache
+
+Construct a new `FileLock` on every `_git_filelock` call. Rejected: breaks nested acquire re-entry (the original HIVE-104 motivation for the cache). Would require restructuring `vault_write_lock` to track per-call lock instances.
+
+### C. Custom inter-process primitive
+
+Roll our own `.git/hive.lock` with an explicit "force-release on PID failure" API. Rejected: filelock is the right library; the bug is in our composition, not the abstraction.
+
+### D. Phase C daemon model NOW
+
+Eliminate the multi-process contention class entirely by funneling all SQLite + git through a single daemon. Rejected for this ADR scope: the daemon model is a v2.0 redesign that needs Phase A+B telemetry as input. ADR-012 is the cooperation-pattern fix that buys telemetry time.
+
+## Implementation
+
+`src/hive/_helpers.py`:
+- `evict_filelock(vault_path) -> bool` — eviction primitive.
+- `_post_kill_drain() -> float` — lazy settings read.
+- `_drain_and_evict(vault, killed_pids, tool_name)` — sleep + evict + record + log.
+- `_record_lock_eviction(vault, killed_pids)` — defer to module-level tracker singleton.
+- `_LOCK_EVICTION_TRACKER` + `register_lock_eviction_tracker(tracker)` — process-global singleton wiring.
+- `_VAULT_FOR_EVICTION_CV: ContextVar[Path | None]` — contextvar carrying the vault from `wrap_sync_tool` to `tool_span`.
+
+`src/hive/_lock_eviction.py` (new):
+- `LockEvictionTracker(_SqliteTracker)` with `record(vault, killed_pids)`, `count_last_30d()`, `last_iso()`. DB at `~/.local/share/hive/lock_evictions.db`.
+
+`src/hive/_deadline.py`:
+- `bounded_call` calls `_drain_and_evict` after `_cleanup_index_lock` when `vault_for_index_cleanup` is set and killed_pids is non-empty.
+
+`src/hive/_helpers.py` (tool_span):
+- After ghost-response record + WARNING log, reads `_VAULT_FOR_EVICTION_CV` and calls `_drain_and_evict` when set + killed.
+
+`src/hive/_helpers.py` (wrap_sync_tool):
+- For tools in `_PARTIAL_STATE_TOOLS = {"vault_write", "vault_patch"}`, sets `_VAULT_FOR_EVICTION_CV` to `ctx.vault` for the duration of the call.
+
+`src/hive/config.py`:
+- `post_kill_drain_s: float = Field(default=5.0, ge=0.5, le=30.0)`.
+
+`src/hive/_context.py`:
+- `ServerContext.lock_eviction: LockEvictionTracker`.
+
+`src/hive/_vault_health.py`:
+- `runtime_block_text` surfaces `lock_eviction.count_30d` + `lock_eviction.last_iso` under `## runtime`.
+
+## References
+
+- Issue: [hive#141](https://github.com/mlorentedev/hive/issues/141) — original repro
+- Spec: `specs/HIVE-116-stale-lock-after-deadline/` (repo)
+- Prior ADR: [adr-008-hard-deadline-enforcement.md](adr-008-hard-deadline-enforcement.md) — amended with §5 referencing this ADR
+- Foundation lesson: [lessons.md](../lessons.md), "Three timeouts in a chain aren't a deadline"
+- Corollary lesson: [lessons.md](../lessons.md), "You cannot cancel a Python thread you started" — captures the cooperation pattern this ADR formalizes
+- Phase C dependency: ADR-011 daemon model (deferred; this ADR buys observation time)
+
+<!-- Provenance (maintainer's cross-project knowledge store; not linked to preserve repo->store independence): pattern-multi-process-mcp-server — extended with primitive 8 (cooperative-lock eviction). -->

--- a/docs/adr/sequence-diagrams.md
+++ b/docs/adr/sequence-diagrams.md
@@ -1,0 +1,165 @@
+---
+id: sequence-diagrams
+type: architecture
+status: active
+created: "2026-03-03"
+owner: manu
+---
+
+# Hive: Sequence Diagrams
+
+> End-to-end flows for the three primary interaction patterns.
+> Rendered by Obsidian or any Mermaid-compatible viewer.
+
+## 1. Vault Query Flow
+
+Standard read path — covers `vault_query`, `vault_search`, `vault_smart_search`.
+
+```mermaid
+sequenceDiagram
+    participant C as Claude Code
+    participant V as Vault MCP Server
+    participant FS as Filesystem
+    participant G as Git
+
+    C->>V: vault_query(project, section)
+    V->>V: _resolve_file(vault_path, project, section, path)
+    alt project not found
+        V-->>C: "Project 'X' not found."
+    else file not found
+        V-->>C: "'section' not found in project 'X'."
+    else file exists
+        V->>FS: Path.read_text()
+        FS-->>V: raw content
+        V->>V: _truncate(content, max_lines)
+        opt include_metadata=True
+            V->>V: parse_frontmatter(content)
+            V->>V: prepend metadata line
+        end
+        V-->>C: truncated content
+    end
+```
+
+## 2. Worker Delegation Flow
+
+Task delegation with 3-tier routing and budget control.
+
+```mermaid
+sequenceDiagram
+    participant C as Claude Code
+    participant W as Worker MCP Server
+    participant O as Ollama
+    participant OR as OpenRouter
+    participant B as Budget DB
+
+    C->>W: delegate_task(prompt, task_type)
+    W->>O: POST /api/generate
+    alt Ollama available
+        O-->>W: response
+        W-->>C: result (model: qwen2.5-coder:7b)
+    else Ollama unreachable
+        W->>OR: POST /chat/completions (free model)
+        alt free tier succeeds
+            OR-->>W: response
+            W-->>C: result (model: qwen3-coder:free)
+        else free tier fails & max_cost > 0
+            W->>B: can_spend(cost)?
+            alt budget allows
+                B-->>W: true
+                W->>OR: POST /chat/completions (paid model)
+                OR-->>W: response + cost
+                W->>B: record(cost)
+                W-->>C: result (model: deepseek)
+            else budget exhausted
+                B-->>W: false
+                W-->>C: "Budget exhausted."
+            end
+        else no fallback
+            W-->>C: "All models unavailable."
+        end
+    end
+```
+
+## 3. Session Briefing Flow
+
+One-call cold-start that replaces 3–4 manual tool calls.
+
+```mermaid
+sequenceDiagram
+    participant C as Claude Code
+    participant V as Vault MCP Server
+    participant FS as Filesystem
+    participant G as Git
+
+    C->>V: session_briefing(project)
+    V->>V: _resolve_project_dir(project)
+    alt project not found
+        V-->>C: "Project 'X' not found."
+    else project exists
+        V->>FS: read tasks (11-tasks.md)
+        FS-->>V: tasks content
+        V->>V: _truncate(tasks, 50 lines)
+
+        V->>FS: read lessons (90-lessons.md)
+        FS-->>V: lessons content
+        V->>V: last 30 lines
+
+        V->>G: git log --oneline -5
+        G-->>V: recent commits
+
+        V->>FS: rglob("*.md") in project dir
+        FS-->>V: file list
+        V->>V: count files + detect stale
+
+        V->>V: assemble markdown sections
+        V-->>C: "# Session Briefing — {project}\n## Active Tasks\n..."
+    end
+```
+
+## 4. Resource Discovery Flow
+
+MCP clients discovering vault content without knowing tool names.
+
+```mermaid
+sequenceDiagram
+    participant MC as MCP Client
+    participant V as Vault MCP Server
+    participant FS as Filesystem
+
+    MC->>V: list_resources()
+    V-->>MC: [hive://projects, hive://health]
+
+    MC->>V: list_resource_templates()
+    V-->>MC: [hive://projects/{project}/context, .../tasks, .../lessons]
+
+    MC->>V: read_resource("hive://projects/hive/context")
+    V->>V: _resolve_file(vault_path, "hive", "context", "")
+    V->>FS: Path.read_text()
+    FS-->>V: content
+    V->>V: _truncate(content, 200)
+    V-->>MC: ResourceResult(content)
+```
+
+## 5. Vault Write Flow
+
+Write path with frontmatter validation and atomic git commit.
+
+```mermaid
+sequenceDiagram
+    participant C as Claude Code
+    participant V as Vault MCP Server
+    participant FS as Filesystem
+    participant G as Git
+
+    C->>V: vault_update(project, section, "replace", content)
+    V->>V: validate_frontmatter(content)
+    alt invalid frontmatter
+        V-->>C: "Frontmatter validation failed: ..."
+    else valid
+        V->>FS: Path.write_text(content)
+        V->>G: git add <file>
+        V->>G: git commit -m "vault: update project/section"
+        G-->>V: committed
+        V-->>C: "Updated project/section (replace)."
+    end
+```

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1,0 +1,360 @@
+---
+id: "hive-lessons"
+type: lesson
+status: active
+created: "2026-03-01"
+owner: manu
+---
+
+# Hive: Lessons Learned
+
+## Architecture Decisions (Pre-Implementation)
+
+### 2026-03-01: Claude Code as orchestrator, not a custom framework
+- **Context:** Evaluated CrewAI, LangGraph, AutoGen as orchestration options.
+- **Decision:** Use Claude Code natively as orchestrator. Extend with MCP servers only.
+- **Rationale:** Custom orchestrators replace Claude Code (lose ecosystem improvements). MCP servers extend it (ride the wave). Only ~650 lines of custom Python to maintain.
+- **Trade-off:** Limited to what Claude Code's Agent/MCP system can do. Acceptable — it already does parallel subagents, hooks, and skills.
+
+### 2026-03-01: Python over Go for MCP servers
+- **Context:** User prefers Go for performance. Evaluated both options.
+- **Decision:** Python (FastMCP SDK).
+- **Rationale:** MCP servers are I/O bound (file reads, API calls). Go's performance advantage is ~1ms per request on workloads that take seconds. FastMCP SDK is mature, reduces boilerplate to ~400 lines. Can rewrite in Go later (MCP is protocol-based).
+
+### 2026-03-01: Separate project from dotfiles
+- **Context:** Could live inside dotfiles or as standalone project.
+- **Decision:** Standalone `~/Projects/hive`, deployed by dotfiles setup scripts.
+- **Rationale:** Own lifecycle, own dependencies (pyproject.toml), own tests. Shareable with team members who don't need personal dotfiles. Dotfiles references hive, doesn't contain it.
+
+### 2026-03-01: pydantic-settings over manual env var resolution
+- **Context:** config.py had 6 `_resolve_*()` functions + module-level constants (52 lines). No startup validation, harder to test.
+- **Decision:** Refactor to `pydantic-settings` `BaseSettings` with `HIVE_` prefix.
+- **Rationale:** Standard 12-factor pattern. Automatic type coercion (str→Path, str→float). Startup validation catches bad config immediately. `AliasChoices` for backward-compatible `OPENROUTER_API_KEY` (no prefix). 52 → 25 lines, zero test file changes needed (DI already in place).
+- **Trade-off:** New dependency (`pydantic-settings`). Acceptable — pydantic is already a transitive dep of FastMCP, so it adds ~0 weight.
+
+### 2026-03-01: Squash merge for feature branches
+- **Context:** Feature branches accumulate WIP/fix commits that pollute master history.
+- **Decision:** Always squash merge PRs into master.
+- **Rationale:** Each commit on master = 1 complete feature/fix. Clean `git log`, easy `git revert`. Branch history preserved in GitHub PR for forensics if needed.
+
+## Operational Lessons
+
+### 2026-03-04: max_lines=100 was dangerously aggressive
+- **Context:** Default `max_lines` was 100. Benchmarking suite revealed that real vault files (roadmap, tasks, lessons) are 125-173 lines. At max_lines=100, tools captured only 7-22% of actual content.
+- **Impact:** `session_briefing` was silently truncating critical information. Users had no signal that they were missing content.
+- **Fix:** Raised default to 500. At 500 lines, content capture is 98-100% for all existing vault files.
+- **Lesson:** Never pick defaults by intuition. Benchmark against real data first.
+
+### 2026-03-04: Benchmark-driven defaults over gut feeling
+- **Context:** Both `max_lines` (100) and budget cap ($5/mo) were set by rough estimation during initial development.
+- **Decision:** Built a benchmarking suite that measures content capture ratio, token savings, and latency across real vault files.
+- **Outcome:** max_lines raised 5x (100 to 500), budget lowered 5x ($5 to $1). Both changes backed by data, not guesswork.
+- **Lesson:** For any configurable default, write a characterization benchmark before picking the value. The cost of being wrong silently is higher than the cost of measuring.
+
+### 2026-03-04: The `:free` suffix bug — test your actual infrastructure
+- **Context:** OpenRouter paid tier smoke test was failing. The model ID being sent included the `:free` suffix (e.g., `qwen/qwen3-coder:free`), which routed to the free tier instead of the paid model.
+- **Root cause:** Configuration assumed the model string was used as-is, but the `:free` suffix is a routing hint, not part of the model name.
+- **Lesson:** Smoke tests must exercise the actual production path. Unit tests with mocked responses would not have caught this — only a real HTTP call to OpenRouter revealed the suffix behavior.
+
+### 2026-03-04: vault_search has best signal-to-noise ratio
+- **Context:** Benchmarking measured signal-to-noise ratio across tools. `vault_search` scored 98.8% (almost all returned content is relevant). `session_briefing` scored 78.5% (includes boilerplate headers, health checks, git log noise).
+- **Implication:** For targeted queries, prefer `vault_search` over `session_briefing`. Reserve `session_briefing` for cold-start orientation where breadth matters more than precision.
+- **Action:** This data feeds into P1 (Context Curator) design — relevance scoring should weight search results higher than briefing sections.
+
+### [2026-03-05] Per-repo agent systems vs cross-project vault — competitive analysis
+**Context:** Analyzing Bruno Bertolini's per-repo .agent/ system (rules, skills, agents, specs) that runs 6 CI agents on every PR for quality gates, security, architecture, and dogfood enforcement.
+**Problem:** Should Hive adopt CI-based quality gate agents (architecture check, security scan, dogfood enforcement) or a PRD→techspec→exec pipeline? Is the per-repo .agent/ pattern superior to a cross-project vault?
+**Solution:** No features to copy. Per-repo agents excel at CI automation but are limited to single-repo scope, scale poorly with .md files (author admits "too big"), and lack cross-project context. Hive's strengths (session_briefing, smart_search, EMA relevance, cross-project vault, capture_lesson) are exactly what per-repo systems cannot do. The only actionable takeaway is P3 drift detector (vault_validate) which is already on roadmap — validates code changes against vault ADRs/patterns. PRD→exec pipeline already covered by Claude Code skills (/prd, /writing-plans). Self-improvement loop is our P2 (auto-capture). RAG not needed until 500+ files (ADR-003).
+**Tags:** `#competitive-analysis` `#architecture` `#ci-cd` `#self-improvement`
+
+### [2026-03-06] anyOf in JSON Schema makes MCP tools invisible to Claude Code
+**Context:** Auditing why `vault_patch`, `capture_lesson`, and `vault_list_files` were missing from Claude Code's deferred tools list (14 of 17 visible).
+**Problem:** Claude Code's deferred tool indexer silently drops tools whose JSON Schema contains `anyOf` — generated by Python `| None` union types via Pydantic. Affected tools become completely unusable in a session.
+**Solution:** Replace `T | None = None` with empty defaults (`str = ""`, `list[T] = []`). Suppress Ruff B006 (mutable default) with `# noqa: B006` — safe because FastMCP creates Pydantic models per call. Design rule: never use `| None` in MCP tool parameters.
+**Tags:** `#mcp` `#claude-code` `#fastmcp` `#schema` `#interop`
+
+### [2026-03-06] Subprocess and I/O resilience audit — 4 crash vectors found
+**Context:** User reported `vault_patch` crashing MCP server on Windows. Expanded into full audit of all subprocess and I/O paths.
+**Problem:** Four categories of unhandled exceptions could crash the server: (1) `_git_commit` missing catch-all, (2) `_git_log`/`_git_recent` only catching `TimeoutExpired`, (3) `httpx.ReadTimeout` not caught in HTTP clients, (4) file I/O in write tools with no `except OSError`.
+**Solution:** (1) Catch-all `except Exception` in all git helpers + timeout 10→30s. (2) Same for `_git_log`/`_git_recent`. (3) Added `except httpx.TimeoutException` in `OllamaClient` and `OpenRouterClient`. (4) Wrapped `read_text`/`write_text` in write tools with `except OSError`. 10 new tests, 290 total.
+**Tags:** `#resilience` `#subprocess` `#httpx` `#mcp-stability`
+
+## ReDoS in vault_search (2026-03-06)
+
+- **Context:** `vault_search(use_regex=True)` compiles user-supplied regex with `re.compile()` and applies it to every line of every vault file
+- **Root cause:** Python's `re` module has no backtracking limit. Pathological patterns like `(a+)+$` cause exponential time on non-matching lines
+- **Fix:** Cap regex pattern length at 200 chars. Practical constraint: vault files are small markdown, per-line matching limits blast radius
+- **Lesson:** Any tool that accepts regex from untrusted input needs a complexity gate — length limit at minimum, `re2` library for production systems
+
+## list_models() missing status check (2026-03-06)
+
+- **Context:** `OpenRouterClient.list_models()` called `resp.json()` without checking `resp.status_code` first
+- **Root cause:** The `generate()` method had proper status checks but `list_models()` was added later and missed the pattern
+- **Fix:** Added `if resp.status_code >= 400` guard + `float()` pricing wrapped in try/except ValueError
+- **Lesson:** When adding new methods to an HTTP client class, copy the full error-handling pattern from existing methods, not just the happy path
+
+### [2026-03-07] MCP server vs agent — architectural boundary
+**Context:** Evaluating whether hive should evolve from MCP server to agent framework
+**Problem:** Confusion between MCP servers (tool providers, stateless, client-agnostic) and agents (autonomous actors with their own decision loops). Some competitor projects blur this line.
+**Solution:** MCP servers extend the host — they provide tools the host decides when to call. Agents replace the host's decision loop. Hive is and should remain an MCP server. The host (Claude Code, Gemini CLI, etc.) is the orchestrator. Adding agent behavior would couple hive to a specific host.
+**Why:** Protocol-level separation of concerns. MCP is a tool interface, not an execution framework. Staying protocol-pure keeps hive client-agnostic.
+**Tags:** `#architecture` `#mcp` `#design-principle`
+
+### [2026-03-07] CI publish failures on duplicate versions — make idempotent
+**Context:** release-please created a release, CI published to PyPI and MCP Registry. Re-running the workflow failed because the version was already published.
+**Problem:** MCP Registry publish step returned a non-zero exit code on duplicate version, failing the entire CI pipeline. PyPI had the same issue but was already handled with `--skip-existing`.
+**Solution:** Added `continue-on-error: true` to the MCP Registry publish step. Duplicate publishes are expected (re-runs, manual triggers) and should not block CI.
+**Why:** Idempotency in CI pipelines. Any publish step that can be re-run must tolerate "already exists" as a success condition.
+**Tags:** `#ci` `#release` `#idempotency`
+
+### [2026-03-07] Evaluating external tools — separation of concerns over feature envy
+**Context:** Analyzed claude-qmd-sessions (hook-driven session transcript indexing via qmd). Evaluated 4 ideas: auto-briefing hooks, transcript indexing, CWD auto-detection, dual-cap context.
+**Problem:** Temptation to absorb external tool patterns into hive (session transcript search, hook automation, CWD-based project detection).
+**Solution:** None warranted inclusion. Hooks are user-config (not server feature) — documented instead. Transcript indexing adds noise (hive already has capture_lesson for curated extraction). CWD detection is impossible (MCP server doesn't receive client CWD). Dual-cap is YAGNI.
+**Why:** An MCP server should do one thing well (vault access) rather than absorb tangential features. The right response to "interesting external pattern" is often documentation, not code.
+**Tags:** `#architecture` `#yagni` `#competitive-analysis`
+
+### 2026-03-08: Tool consolidation — 19 to 10 tools for Claude Code compatibility
+- **Context:** Claude Code silently drops MCP tools beyond ~14 from its deferred tool list. Hive had 19 tools, 5 were invisible.
+- **Problem:** Users could never discover or use `vault_patch`, `vault_list_files`, `extract_lessons`, `vault_validate`, or `vault_usage` because Claude Code's client-side limit hid them from the tool picker.
+- **Solution:** Consolidated 19 tools into 10 by merging related functionality behind mode-switching parameters (e.g., `vault_search` gained `ranked=True` and `since_days=N` instead of separate `vault_smart_search` and `vault_recent` tools). No functionality lost — every feature accessible via the consolidated API.
+- **Lesson:** MCP client implementations have undocumented limits. Design tool surfaces to stay under ~12 tools per server. Prefer fewer tools with mode parameters over many single-purpose tools.
+
+### 2026-03-08: Test flakiness from real external services in unit tests
+- **Context:** After merging `vault_summarize` into `delegate_task`, the large-file test became flaky — passing in isolation, failing in full suite.
+- **Problem:** The `vault_mcp` test fixture creates a server with default settings. When `OPENROUTER_API_KEY` is set in the environment (from dotfiles), the server actually connects to OpenRouter and returns a real summary instead of the expected fallback content.
+- **Solution:** Made test assertions handle both cases (worker available → summary, worker unavailable → raw content). The proper fix would be injecting a null OpenRouter client in the vault_mcp fixture.
+- **Lesson:** Test fixtures that create servers without explicit client injection will use real external services if env vars are set. Always inject mock clients in unit test fixtures.
+
+### [2026-03-10] Glama MCP Directory Listing Requirements
+**Context:** Submitting hive-vault to MCP server directories for discoverability
+**Problem:** punkpeye/awesome-mcp-servers requires a Glama listing link next to the GitHub link. Glama requires a glama.json in the repo root.
+**Solution:** 1) Create glama.json with $schema and maintainers array. 2) Add Glama badge (PNG, 380x200) to README. 3) Update awesome-list PR entry with [glama](https://glama.ai/mcp/servers/OWNER/REPO) link after GitHub link. Schema: https://glama.ai/mcp/schemas/server.json — only required field is maintainers (GitHub usernames).
+**Tags:** `#distribution` `#mcp` `#glama`
+
+### [2026-03-12] SQLite SQLITE_MISUSE from concurrent MCP tool calls
+**Context:** FastMCP dispatches synchronous tool handlers to a thread pool via anyio.to_thread.run_sync. Concurrent tool calls share the same ServerContext, including SQLite-backed trackers.
+**Problem:** RelevanceTracker and UsageTracker used check_same_thread=False without locking, causing SQLITE_MISUSE (error 21). BudgetTracker lacked the flag entirely, causing ProgrammingError on cross-thread access. vault_write/vault_patch had TOCTOU race conditions on file read-modify-write. _git_commit had no serialization, allowing interleaved git add/commit.
+**Solution:** Added threading.Lock to all three SQLite trackers. Used Lock (not RLock) with internal _method() pattern to avoid deadlock on reentrant calls (e.g. month_stats calling _month_spent). Added module-level _WRITE_LOCK in _vault_write.py for atomic file I/O + git commit. Added _GIT_LOCK in _helpers.py to serialize all git operations.
+**Tags:** `#concurrency` `#sqlite` `#threading` `#mcp`
+
+### [2026-03-13] asyncio.timeout cannot interrupt threads — use lock timeouts for sync code
+**Context:** Adding timeouts to MCP tool handlers to fix indefinite hangs (issue #63)
+**Problem:** asyncio.timeout() only cancels at await points — it cannot interrupt a thread blocked on Lock.acquire() or subprocess.run(). Converting sync tools to async via to_thread gives false sense of control.
+**Solution:** Use Lock.acquire(timeout=N) for sync blocking points, asyncio.timeout() for async handlers. Defense in depth: each layer has its own timeout mechanism matching its execution model.
+**Tags:** `#python` `#asyncio` `#concurrency` `#mcp`
+
+### [2026-03-10] uv sync editable install breaks multi-stage Docker builds
+**Context:** Building a multi-stage Docker image for hive-vault. The builder stage used `uv sync --frozen --no-dev` to install the local package, then only `.venv` was copied to the final stage.
+**Problem:** Runtime `ModuleNotFoundError: No module named 'hive'`. `uv sync` installs the local project as an editable/direct-url reference pointing to `/app/src`, which doesn't exist in the final image (only `.venv` is copied).
+**Solution:** Use `uv sync --frozen --no-dev --no-install-project` for third-party deps only, then `.venv/bin/pip install --no-cache-dir --no-deps .` to install the local package as a proper wheel embedded in `.venv/lib/`. The wheel is self-contained — no reference to source paths.
+**Why:** `uv sync` optimizes for development (editable installs are faster for iteration). In multi-stage Docker builds where source isn't copied to the final stage, you need a non-editable wheel. This is a `uv`-specific gotcha — `pip install .` has always produced non-editable installs by default.
+**Tags:** `#docker` `#uv` `#multi-stage` `#python-packaging`
+
+### [2026-03-15] MCP tool parameter names must match LLM mental models
+**Context:** vault_patch tool had parameters named `old_text` and `new_text`. LLMs (Claude, Gemini) consistently hallucinated `find` and `replace` instead, causing Pydantic validation failures at runtime.
+**Problem:** The parameter names were technically correct but didn't match the natural mental model that LLMs (and humans) have for text substitution operations. Every vault_patch call risked a validation error from the LLM guessing the "obvious" names.
+**Solution:** Renamed `old_text`→`find` and `new_text`→`replace` across the entire codebase (7 files). Breaking API change, but eliminated an entire class of runtime failures. Evaluated adding aliases for backward compatibility — rejected as over-engineering since no external consumers exist yet.
+**Why:** MCP tools are called by LLMs, not humans typing exact names. Parameter naming is a DX/UX decision that directly affects tool reliability. Shorter, more idiomatic names reduce schema misreads. Design rule: when naming MCP tool parameters, prefer the term an LLM would guess first.
+**Tags:** `#mcp` `#naming` `#llm-ergonomics` `#dx`
+
+### [2026-03-26] BFS hierarchical scope resolution for nested vault directories
+**Context:** Hive vault uses a flat `10_projects/<slug>/` layout, but the new `50_work/` scope is multi-level (e.g. `50_work/45-development/<family>/<component>/`). The existing flat resolver only saw direct children of the scope root, so deep projects were unreachable via short slug — users had to spell out the full path.
+**Problem:** `_resolve_project_dir` could not find a slug like `hydra3d-plus` under a nested work tree. Adding a `work` scope without changing resolution would have forced verbose literal paths for every work query, breaking the ergonomic short-slug API users already had for `10_projects`.
+**Solution:** Switched `_resolve_project_dir` to breadth-first traversal: try direct child first, then BFS through subdirectories — shallowest match wins. Slugs containing `/` bypass BFS and resolve as literal relative paths inside the scope (escape hatch for collisions or explicit targeting). Added `scope` filter to `vault_search` (restricts all 3 modes to a single scope) and `_find_duplicate_names` in `vault_health` to surface BFS collisions before they cause silent mis-resolution.
+**Why:** BFS preserves the short-slug API across heterogeneous vault layouts (flat for projects, nested for work). Shallowest-wins keeps resolution deterministic; the explicit-path escape hatch covers the duplicate-name edge case without coupling tools to a single layout. Duplicate detection in `vault_health` makes the previously silent collision surface visible at audit time.
+**Tags:** `#vault` `#scope-resolution` `#bfs` `#mcp`
+
+### [2026-03-11] Three-pass cascading match for vault_patch tolerant text replacement
+**Context:** `vault_patch` originally required `old_text` to match the file content byte-for-byte, including YAML frontmatter. LLMs typically copy snippets from `vault_query` output that has the frontmatter stripped or whitespace normalized, so the patch call would fail every time the body was sourced from a prior read (Issue #52).
+**Problem:** Strict matching is brittle to two realistic LLM-induced drifts: (a) the frontmatter is missing because the LLM only copied the body, (b) trailing/leading whitespace in tables or code blocks got normalized during quoting. Either drift produced a hard error with no hint of how close the match was, breaking the read→patch workflow entirely.
+**Solution:** `_match_and_replace()` in `_helpers.py` performs three cascading passes — (1) exact match on full file, (2) exact match on body only (strip frontmatter, then re-attach after replacement), (3) whitespace-normalized match on body (collapse runs of whitespace to a single space for comparison only). First successful pass wins. If all three miss, `difflib.SequenceMatcher` computes a similarity percentage and the error message includes the closest near-match excerpt — turning a dead-end "not found" into an actionable diagnostic.
+**Why:** Cascading from strict→loose preserves correctness when the LLM gets the text right, while tolerating the common failure modes. Returning similarity diagnostics on total miss converts a UX dead end into a debugging signal: the LLM can see how close it got and adjust. `replace_body` mode was evaluated as an alternative and discarded — tolerant matching covers the same use cases without adding a second tool surface.
+**Tags:** `#vault-patch` `#tolerant-matching` `#llm-ergonomics` `#mcp`
+
+### [2026-05-15] In-memory MCP tests do not exercise the stdio transport race
+**Context:** Debugging issue #75 (Hive transport dying after first rejected tool call). The in-memory FastMCP `call_tool` tests passed cleanly when I cancelled the task and made another call — looked like the server was fine.
+**Problem:** That gave false confidence. The actual bug only reproduces when the cancellation goes through the JSON-RPC wire as a `notifications/cancelled` message AND the server runs as a real subprocess with `mcp.server.stdio`. The race is in `RequestResponder.__exit__`'s interaction with `anyio.CancelScope`, which the in-memory path never touches.
+**Solution:** For any future MCP transport-level bug, write the regression test as a subprocess driving real JSON-RPC. `tests/test_transport_recovery.py` spawns `python -m hive.server` and sends `initialize` → `tools/call` → `notifications/cancelled` → `tools/call` to verify the second call still responds. Pairs in-memory tests for the API surface with subprocess tests for the transport.
+**Why:** FastMCP's `call_tool` shortcuts the full message dispatch and never instantiates `RequestResponder` with the cancel-scope contract. The receive loop's task group is where the bug lives, not in the handler. Two distinct surfaces need two distinct test strategies.
+**Tags:** `#mcp` `#testing` `#stdio` `#cancellation` `#issue-75`
+
+### [2026-05-15] Forward-compatible monkey-patches must be self-gated on the failure mode
+**Context:** Patching `mcp.shared.session.RequestResponder.__exit__` to fix the issue #75 cancellation leak. Upstream will eventually fix it; we don't want our patch to mask a different bug if upstream changes the internal flow.
+**Problem:** A naive monkey-patch overrides upstream behaviour permanently. Once we ship it, every future bug in that method becomes invisible (or worse, the patch's logic conflicts with a new upstream fix and creates a *new* bug).
+**Solution:** Gate the patch on the exact failure-mode signature: `if self._completed and isinstance(exc, anyio.get_cancelled_exc_class())`. The first clause says "we already sent a response" — the second says "this is anyio's cancellation". Anything else re-raises normally. Wrap the patch application in a defensive `try`/except that logs a warning if `RequestResponder` was renamed or restructured upstream.
+**Why:** A self-gated patch becomes inert the moment upstream lands a fix — the trigger condition simply stops being reachable. That makes the monkey-patch removable without coordination: even if we forget to drop it, it doesn't do anything harmful in the post-fix world. Defensive import keeps the production server from crashing if upstream renames the class.
+**Tags:** `#monkey-patch` `#mcp` `#forward-compat` `#issue-75`
+
+### [2026-05-15] release-please `extra-files` does not retroactively patch drifted files
+**Context:** `server.json` was added to `release-please-config.json` as an `extra-files` entry pointing at `$.version` and `$.packages[0].version`. The file was already at v1.4.5 when the config landed. PyPI advanced through 1.5.x → 1.12.2 over eight releases, but `server.json` stayed at 1.4.5 the entire time, and the MCP Registry kept rejecting `mcp-publisher publish` with `400 duplicate version`. The failure was hidden by a generic `|| echo "skipped"` on the publish step.
+**Problem:** release-please's `extra-files` updater only fires when it bumps a version inside a release PR. It does not synchronise pre-existing drift — if the file is wrong when you add the config, it stays wrong. Combined with a catch-all error silencer, the registry quietly froze for two months.
+**Solution:** Bump the drifted file manually to the current version once. release-please picks up from there. While there, replace the catch-all silencer (`|| echo skipped`) with a grep on the *specific* failure string (`cannot publish duplicate version`) so genuine failures surface. Add a `workflow_dispatch` input to the release workflow so you can re-publish to the registry without inventing a new release.
+**Why:** Generic error swallowers are tech-debt batteries: they capture symptoms forever until someone notices the divergence. Pair every "best-effort" step with a precise filter that distinguishes "expected idempotent miss" from "real failure", and provide a manual re-run path so corrective action doesn't require a fake feature commit.
+**Tags:** `#release-please` `#ci` `#error-handling` `#mcp-registry`
+
+### [2026-05-15] Boolean `workflow_dispatch` inputs are real booleans in `if:` expressions
+**Context:** Added `workflow_dispatch` with a boolean input `republish_mcp` and gated the publish job with `if: inputs.republish_mcp == 'true'`. The job skipped on every manual trigger.
+**Problem:** GitHub Actions converts `type: boolean` inputs to actual booleans when reading via `inputs.*` in expressions. Comparing against the string `'true'` always evaluates false, silently skipping the gated job.
+**Solution:** Use the input truthily (`inputs.republish_mcp`) or compare against the unquoted boolean (`inputs.republish_mcp == true`). Confirmed by re-triggering and seeing `publish-mcp` actually run.
+**Why:** Documented but easy to miss — most other Actions contexts are strings. When a `workflow_dispatch` input is declared as boolean, the expression engine respects the type. String comparison is a silent footgun: the workflow appears to "work" because the trigger succeeds, but the gated job is never reached.
+**Tags:** `#github-actions` `#workflow-dispatch` `#ci` `#boolean-coercion`
+
+### [2026-05-17] release-please leaves uv.lock self-reference stale on every release
+**Context:** hive-vault uses release-please for version bumps. `release-please-config.json` registers `pyproject.toml` and `server.json` (via `extra-files`), but `uv.lock` cannot be added there — its `[[package]]` array-of-tables format makes jsonpath targeting unreliable in release-please's TOML updater. Every release left the lock's editable self-reference anchored at the previous version. By 2026-05-17 master's `uv.lock` said `1.12.1` while `pyproject.toml` said `1.12.6` (five releases of drift).
+**Problem:** The drift is invisible in CI because `uv` operations still resolve, but every developer who runs `uv lock` / `uv sync` / `uv run` on master gets an uncommitted `uv.lock` diff. The signal of meaningful lock changes is blurred and master is internally inconsistent (lock self-ref vs `pyproject.toml` version mismatch). Identical pattern hits any project pairing release-please with `uv`, `poetry`, or `Cargo`.
+**Solution:** In `release.yml`, after `googleapis/release-please-action@v4`, gate four steps on `if: steps.release.outputs.pr`: (1) jq-extract the PR's `headBranchName` into `GITHUB_ENV`, (2) `actions/checkout@v4` of that branch with the release PAT, (3) `setup-uv` + Python, (4) `uv lock` and conditionally commit/push any diff back to the PR branch. Route the dynamic branch name through `GITHUB_ENV` (not direct `${{ steps.… }}` interpolation in `run:`) to satisfy the workflow-injection lint. Cross-project version: the generalized "Special case: lock files with self-references" pattern lives in the maintainer's cross-project knowledge store (this lesson is its L-HIVE-88 origin); not linked here to preserve repo->store independence.
+**Why:** release-please's `extra-files` only mutates targets when it bumps versions during a release PR — it cannot reliably address array-of-table TOML entries by name. Regenerating the lock on the release-please branch shifts the work to where it actually has access to the new `pyproject.toml` version. The `if: steps.release.outputs.pr` gate keeps the steps no-op when release-please has nothing to release; the PAT keeps the commit attributable and re-triggers the standard CI workflow on the new commit.
+**Tags:** `#release-please` `#uv` `#ci` `#cross-project` `#lock-files`
+
+### [2026-05-18] Multi-process MCP server contention surfaces — checklist + patterns
+
+**Context:** Hive runs as N independent `uvx hive-vault` subprocesses (one per Claude Code session) sharing the same vault git repo + three SQLite trackers. PR #90 fixed the symptoms (39-min hang ending in `AssertionError('Request already responded to')`; recurring `git commit timed out`; silent capture_lesson loss). PR #92 hardened the design with the patterns that apply across any stateful multi-process MCP server.
+
+**Problem:** Intra-process primitives (`threading.Lock`, default `sqlite3` connection) silently fail to coordinate across separate MCP server subprocesses, even when each is correct on its own. The symptoms only appear under parallel usage and are hard to attribute (cuelgues, crash from monkey-patch-able assertions, silent data loss).
+
+**Solution:** Four primitive patterns:
+
+1. **Inter-process file lock** (`filelock`) on the git index. The thread-local `_GIT_LOCK` only serializes within one process — N processes still race on `.git/index.lock`. Wrap the whole write critical section (read-modify-write + commit), not just the git call, or you lose data on concurrent appends to the same file (the `capture_lesson` loss).
+2. **SQLite as inter-process queue, not async cache.** Set `connect(timeout=10)` + `PRAGMA busy_timeout=10000` + `PRAGMA synchronous=NORMAL` + `PRAGMA wal_autocheckpoint=200`. Replace SELECT+UPDATE with `INSERT ... ON CONFLICT DO UPDATE`. Buffer writes in memory and flush in batches; reads flush first so they see fresh data.
+3. **Rate-limit shared-state mutations** (`apply_decay` was the canonical bug). Use an atomic `INSERT ... ON CONFLICT DO UPDATE WHERE elapsed >= T` claim: row updates = decay runs; row unchanged = skip. Multiple briefings within T seconds = exactly one decay.
+4. **Cache subprocess-spawn ops** by HEAD SHA. `git log` / `git recent` were spawning per call. `_current_head_sha(vault)` reads `.git/HEAD` directly (no subprocess), perfect cache key.
+
+**Process-model patterns:**
+- Per-PID log file (`hive-{pid}.log`) — `RotatingFileHandler` rotation races corrupt the log under N concurrent writers.
+- Defer `create_server()` out of import-time → main(). Importing the module side-effect-free saves ~300-600ms × N spawns.
+- For client cancellation races, monkey-patch BOTH `RequestResponder.__exit__` (re-raised CancelledError, issue #75) AND `RequestResponder.respond` (AssertionError on `_completed=True` when handler finishes after cancel). Self-gate both on the exact failure mode so they degrade silently if upstream fixes.
+
+**UX:** `format_io_error(exc, path, action)` discriminator returning per-class hints beats `f"File I/O error: {exc!r}"`. The LLM relay can act on "permission denied — check writable by MCP process" but not on `[Errno 13]`.
+
+**Verdict on scaling:** The original ADR-005 estimated wall at 50 sessions. Audit revised down to ~20–25 (every read also writes to SQLite via `track()`; triple-timeout stack up to 90s; `apply_decay` correctness break at 5+ concurrent briefings). Post-PR-92 (buffered writes + apply_decay gate + git_log cache), the wall should rise but exact number needs measurement.
+
+**Tags:** `#mcp` `#concurrency` `#multi-process` `#sqlite` `#filelock` `#scalability`
+
+**Cross-project pattern:** the multi-process-mcp-server pattern (maintainer's cross-project knowledge store) was distilled from this lesson (origin L-HIVE-90/92); not linked here to preserve repo->store independence.
+
+### [2026-05-19] GitHub Actions floating major tags are publisher-dependent — verify before bumping
+**Context:** Bumping all CI actions to Node 24 ahead of 2026-06-02 deprecation. Started with @v6/@v8/@v5 across checkout/setup-uv/release-please-action.
+**Problem:** CI failed with "Unable to resolve action astral-sh/setup-uv@v8, unable to find version v8" even though gh api showed v8.1.0 as latest release. Each action publisher uses a different tagging convention: actions/checkout publishes floating majors (v6 → v6.0.2), googleapis/release-please-action publishes floating majors (v5 → v5.0.0), but astral-sh/setup-uv publishes only floating MINORS (v7.4, v7.5, v7.6) plus exact SemVer (v8.0.0, v8.1.0). No floating major tag exists for setup-uv.</problem>
+<parameter name="solution">Before bumping a GitHub Action's major version, verify the floating tag actually exists: gh api repos/OWNER/REPO/git/refs/tags/vN. If 404, fall back to exact SemVer (vN.M.P) or the highest floating minor (vN.M). For astral-sh/setup-uv, pin to v8.1.0 exactly until a v8 floating tag is published.
+**Solution:** 
+**Tags:** `#ci` `#github-actions` `#deps`
+
+### [2026-05-19] mypy 1→2 + fastmcp 3.1→3.3 were no-ops because --strict already covered the surface
+**Context:** Two "risky major" dep bumps in v1.13.0 stabilization cycle: mypy 1.19.1 → 2.1.0 (tightened defaults) and fastmcp 3.1.0 → 3.3.1 (MCP framework). Both initially classified as needing dedicated smoke + risk assessment.
+**Problem:** Risk classification of major bumps tends to over-estimate effort for codebases that already use strict configs. mypy 2's "tightened defaults" are a subset of what --strict already enforces. fastmcp 3.3's API surface for @mcp.tool / call_tool / FastMCP() was stable across 3.1 → 3.3. Spending separate PR cycles on each was lower ROI than expected.</problem>
+<parameter name="solution">For major bumps in projects already on strict configs (mypy --strict, ruff with aggressive ruleset, full async typing), run `make check` once on the bumped lockfile BEFORE designing a multi-step smoke plan. If green, ship as a small lockfile-only PR. The integration tests already exercise the framework wire; the type checker already enforces the strictest contracts. Save the dedicated-smoke effort for bumps where the project's own strictness DOESN'T cover the change vector (e.g. API rename, behavior flag flip).
+**Solution:** 
+**Tags:** `#deps` `#tooling` `#process`
+
+### [2026-05-20] Empirical wire-level test must precede ADRs about MCP cancellation/race behavior
+**Context:** Drafting ADR-006 (commit policy) and ADR-007 (MCP cancellation response) for HIVE-104. ADR-007 §1 originally decided that `_compat._patched_respond` would attempt a "best-effort raw stdio write" of the JSON-RPC response when `_completed=True` to recover user-visible ghost responses. Promoted to Accepted via vault_write after a multi-turn architectural design discussion. The decision rested on an unstated assumption: that no prior response had reached the wire by the time our patched `respond()` fires.
+**Problem:** A 20-iteration empirical classifier (`tests/test_compat_shim.py::test_classify_cancellation_race`, spawns a real hive subprocess on Linux, drives `tools/call` + `notifications/cancelled`, inspects wire bytes) ran AFTER promotion and showed scenario (a) — "ErrorData wins" — in 20/20 cases. `RequestResponder.cancel()` at `mcp/shared/session.py:148-150` always succeeds in calling `_send_response(ErrorData)` before our handler completes; the wire response is invariably `{"id": N, "error": {"code": 0, "message": "Request cancelled"}}`. The "best-effort raw send" decision would have produced a duplicate response (same request_id, success after error) in 100% of cases — a protocol violation worse than the silent-suppress status quo. ADR-007 §1 had to be retracted in Amendment #2 (same day as promotion), and Fase C scope dropped from ~80 LOC raw-stdio-framing to ~30 LOC observability-only.
+**Solution:** For any ADR whose decision depends on wire-level behavior under cancellation or race conditions, write the empirical classifier BEFORE the ADR's decision section is locked in. The classifier pattern is cheap (~50 LOC, mirrors the subprocess fixture in `tests/test_transport_recovery.py`): spawn the real server, drive the race over N iterations, classify outcomes into well-defined scenarios, count distribution. Do NOT rely on in-memory mocks of anyio streams for this — stdio framing and cancellation timing only behave faithfully end-to-end via subprocess. Also: ADRs MUST allow Status amendments without supersession (ADR-007 carries two amendments stacked under one Status block); the document a future reader sees is the FULL audit trail of how the decision evolved, not just the latest verdict.
+**Tags:** `#adr` `#testing` `#mcp` `#cancellation` `#design-process`
+
+### [2026-05-20] Pattern-sweep vault before opening any non-trivial branch
+**Context:** Starting the post-HIVE-104 docs cleanup PR. Named the branch docs/post-HIVE-104 and was about to push when a sweep of _meta/patterns/pattern-git-workflow.md surfaced two rule violations.
+**Problem:** Violations were: (1) docs/ prefix not in the approved table (chore/, fix/, feat/, release/), and (2) post-HIVE-104 is a milestone/phase reference, forbidden by git-workflow §7 "phase tracking belongs in the vault backlog, not git history". Without the sweep, both would have landed on origin and been visible to humans/CI.
+**Solution:** Before the first commit on any new branch, query the cross-cutting patterns that gate the work: vault_query(project="_meta", path="patterns/pattern-git-workflow.md") for branch/commit/PR rules, plus any topic-specific pattern (docs-site-starlight, language-standards, spec-driven-development). Renaming the branch later is cheap; renaming after push is not. The branch was renamed to chore/commit-policy-doc-followups before any push.
+**Tags:** `#workflow` `#git` `#rules-discipline`
+
+### [2026-05-21] Substring assertions on full report output break when vault_path is included
+**Context:** Implementing the `## server` identity block in `vault_health` (issue #109) — the block embeds `vault_path: <abs path>`. Four pre-existing tests in `test_server.py` used substring assertions like `assert "stale" not in result.lower()`, `assert "error" not in result.lower()`, `assert "ghost_responses" not in result`. They started failing because pytest's `tmp_path` includes the test name (e.g. `test_terminal_status_not_stale0`), which is now legitimately printed verbatim inside the identity block.
+**Problem:** Bare substring negation on a multi-line markdown report is fragile against any future field that interpolates user-controlled / path-like data. Once vault_path was added, four tests false-positive on substrings that happen to be inside the path. Adding the field exposed brittleness that had been latent.
+**Solution:** Anchor negative assertions on the structural marker the producer code actually emits — `## ghost_responses` (the section header), `[error]` (the issue marker), `Stale files` (the label). Positive assertions can stay loose. Rule of thumb: if you're asserting that section X is absent, assert the section *header* is absent, not the topic word.
+**Tags:** `#testing` `#regression` `#vault-health`
+
+### [2026-05-21] Substring assertions on full vault_health output break when vault_path is included
+**Context:** Implementing the `## server` identity block in `vault_health` (issue #109) — the block embeds `vault_path: <abs path>`. Four pre-existing tests in `test_server.py` used substring assertions like `assert "stale" not in result.lower()`, `assert "error" not in result.lower()`, `assert "ghost_responses" not in result`. They started failing because pytest's `tmp_path` includes the test name (e.g. `test_terminal_status_not_stale0`), which is now legitimately printed verbatim inside the identity block.
+**Problem:** Bare substring negation on a multi-line markdown report is fragile against any future field that interpolates user-controlled / path-like data. Once vault_path was added, four tests false-positive on substrings that happen to be inside the path. Adding the field exposed brittleness that had been latent.
+**Solution:** Anchor negative assertions on the structural marker the producer code actually emits — `## ghost_responses` (the section header), `[error]` (the issue marker), `Stale files` (the label). Positive assertions can stay loose. Rule of thumb: if you're asserting that section X is absent, assert the section *header* is absent, not the topic word.
+**Tags:** `#testing` `#regression` `#vault-health`
+
+### [2026-05-21] Path.write_text in tests must pass encoding=utf-8 on Windows
+**Context:** Re-running the full pytest suite on Windows during #109. `tests/test_server.py::TestVaultValidate::test_posix_class_in_heading_not_flagged` was already failing on master (unrelated to the identity block) — the test writes a markdown file with an em-dash and then calls `vault_health(checks=["links"])`, which routes the read through `_safe_read` (`f.read_text(encoding="utf-8")`).
+**Problem:** Path.write_text(...) without an explicit encoding uses locale.getencoding() — cp1252 on Windows by default. cp1252 happily encodes the em-dash to byte 0x97. _safe_read then opens the file expecting UTF-8, sees the lone 0x97, raises UnicodeDecodeError, and the file is silently reported as `[error] ... File unreadable (I/O or encoding error)`. The test then sees `posix-heading.md` in the error message and false-positives — the actual POSIX-class regression check is masked.
+**Solution:** Always pass `encoding="utf-8"` to Path.write_text (and read_text) in tests that put non-ASCII content into vault files. The production reader is hard-coded to UTF-8; writers must match. This bites on Windows only — Linux/macOS CI defaults to UTF-8 — so it's invisible until someone runs the suite locally on Windows.
+**Tags:** `#testing` `#windows` `#encoding`
+
+### [2026-05-21] Three timeouts in a chain aren't a deadline
+**Context:** Designing HIVE-115 latency-tail re-architecture. Hive's `tool_span` wraps async tool handlers with `asyncio.timeout(60)`. Inside, `Lock.acquire(timeout=30)` enforces lock-wait. Inside that, `subprocess.run(timeout=30)` enforces git subprocess wall-time. Three nested timeouts, each correct at its layer. Live evidence in issue #111: `capture_lesson` elapsed 838s while `ctx.tool_timeout` was 60s — 14× the documented contract. Three failure modes observed in production: invisible hang, client interprets silence as user-rejection, "Server busy" canned string returned while operation still running. See the lesson "SQLite WAL doesn't auto-checkpoint when N processes hold readers" (below) for the SQLite half of the same systemic issue.
+**Problem:** `asyncio.timeout` only cancels at `await` points. Once execution enters `asyncio.to_thread(...)`, asyncio cancels the future but cannot interrupt the thread itself — Python has no portable way to inject an exception into a running thread. Inside that thread, `Lock.acquire(timeout=30)` and `subprocess.run(timeout=30)` enforce only their own deadlines. The composition is unsafe: 30s lock wait + 30s subprocess wait + repeated retries can chain into 60+ seconds outside the 60s asyncio envelope. None of the layers act as a true deadline over the composed chain. The deadline is advisory, not enforced. Logs show "ok elapsed_ms=838360" with tool_timeout=60 — the call returned eventually, but 14× over contract.
+**Solution:** A real deadline requires ONE supervisor with termination authority over all sub-operations. Pattern: introduce `bounded_call(fn, deadline_s)` helper that holds a context-local registry of `subprocess.Popen` handles + `ThreadPoolExecutor` futures. On deadline expiry: cancel the future (best-effort), then `Popen.terminate()` on each registered child (SIGTERM with 2s grace → SIGKILL on POSIX; `TerminateProcess` on Windows with `CREATE_NEW_PROCESS_GROUP` so child trees go down), surface a real `mcp.protocol.TimeoutError` to the client. Migration cost: `subprocess.run → Popen` in all 5 git callsites (`_helpers._git_commit`, etc.). Tracked as ADR-008 hard-deadline-enforcement, lands in Phase B of HIVE-115. Generalization: ANY tool or API with a documented timeout must enforce it at one layer with kill authority. Per-step timeouts that compose do not compose into a global deadline. This refines the four-layer model in the maintainer's cross-project async-threading pattern §1 — defense-in-depth is correct, but ONE layer must own preemption.
+**Tags:** `#python` `#asyncio` `#deadline` `#timeout` `#subprocess` `#concurrency` `#HIVE-115` `#ADR-008`
+
+### [2026-05-21] SQLite WAL doesn't auto-checkpoint when N processes hold readers (baseline N=3-5)
+**Context:** Investigating multi-process WAL bloat for HIVE-115. Local snapshot 2026-05-21: 3 concurrent hive-vault processes alive (PIDs 475646, 529429, 540650 — 25min, 7min, 4min old). `lsof` confirms each holds open file handles to all 3 SQLite DBs simultaneously (worker.db, relevance.db, lesson_reinforcement.db). Observed sizes: `relevance.db-wal` = 4.1 MB vs `.db` = 53 KB (77× ratio), `lesson_reinforcement.db-wal` = 157 KB vs 12 KB (13×), `worker.db-wal` = 91 KB vs 8.2 KB (11×) — and `worker.db-wal` was last modified 2 months ago (March 13). Critical context: 3-5 concurrent Claude Code sessions per user is the BASELINE daily usage pattern of hive, not edge case. Prior ADR-005 scale table dimensioned "1-3 = fine, 5 = occasional waits"; the system is operating at the codo of its own scaling boundary in normal use.
+**Problem:** `PRAGMA journal_mode=WAL` + `PRAGMA wal_autocheckpoint=1000` does NOT mean "WAL stays small". Any concurrent reader that has an open snapshot blocks the checkpoint operation from advancing past the frame it's reading. With process-per-MCP-client orchestration (ADR-001/ADR-005), every additional Claude Code session adds a process that opens read handles on ALL trackers even if it only uses one. Result: at N=3-5 baseline, there is virtually always a snapshot holder; the WAL never drains. Worse: the original Phase A design called for `PRAGMA wal_checkpoint(TRUNCATE)` on shutdown — but at N=3-5, there is rarely a "last process to shut down". The shutdown drain is virtually inert; the WAL grows unboundedly until a true idle moment that may never come. Per-open WAL replay cost grows linearly with WAL size, so each new hive process pays an increasing startup tax.
+**Solution:** Under multi-process patterns at N>1 baseline, the WAL drain must be PERIODIC, not shutdown-driven. Concretely (Phase A of HIVE-115, ADR-009 v1): (1) start a background `threading.Thread(daemon=True)` in every hive process that runs `PRAGMA wal_checkpoint(PASSIVE)` every 30s on each tracker's connection. PASSIVE does not block readers and advances checkpoint as far as current frames allow. (2) Keep `wal_checkpoint(TRUNCATE)` on graceful shutdown as a fallback — useful when N IS 0 (rare but possible). (3) Surface `wal_size_bytes` in `vault_health(include_runtime=True)` so growth is observable before it becomes contention. Cross-references: the lesson "Three timeouts in a chain aren't a deadline" (above) (same root: composition of locally-correct decisions failing at the actual usage envelope). For Phase B see ADR-009 v2 (Outbox+Reconciler) which makes the reconciler thread the single periodic checkpoint owner. Long-form analysis: HIVE-115 backlog (tracked in the forge — GitHub issues / milestones).
+**Tags:** `#sqlite` `#wal` `#multiprocess` `#checkpoint` `#concurrency` `#HIVE-115` `#ADR-009`
+
+### [2026-05-21] Cooperative external committer needs explicit coordination, not best-effort
+**Context:** Investigating `.git/index.lock` contention for HIVE-115. Hive's vault git policy (ADR-006) treats commits as "best-effort, never fail the write". The Obsidian vault has the obsidian-git plugin configured: `autoSaveInterval=10` minutes, `autoPullInterval=10`, `autoPullOnBoot=true`, `pullBeforePush=true`. Neither tool knows the other exists. When obsidian-git fires its 10-minute backup tick, it holds `.git/index.lock` for the duration of pull + commit + push (~5-15s, the pullBeforePush=true triples the window). During that window, any hive `_GIT_LOCK` + `_git_filelock` acquire blocks. Issue #110 evidence: silent 30-second freezes per call coinciding with obsidian-git ticks, leading to `_LOCK_TIMEOUT=30` abandons. Prior ADR-006 §6 already added "detect_obsidian_git()" as informational signal in `vault_health`, but treated it as advisory only.
+**Problem:** When hive treats git as "best-effort, never fail the write" and obsidian-git treats git as "auto-commit every interval", the two cooperative processes COMPETE for `.git/index.lock` instead of coordinating. The result is silent: hive abandons with a WARNING log after 30s, the user sees a freeze, but no errors propagate. Worse, the windows are not synchronized — obsidian-git's `pullBeforePush=true` extends the lock window 3× over a plain commit, so the probability of coincidence is high during write-heavy hive sessions. The pre-existing "informational detection" in vault_health is insufficient: it surfaces presence, not active coordination. There is no fallback path when the external committer is paused or broken.
+**Solution:** Promote `detect_obsidian_git()` from informational to first-class design concept. Phase A of HIVE-115 (ADR-010 external-committer-coexistence): (1) `HIVE_LOCK_TIMEOUT_S` env-tunable so users with large vaults can absorb longer external windows; (2) structured `mcp.lock_contention` log per acquire attempt with `waited_ms` field; (3) `obsidian_git_present` boolean surfaced in `vault_health(include_runtime=True)`. Phase B (ADR-009 v2 outbox path): when external committer detected AND recent (probe `git log -1 --since="$((autoSaveInterval*2)) minutes ago"` returns a commit), DEFER hive's writes via `commit=False` automatically (not just opt-in); when detector reports stale/missing, FALLBACK to hive's own backoff-retry reconciler. Critical: never blindly defer indefinitely — a paused obsidian-git plugin would silently halt all vault commits. Pattern: cooperate-or-fallback, never compete-blindly. Cross-ref the lesson "SQLite WAL doesn't auto-checkpoint when N processes hold readers" (above) for the SQLite half of the same multi-writer coordination problem.
+**Tags:** `#git` `#obsidian-git` `#coordination` `#filelock` `#multiprocess` `#HIVE-115` `#ADR-010`
+
+### [2026-05-21] Telemetry IS the design, not an afterthought
+**Context:** Investigating root causes of HIVE-115. The 838s `capture_lesson` event from issue #111 was invisible until manual log archaeology surfaced one INFO line buried in a per-PID log file: `mcp ok ... tool=capture_lesson id=11 elapsed_ms=838360`. The configured `tool_timeout=60` value lived in code, but the actual elapsed time was only logged at INFO with no structured fields. WAL bloat (4.1 MB `relevance.db-wal`) was invisible until manual `ls` showed the size — no metric exposed it. Lock contention with obsidian-git was suspected only by correlating obsidian-git's `autoSaveInterval=10` config with hive's 30s freezes. None of these were observable from inside the system; all required external archaeology.
+**Problem:** A tool with a documented contract (e.g. `HIVE_TOOL_TIMEOUT=60`) but no structured telemetry for the actual elapsed time, the wait breakdown, or the contract violations is operating blind. When something goes wrong, debugging requires log spelunking instead of metric query. By the time someone notices a 14-minute hang in a per-PID log file, the user has already abandoned the session and lost confidence. Worse, decisions about whether to re-architect become subjective ("seems slow lately") instead of measured. The prior plan for HIVE-115 included a Phase B (Outbox+Reconciler) that depends on sizing the bounded_call grace period correctly — without distribution data for `last_git_lock_wait_ms`, the grace period would be guessed, not measured.
+**Solution:** Any tool/api with a configured deadline needs structured logging of `{deadline, elapsed, wait_breakdown}` from day one. For HIVE-115 Phase A: emit one structured `mcp.lock_contention` log per `_GIT_LOCK.acquire` attempt with `{tool, lock, waited_ms, abandoned}`; surface `wal_size_bytes`, `competing_pid_count`, `last_git_lock_wait_ms` (rolling N=100), `obsidian_git_present` via `vault_health(include_runtime=True)`. Treat instrumentation as a SHIPPING REQUIREMENT alongside the fix, not as follow-up work. Without these metrics, the gate condition for Phase B advancement ("≥10 events of waited_ms>5000, or p99 wal_size > 5 MB, or ≥1 tool_timeout_exceeded") cannot be evaluated objectively. Generalization: when a design choice introduces a contract (deadline, capacity, freshness), the same PR must introduce its observability — they are inseparable. Cross-ref: the maintainer's cross-project phased-redesign-with-telemetry-gates pattern documents the gating discipline; the lesson "Three timeouts in a chain aren't a deadline" (above) is the canonical "broken contract due to lack of enforcement and observability" pair.
+**Tags:** `#observability` `#telemetry` `#design` `#instrumentation` `#HIVE-115` `#phase-a`
+
+### [2026-05-22] ContextVar propagates across asyncio.to_thread — use over explicit parameter passing for per-call state
+**Context:** HIVE-115 PR-3: designing `bounded_call`'s process_registry parameter (a list[Popen] mutated by sync code in a worker thread, iterated by async code on deadline expiry). ADR-008 §1 originally specified explicit parameter passing because "asyncio.to_thread boundary makes contextvar propagation fragile across the async/sync layer".
+**Problem:** Threading the registry through every git helper signature (`_git_commit(vault, paths, message, registry=...)`, `_git_commit_all(vault, message, registry=...)`, plus every wrapper that calls them) would be invasive across 8 callsites and break every existing test that passes positional args. ADR claim went unverified against current CPython docs.
+**Solution:** CPython 3.9+ `asyncio.to_thread` uses `contextvars.copy_context()` internally — the same `ContextVar`-bound list reference is visible from both async land and the worker thread, and mutations land in the same object (not a copy). Adopted `_GIT_REGISTRY_CV: ContextVar[list[Popen] | None]` with default `None`. `tool_span` (async wrapper) sets the CV at entry, `_run_git` (sync, runs inside `asyncio.to_thread`) reads `_GIT_REGISTRY_CV.get()` and appends/removes. Zero signature changes at callsites. Verified by `tests/test_bounded_call.py::test_subprocess_terminated` killing a registered Popen from async land. Lesson: re-evaluate ADR claims about Python concurrency against current docs before designing workarounds; contextvar propagation across `to_thread` is documented and robust.
+**Tags:** `#python` `#concurrency` `#async` `#contextvars` `#design`
+
+### [2026-05-22] GitHub `Closes #N` keyword only parsed when on its own line at PR body footer
+**Context:** HIVE-115 PR-3 (#119) body included `Closes #111` inside a Summary section bullet list ("Closes **#111** — the 838s..."). PR-4 (#121) body had the same `Closes #110` styling.
+**Problem:** After PR-3 merged, issue #111 stayed OPEN — had to close manually with a `gh issue close` + reference comment. GraphQL `closingIssuesReferences` returned empty. The auto-close keyword detection failed silently.
+**Solution:** For PR-4 (#121), placed `Closes #110` on its own line at the body footer. GraphQL verified `closingIssuesReferences: [{number: 110}]`. On merge, #110 auto-closed correctly. Rule: GitHub's close-keyword scanner is fragile within rich markdown (bold, inline list items, surrounding text); always put `Closes #N` / `Fixes #N` / `Resolves #N` on a bare line at the bottom of the PR body. Verify with `gh api graphql -f query='{... pullRequest(number:N) { closingIssuesReferences { nodes { number } } } }'` before relying on auto-close.
+**Tags:** `#github` `#workflow` `#pull-request` `#automation`
+
+
+### [2026-05-28] You cannot cancel a Python thread you started
+
+**Tag:** concurrency, deadlines, cooperation-pattern, hive-116
+
+**Context.** HIVE-115 PR-3 introduced `bounded_call`/`tool_span` to enforce wall-clock deadlines on tool calls. The supervisor terminates registered `Popen` subprocesses on expiry — that part works. But two weeks of empirical use (issue #141) showed that the worker thread doing the sync `_git_commit` is NOT cancelled when the deadline fires. The client sees `TimeoutError`, but the thread keeps running. In one Windows case it ran 246 seconds after the supposedly-60s deadline. While the thread runs, it holds `_GIT_LOCK` (threading) + the singleton `_git_filelock` (filelock) and blocks every sibling.
+
+**Problem.** `asyncio.timeout` is purely cooperative — it cancels the awaiting coroutine at the next `await`, but `asyncio.to_thread`'s worker thread has no awaitable inside the body. CPython has no `Thread.cancel()`. `PyThreadState_SetAsyncExc` exists but is documented as not reliable for cancelling code inside C-implemented blocking calls (which is exactly where stuck threads live). So a thread inside `subprocess.communicate()` stays there until the subprocess flushes its stdio — and on Windows, communicate() on a SIGKILLed child can block far longer than it does on POSIX. Result: deadline supervisor + runaway thread + cached singleton lock = "fast client response, blocked siblings, orphan lock file." Foundation lesson is "Three timeouts in a chain aren't a deadline" (above); this lesson is the corollary that motivates the cooperation primitive.
+
+**Solution.** Stop trying to cancel the thread. Instead, **evict the cached lock object from the singleton cache so the next acquire constructs a fresh one.** The runaway thread eventually releases (FD closes when the thread exits or when GC reaps the FileLock); meanwhile the new acquires bypass it. On POSIX the kernel tracks `fcntl.flock` per-fd, so the new FileLock can acquire the moment the runaway holder's fd closes. On Windows the orphan lock file persists in `.git/` until the parent process exits (filelock library invariant), but no longer blocks new acquires.
+
+The supervisor inserts the eviction between SIGKILL and the TimeoutError raise:
+
+```python
+# In bounded_call / tool_span TimeoutError branch:
+killed = await _terminate_registry(registry, grace_s)
+if vault is not None and killed:
+    _cleanup_index_lock(vault, killed)
+    await asyncio.sleep(HIVE_POST_KILL_DRAIN_S)  # 5s default
+    evict_filelock(vault)                          # pop from cache
+    _record_lock_eviction(vault, killed)           # telemetry
+raise TimeoutError(...)
+```
+
+The 5s drain is intentional: gives the worker thread a chance to escape `with lock:` naturally on the happy path (Linux subprocess.communicate returns within ~100ms of SIGKILL). Eviction is the safety net for the worst case where the thread is stuck. Drain calibration {1, 5, 10} converged on 5s as the smallest value that never raced eviction in 20-run validation.
+
+**Codified in [adr/adr-012-cooperative-filelock-eviction-on-deadline.md](adr/adr-012-cooperative-filelock-eviction-on-deadline.md)** (decision) + the maintainer's cross-project multi-process-mcp-server pattern §primitive-8 (reusable form). [adr/adr-008-hard-deadline-enforcement.md](adr/adr-008-hard-deadline-enforcement.md) §5 amendment cross-references this.
+
+**Anti-pattern caught.** Earlier draft of HIVE-116 considered "Option A: `Popen.wait(timeout=N)` inside `_run_git`" — an inner timeout to make the thread escape voluntarily. This violates the SSOT principle from HIVE-115 audit B1 ("bounded_call is the single source of truth for deadlines, inner timeouts race the supervisor's external termination"). Eviction is the right shape because it doesn't add a second clock; it cleans up state the runaway thread is no longer authoritative over.
+
+**Cross-platform note.** On Windows, the `.git/hive.lock` file may persist as a 0-byte file even after eviction — `Device or resource busy` on `rm` until the parent process exits. This is the filelock library's invariant (the file is the handle's medium; closing the handle doesn't unlink the file). Documented in `docs/troubleshooting.md` as a cosmetic artifact, not a functional issue.
+
+**When to escalate.** If `vault_health.runtime.lock_eviction.count_30d` rises above ~10/month in normal use, the cooperation pattern is reaching its limit and ADR-011 (daemon model) becomes mandatory. ADR-012 buys observation time for the 2026-06-05 Phase C decision checkpoint (issue #124); it is not a permanent fix for sustained N≥10 multi-session usage.
+
+### [2026-05-27] Zero-byte WAL file means fully checkpointed, not broken
+**Context:** Debt triage session 2026-05-27: investigating ~/.local/share/hive/worker.db WAL sidecar observed as stale during HIVE-116 investigation.
+**Problem:** worker.db had a 0-byte WAL file with mtime from Mar 10 (~2.5 months stale). Initial impression was that the WAL checkpoint wasn't running. This caused diagnostic confusion during HIVE-116 investigation.
+**Solution:** A 0-byte .db-wal file means the WAL was FULLY checkpointed (success signal, not failure). SQLite leaves the empty WAL file behind after checkpoint. The old mtime just means no writes happened since then — normal for budget.db when OpenRouter isn't heavily used. Added _clean_stale_wal_files() at server startup in _helpers.py to auto-remove 0-byte WALs ≥30d stale, preventing future diagnostic confusion.
+**Tags:** `#sqlite` `#wal` `#debt`
+
+### [2026-05-27] Makefile DX improvements: cross-platform clean, test-one, logs target
+**Context:** DX bundle improvements during 2026-05-27 debt triage session.
+**Problem:** make clean used rm -rf (POSIX-only), no make test-one target existed for quick single-test runs, log path was only documented in troubleshooting docs.
+**Solution:** Replaced rm -rf in make clean with uv run python -c (cross-platform), added make test-one ARGS=... target, added make logs target that shows path + tail -f tip. Updated .claude/CLAUDE.md with upstream _compat.py tracker + issue #127 reference.
+**Tags:** `#dx` `#makefile` `#cross-platform`

--- a/docs/runbooks/audit-checklist.md
+++ b/docs/runbooks/audit-checklist.md
@@ -1,0 +1,95 @@
+---
+id: audit-checklist
+type: runbook
+status: active
+created: "2026-03-03"
+owner: manu
+---
+
+# Hive: Architecture Audit Checklist
+
+> Run this checklist at major milestones or when onboarding.
+> Last audit: 2026-03-09 (post-consolidation, 19→10 tools)
+
+## 1. MCP Server (10 tools)
+
+- [ ] `make check` passes (lint + mypy + tests)
+- [ ] `uvx hive-vault` starts without errors
+- [ ] `vault_list()` returns known projects
+- [ ] `vault_list(project="hive")` returns files in project
+- [ ] `vault_query(project="hive", section="context")` returns content
+- [ ] `vault_search(query="active")` returns results across projects
+- [ ] `vault_search(query="hive", ranked=True)` returns scored results
+- [ ] `vault_search(since_days=7)` returns recent changes
+- [ ] `vault_write(project, section, operation="append", content)` appends + commits
+- [ ] `vault_write(project, path, content, doc_type, operation="create")` creates with frontmatter
+- [ ] `vault_patch(project, path, old_text, new_text)` does surgical replace
+- [ ] `vault_health()` reports file counts, stale files, missing sections
+- [ ] `vault_health(checks=["frontmatter", "stale", "links"])` runs validation
+- [ ] `vault_health(include_usage=True)` shows tool usage analytics
+- [ ] `capture_lesson(project, title, context, problem, solution)` writes inline
+- [ ] `session_briefing(project="hive")` returns tasks + lessons + git log + health
+- [ ] `delegate_task(prompt="echo hello")` routes to Ollama or OpenRouter
+- [ ] `delegate_task(project="hive", section="context")` summarizes vault file
+- [ ] `worker_status()` returns budget, connectivity, and available models
+- [ ] `list_resources()` returns 2 static + 3 templates
+- [ ] `read_resource("hive://projects")` returns project listing
+
+**Count:** 10 tools (7 vault + 1 session + 2 worker), 5 resources, 4 prompts
+
+## 2. Configuration
+
+- [ ] `HiveSettings` loads from environment with `HIVE_` prefix
+- [ ] `OPENROUTER_API_KEY` bare alias works (backward compat)
+- [ ] `VAULT_PATH` points to valid Obsidian vault
+- [ ] `HIVE_OLLAMA_ENDPOINT` resolves to reachable Ollama instance
+- [ ] `HIVE_DB_PATH` creates parent directories if missing
+- [ ] `HIVE_LOG_PATH` creates rotating log file
+
+## 3. Infrastructure
+
+- [ ] Ollama (`ollama.kubelab.live:11434`) responds to health check
+- [ ] OpenRouter API key is loaded (via age-encrypted dotfiles)
+- [ ] MCP server registered in `~/.claude.json` (single hive server)
+- [ ] Vault git repo (`~/Projects/knowledge/`) is clean, no uncommitted changes
+- [ ] SQLite budget DB exists and is writable (WAL mode)
+
+## 4. CI/CD
+
+- [ ] GitHub Actions workflow runs on push to master
+- [ ] CI matrix: Python 3.12 + 3.13
+- [ ] Steps: ruff → mypy → pytest with coverage
+- [ ] CI completes in <60s
+- [ ] release-please configured for SemVer
+
+## 5. Code Quality
+
+- [ ] ruff check: zero warnings
+- [ ] mypy --strict: zero errors
+- [ ] Test count: ≥330
+- [ ] Coverage: ≥90%
+- [ ] No functions >40 lines
+- [ ] No classes >250 lines
+- [ ] No cyclomatic complexity >10
+
+## 6. Security
+
+- [ ] No hardcoded secrets in source
+- [ ] API keys loaded from environment only
+- [ ] OpenRouter key encrypted with age in dotfiles
+- [ ] No SQL injection vectors (parameterized queries in budget.py)
+- [ ] Frontmatter validation prevents arbitrary YAML injection on writes
+- [ ] Git commits are atomic (add + commit in sequence)
+- [ ] Regex patterns capped at 200 chars (ReDoS prevention)
+- [ ] API error text truncated to 200 chars (info disclosure prevention)
+- [ ] Path traversal blocked via resolve().relative_to()
+
+## 7. Documentation
+
+- [ ] `00-context.md` reflects current architecture and API surface
+- [ ] ADR-001 (orchestration model) — accepted, still valid
+- [ ] ADR-002 (system architecture) — accepted, matches shipped code
+- [ ] `CLAUDE.md` in repo root has correct paths and commands
+- [ ] `MEMORY.md` in auto-memory is current and concise
+- [ ] README.md tool table matches actual tool count (10)
+- [ ] Site docs match consolidated tool names

--- a/docs/troubleshooting/anyof-deferred-tools.md
+++ b/docs/troubleshooting/anyof-deferred-tools.md
@@ -1,0 +1,80 @@
+---
+id: anyof-deferred-tools
+type: troubleshooting
+status: active
+created: "2026-03-06"
+owner: manu
+---
+
+# anyOf in JSON Schema drops MCP tools from Claude Code
+
+## Summary
+
+Claude Code's deferred tool indexer silently drops MCP tools whose JSON Schema contains `anyOf` constructs. This means tools with `Optional` / `| None` parameter types become invisible — they cannot be loaded via `ToolSearch` and are unusable in a session.
+
+## Root Cause
+
+FastMCP (via Pydantic) generates `anyOf` for Python union types:
+
+```python
+# This generates anyOf — tool becomes invisible to Claude Code
+def my_tool(tags: list[str] | None = None) -> str: ...
+
+# This generates clean schema — tool is visible
+def my_tool(tags: list[str] = []) -> str: ...
+```
+
+Schema comparison:
+
+| Python type | JSON Schema | Claude Code |
+|---|---|---|
+| `str \| None = None` | `{"anyOf": [{"type": "string"}, {"type": "null"}]}` | Dropped |
+| `str = ""` | `{"type": "string", "default": ""}` | Works |
+| `list[str] \| None = None` | `{"anyOf": [{"type": "array"}, {"type": "null"}]}` | Dropped |
+| `list[str] = []` | `{"type": "array", "default": []}` | Works |
+
+## Impact
+
+3 of 17 Hive tools were invisible in Claude Code sessions:
+- `vault_patch` — the most critical write tool
+- `capture_lesson` — inline lesson extraction
+- `vault_list_files` — directory navigation (collateral — simple schema but contiguous with affected tools)
+
+## Fix (2026-03-06)
+
+Replaced all `| None = None` with empty defaults:
+
+| Parameter | Before | After |
+|---|---|---|
+| `vault_patch.old_text` | `str \| None = None` | `str = ""` |
+| `vault_patch.new_text` | `str \| None = None` | `str = ""` |
+| `vault_patch.patches` | `list[dict[str, str]] \| None = None` | `list[dict[str, str]] = []` |
+| `capture_lesson.tags` | `list[str] \| None = None` | `list[str] = []` |
+
+Mutable default (`= []`) is safe here because FastMCP wraps parameters in Pydantic models (new instance per call). Ruff B006 suppressed with `# noqa: B006`.
+
+Validation logic updated accordingly:
+- `patches is not None` → `len(patches) > 0`
+- `old_text is None` → `not old_text`
+- `tags or []` → `tags`
+
+## Verification
+
+After fix, all 17 tools generate anyOf-free schemas:
+```
+$ uv run python -c "..." # schema inspection script
+Total tools: 17
+anyOf present: 0
+```
+
+Requires new Claude Code session to verify deferred tool registration (tool list is set at session start).
+
+## Design Rule
+
+**Never use `| None` in MCP tool parameters.** Use empty defaults instead:
+- `str` → `str = ""`
+- `list[T]` → `list[T] = []`  (with `# noqa: B006`)
+- `int` → `int = 0` or `int = -1` (sentinel)
+- `bool` → `bool = False`
+
+This is a Claude Code client limitation, not an MCP protocol issue. Other clients may handle `anyOf` fine.

--- a/docs/troubleshooting/clean-code-solid-audit.md
+++ b/docs/troubleshooting/clean-code-solid-audit.md
@@ -1,0 +1,67 @@
+---
+id: clean-code-solid-audit
+type: troubleshooting
+status: active
+created: "2026-03-06"
+owner: manu
+---
+
+# Clean Code & SOLID Audit (2026-03-06)
+
+## Summary
+
+Full audit of all `src/hive/` Python files for Clean Code principles, SOLID violations, and external attacker security vectors. Performed after fixing the vault_patch connection crash and anyOf schema issues.
+
+## Security Findings (all fixed)
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| ReDoS via `vault_search` regex | MEDIUM | Pattern length capped at 200 chars |
+| `list_models()` no status check before `resp.json()` | LOW | Added `if resp.status_code >= 400` guard |
+| `float()` on API pricing without ValueError catch | LOW | Wrapped in try/except, defaults to 0.0 |
+| Unbounded `rglob` results in `vault_list_files` | LOW | Capped at 500 entries |
+| API error bodies relayed verbatim | LOW | Truncated to 200 chars |
+
+## Security: Already Mitigated (no action needed)
+
+- **Path traversal**: `.resolve()` + `relative_to()` on all path-based tools
+- **Command injection**: subprocess list form, no `shell=True`
+- **SQL injection**: parameterized queries everywhere
+- **YAML injection**: `safe_load` + regex sanitization
+- **SSRF**: endpoints only configurable via env var (not tool params)
+- **API key exposure**: only in Authorization header, never logged
+- **Insecure deserialization**: no pickle/eval/exec, only safe_load/JSON
+
+## Clean Code Findings (tracked as refactoring tasks)
+
+### HIGH (P2 refactoring)
+
+| Finding | File | Lines |
+|---------|------|-------|
+| `create_server()` is 1366 lines (God Function) | server.py:227-1594 | All tools as closures |
+| `vault_patch()` 120 lines, complexity ~13 | server.py:922-1042 | Needs helper extraction |
+| `capture_lesson()` 87 lines, DRY frontmatter | server.py:1044-1130 | Shared with vault_create |
+| `session_briefing()` 75 lines, 6 responsibilities | server.py:1225-1300 | Extract section builders |
+
+### MEDIUM (P3 refactoring)
+
+| Finding | File |
+|---------|------|
+| `vault_search` / `vault_smart_search` duplicate search logic | server.py:680,1173 |
+| 4 `_try_*` worker functions near-identical | server.py:1410-1460 |
+| SQLite init duplicated across budget/usage/relevance | 3 files |
+| "Project not found" string repeated 6x | server.py |
+
+### LOW (documented, not tracked)
+
+- Magic numbers: `[:5]` lines per result, scoring weights, git timeout
+- Undocumented constants: `_RECENCY_DAYS_SCALE`, `_WRITE_MULTIPLIER`
+- Hardcoded paths in config.py defaults
+
+## Decision
+
+Security fixes applied immediately (5 fixes, 5 new tests). Clean code findings tracked as refactoring tasks in `11-tasks.md` — not bugs, not blocking features. The factory-closure pattern in `create_server()` is a deliberate architectural choice that trades file length for shared-state simplicity.
+
+## Verification
+
+298 tests passed, 90% coverage, mypy --strict clean, ruff clean.

--- a/docs/troubleshooting/transport-closed-after-reject.md
+++ b/docs/troubleshooting/transport-closed-after-reject.md
@@ -1,0 +1,91 @@
+---
+id: "hive-issue-75-transport-closed-after-reject"
+type: troubleshooting
+status: resolved
+severity: medium
+tags: [bug, mcp-stability, race-condition, cancellation, upstream, issue-75]
+created: "2026-05-15"
+resolved: "2026-05-15"
+owner: manu
+---
+
+# MCP transport disconnect after rejecting first tool call
+
+## Summary
+
+Rejecting the very first `mcp__hive__*` permission prompt in a fresh Claude Code conversation poisoned the transport for the rest of the conversation. Subsequent calls to any Hive tool returned `MCP error -32000: Connection closed` and then `No such tool available`. The server process stayed alive (`claude mcp list` reported it as connected), but the per-conversation handle was dead.
+
+Tracked as [#75](https://github.com/mlorentedev/hive/issues/75). Fixed in `hive-vault 1.13.0`.
+
+## Environment
+
+- **OS:** Windows 11 Enterprise 10.0.22631
+- **Hive version:** `hive-vault 1.12.0` and below
+- **Python:** 3.12
+- **Transport:** stdio
+- **MCP client:** Claude Code (Opus 4.7)
+- **Library versions affected:** `mcp` 1.26.0 and 1.27.1 confirmed; `fastmcp` 3.1.1 → 3.3.1.
+
+## Reproduction
+
+1. Fresh Claude Code session with hive registered via `uvx hive-vault`.
+2. Invoke any Hive tool (e.g. `mcp__hive__session_briefing`).
+3. Reject the permission prompt.
+4. Invoke any other Hive tool — first call returns `Connection closed`, then `No such tool`.
+5. `claude mcp list` still reports `hive: ✓ Connected`.
+
+Automated regression test: `tests/test_transport_recovery.py::TestSubprocessTransportRecovery`.
+
+## Root cause
+
+In `mcp.shared.session.RequestResponder.__exit__` (mcp 1.26.0 — 1.27.1):
+
+```python
+def __exit__(self, exc_type, exc_val, exc_tb):
+    try:
+        if self._completed:
+            self._on_complete(self)
+    finally:
+        self._entered = False
+        ...
+        self._cancel_scope.__exit__(exc_type, exc_val, exc_tb)  # ←
+```
+
+When the client sends `notifications/cancelled`, `RequestResponder.cancel()`:
+1. Calls `self._cancel_scope.cancel()` — flags the scope.
+2. Sends the `ErrorData(code=0, message="Request cancelled")` response.
+
+The handler task catches the `CancelledError` in `_handle_request` (line 766-771 of `mcp/server/lowlevel/server.py`) and returns cleanly. But the `with responder:` block exits with `exc_type=None` while the cancel scope has a pending cancel — anyio's `CancelScope.__exit__` re-raises `CancelledError`. That exception propagates to the receive loop's `anyio.create_task_group()`, kills it, and the server stops reading stdin.
+
+The flakiness comes from a timing window between when the cancellation arrives and when the handler completes. Reproduction on Windows: 2/5 — 4/5 runs of the subprocess test fail without the patch.
+
+## Fix
+
+`src/hive/_compat.py` monkey-patches `RequestResponder.__exit__` to swallow the spurious `CancelledError` *only* when the responder is already completed (response sent) AND the exception is anyio's cancelled class. Both gates make the patch self-limiting: when upstream fixes the bug, the patch never fires.
+
+```python
+try:
+    self._cancel_scope.__exit__(exc_type, exc_val, exc_tb)
+except BaseException as exc:
+    cancelled_cls = anyio.get_cancelled_exc_class()
+    if self._completed and isinstance(exc, cancelled_cls):
+        return  # swallow — issue #75
+    raise
+```
+
+Applied at import time from `hive/server.py`. The `apply()` function is idempotent and degrades to a warning if `RequestResponder` is renamed/removed upstream.
+
+## Verification
+
+- `tests/test_transport_recovery.py`: 4 tests, 5/5 runs green after the patch (without the patch, the subprocess tests fail 2-4 / 5 times).
+- Lifecycle middleware in `src/hive/_diagnostics.py` logs each cancellation under DEBUG so the next incident is diagnosable from `~/.local/share/hive/hive.log`.
+
+## Upstream report
+
+Drafted for `modelcontextprotocol/python-sdk`. <!-- The full upstream bug-report draft (upstream-mcp-cancellation-race) lives in the maintainer's cross-project knowledge store; not linked here to preserve repo->store independence (knowledge-placement directionality invariant). -->
+
+## Lessons
+
+- **Race conditions in stdio MCP servers manifest only at the transport boundary.** In-memory FastMCP tests are inadequate to characterize cancellation behaviour; you need a subprocess driving real JSON-RPC.
+- **`anyio.CancelScope.__exit__` re-raises on clean exit when the scope was cancelled.** Library code that responds to a cancellation and then exits the scope must either swallow the re-raised exception or propagate it deliberately.
+- **A monkey-patch is acceptable technical debt** when the alternative is an unbounded wait for upstream and the patch is self-gated on the exact failure mode.

--- a/docs/troubleshooting/vault-patch-connection-crash.md
+++ b/docs/troubleshooting/vault-patch-connection-crash.md
@@ -1,0 +1,180 @@
+---
+id: "hive-issue-vault-patch-crash"
+type: troubleshooting
+status: resolved
+severity: high
+tags: [bug, vault_patch, mcp-stability, windows, git-commit]
+created: "2026-03-06"
+resolved: "2026-03-06"
+owner: manu
+---
+
+# vault_patch: MCP server crashes during write operations
+
+## Summary
+
+`vault_patch` intermittently crashes the Hive MCP server process. Data is written to disk correctly, but the MCP response never reaches Claude Code. The server dies shortly after, causing all subsequent MCP calls to fail with `Connection closed`.
+
+Read-only tools (`vault_query`, `vault_health`, `vault_usage`, `vault_search`) work consistently and respond in <2s.
+
+## Environment
+
+- **OS:** Windows 11 Pro 10.0.26100
+- **Hardware:** AMD Ryzen 7 5825U, 16GB shared RAM (no dedicated GPU)
+- **Hive version:** v1.4.2 (via `uvx hive-vault`)
+- **Python:** 3.12
+- **Claude Code client:** Opus 4.6
+
+## Reproduction Steps
+
+1. Start a Claude Code session with Hive MCP configured
+2. Use `vault_query` (works fine, confirms server is alive)
+3. Use `vault_patch` with one or more replacements
+4. Observe: Claude Code reports "The user doesn't want to proceed with this tool use. The tool use was rejected"
+5. Check the file on disk: patches ARE applied
+6. Try any subsequent MCP call: `MCP error -32000: Connection closed`
+
+## Observed Behavior
+
+### Case 1: Multi-patch call (3 replacements)
+- Claude Code reported: "rejected by user"
+- All 3 patches were applied to disk (verified via `vault_query` after restarting server)
+- Server continued responding after this call (did not crash immediately)
+
+### Case 2: Single patch call
+- Claude Code reported: "rejected by user"
+- Patch was applied to disk
+- Immediately after, `vault_query` returned: `MCP error -32000: Connection closed`
+- Server process was dead — all subsequent calls failed
+
+### Case 3: Second single patch call (after Case 2 server restarted)
+- Same behavior: reported as rejected, data written, server crashed
+
+## Analysis
+
+### What vault_patch does internally
+1. Read file from disk
+2. Find `old_text` in content
+3. Replace with `new_text`
+4. Write file to disk
+5. Call `_git_commit()` — runs `subprocess.run(["git", "commit", ...], timeout=10)`
+6. Return MCP response
+
+### Root Cause Hypothesis
+
+The server crashes **after file write but before/during MCP response serialization**. Evidence:
+
+| Observation | Implication |
+|-------------|-------------|
+| Data is written to disk | Steps 1-4 complete successfully |
+| MCP response never arrives | Step 5 or 6 fails |
+| Read-only tools never crash | No git commit, no file write in read path |
+| Server process dies | Unhandled exception or process termination |
+
+Most likely culprit: `_git_commit()` subprocess interaction on Windows.
+
+Possible failure modes in `_git_commit()`:
+- `subprocess.run(timeout=10)` may be too tight on Windows with antivirus/indexing overhead
+- Git hook execution (if any pre-commit hooks exist in the vault repo)
+- stdout/stderr pipe buffer overflow if git produces unexpected output
+- FastMCP stdio transport may interpret subprocess stdout as MCP protocol data (stdout conflict)
+
+### Why Claude Code shows "rejected by user"
+
+Claude Code receives no MCP response (connection drops). It interprets this as user rejection. This is misleading — the user did not reject anything.
+
+## Proposed Fixes (prioritized)
+
+### P0: Response-first pattern
+Send the MCP success response **before** running `_git_commit()`. The git commit is a side effect, not part of the user-facing result.
+
+```python
+# Current (risky):
+_write_file(path, content)
+_git_commit(message)       # <-- can crash here, response never sent
+return {"result": "ok"}
+
+# Proposed (safe):
+_write_file(path, content)
+result = {"result": "ok"}
+try:
+    _git_commit(message)
+except Exception:
+    log.warning("git commit failed, data saved but not committed")
+return result
+```
+
+### P1: Async/background git commit
+Move `_git_commit()` to a background thread or asyncio task so it cannot block the response.
+
+### P2: Increase subprocess timeout on Windows
+Change `timeout=10` to `timeout=30` for git operations. Windows disk I/O is slower, especially with:
+- Windows Defender real-time scanning
+- Windows Search indexer
+- NTFS journaling overhead
+
+### P3: Investigate stdout conflict
+Check if `subprocess.run()` in `_git_commit()` captures stdout/stderr properly. If git writes to stdout and FastMCP uses stdio transport, the output could corrupt the MCP protocol stream.
+
+```python
+# Ensure git output doesn't leak to stdout
+subprocess.run(
+    ["git", "commit", "-m", message],
+    capture_output=True,  # critical for stdio MCP servers
+    timeout=30,
+)
+```
+
+### P4: Add keep-alive / heartbeat
+Check if FastMCP has connection timeout settings. A long-running `_git_commit()` may exceed idle timeout.
+
+## Resolution (2026-03-06)
+
+Fixed in branch `chore/cleanup`. Full audit of all subprocess and I/O paths.
+
+### Fix 1: `_git_commit()` catch-all (original bug)
+- Timeout: 10s → 30s (Windows margin)
+- Added catch-all `except Exception` — git commit is best-effort, never propagates
+- **Effect:** Write tools always return a response, even if git fails
+
+### Fix 2: `_git_log()` / `_git_recent()` catch-all
+- Same pattern: only caught `TimeoutExpired`, missed `OSError` (git not in PATH)
+- Changed to catch-all `except Exception`, return empty on failure
+- **Effect:** `session_briefing` and `vault_recent` survive missing git binary
+
+### Fix 3: `httpx.ReadTimeout` in `clients.py`
+- Clients only caught `ConnectError` and `ConnectTimeout`
+- `ReadTimeout` (LLM inference too slow) was uncaught → would crash `delegate_task`
+- Added `except httpx.TimeoutException` → converted to `ConnectionError`
+- Applied to: `OllamaClient.generate`, `OpenRouterClient.generate`, `OpenRouterClient.list_models`, `OllamaClient.is_available`
+- **Effect:** Slow inference returns error message instead of crashing server
+
+### Fix 4: File I/O protection in write tools
+- `vault_update`, `vault_create`, `vault_patch`, `capture_lesson`: `read_text()`/`write_text()` had no try/except
+- Added `except OSError` → returns error message to client
+- **Effect:** Permission errors or disk-full return clean MCP error, no crash
+
+### Tests added
+- `TestGitCommitResilience`: 3 tests (OSError, RuntimeError, post-failure recovery)
+- `TestGitReadResilience`: 2 tests (session_briefing, vault_recent survive OSError)
+- `TestFileIOResilience`: 2 tests (permission errors on read/write)
+- `TestReadTimeoutResilience`: 3 tests (Ollama generate, OpenRouter generate, Ollama is_available)
+
+### Verification
+- 290 tests passed (was 265), 0 failures
+- mypy --strict clean, ruff clean
+- 90% coverage
+
+## Workaround (no longer needed)
+
+Use Claude Code's `Edit` tool to directly modify vault `.md` files. Then manually commit in the vault repo:
+
+```bash
+cd ~/Projects/knowledge && git add -A && git commit -m "vault update"
+```
+
+## Related
+
+- `_git_commit()` implementation in `server.py`
+- Security audit (2026-03-05) added `try/except CalledProcessError` to `_git_commit` — but did not cover all failure modes
+- `subprocess.run(timeout=10)` added in same audit — insufficient for Windows


### PR DESCRIPTION
## What

Migrates `hive`'s **build/operate** knowledge (ADRs, runbooks, troubleshooting, lessons) out of the maintainer's cross-project knowledge store and into this repo under `docs/` (docs-as-code).

- `docs/adr/` — 11 ADRs (ADR-001…010, 012) + `sequence-diagrams.md`
- `docs/runbooks/` — architecture audit checklist
- `docs/troubleshooting/` — 4 known-issue write-ups (anyOf deferred tools, clean-code/SOLID audit, transport-closed-after-reject, vault-patch connection crash)
- `docs/lessons.md` — accumulated gotchas / post-mortems
- `docs/README.md` — index of the subtrees

Content moved **verbatim**; only cross-references changed. `README.md` and `.claude/CLAUDE.md` re-pointed at `docs/` (also fixes two stale `docs/architecture/…` ADR links that never resolved).

## Why

Project-bound, operate-time knowledge belongs next to the code it describes — versioned with it and readable by any agent in-context, with no dependency on a private knowledge store. This is the per-repo step of the knowledge-placement model: the store keeps only the *decide/position + personal* layer; the repo owns *build/operate*.

**Directionality invariant:** the store may link out to repos; repos must never depend on the store. Cross-references were rewritten by where the target lives after migration:

- Target that **also moved here** (sibling ADRs, lessons sections, the transport troubleshooting note) → relative repo path.
- Target that **stays in the store** (cross-project patterns, the dotfiles MCP-persistence ADR, the upstream bug-report draft) or in the **forge** (HIVE-115 backlog) → plain-text provenance / HTML comment, never a live link.

Product-runtime references (hive's default `VAULT_PATH = ~/Projects/knowledge`, the `10_projects/<slug>` scope-routing layout in a lesson) are kept verbatim — they are hive's domain content, not store-provenance links.

## Scope

Move-only. No code or unrelated files changed. The knowledge store (vault) side is handled centrally by the migration orchestrator — this PR is the repo side only.

Verification: `grep -rn '\[\[' docs/` returns only a TOML `[[package]]` token inside a code span; `grep -rn '00_meta\|10_projects' docs/` matches only domain content; all relative `.md` links resolve.

## skip-sdd rationale

This is a mechanical content migration per the `KPM-001` knowledge-placement-migration master spec (`knowledge/specs/KPM-001-knowledge-placement-migration/`), not a feature change, so it does not carry a per-feature SDD. The `skip-sdd` label is a dotfiles-CI convention and may not exist in this repo; the rationale is recorded here and in the commit trailer.
