### PR TITLE
feat(tools): accept wrong param-name aliases + tighten docstrings (#151)

### DIFF
--- a/specs/HIVE-119-tool-param-aliases/features.json
+++ b/specs/HIVE-119-tool-param-aliases/features.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "HIVE-119-tool-param-aliases-f1",
+    "behavior": "vault_list(subpath=X) is accepted and behaves identically to vault_list(path=X)",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k subpath_aliases_path -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-119-tool-param-aliases-f2",
+    "behavior": "vault_patch(old_string=A, new_string=B) is accepted and applies the same replacement as find/replace",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k old_new_string -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-119-tool-param-aliases-f3",
+    "behavior": "vault_search(regex=True) is accepted and behaves identically to use_regex=True",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k regex_aliases_use_regex -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-119-tool-param-aliases-f4",
+    "behavior": "vault_query(identifier=X) is accepted and behaves identically to vault_query(path=X)",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k identifier_aliases_path -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-119-tool-param-aliases-f5",
+    "behavior": "When both canonical and alias are supplied, the canonical value wins (alias ignored)",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k path_beats_subpath -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-119-tool-param-aliases-f6",
+    "behavior": "No registered tool's JSON Schema contains anyOf (the load-bearing | None ban holds)",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k anyof -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-119-tool-param-aliases-f7",
+    "behavior": "Docstrings of the 7 affected tools name canonical params and call out the common wrong name",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k wrong_names -q",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/HIVE-119-tool-param-aliases/proposal.md
+++ b/specs/HIVE-119-tool-param-aliases/proposal.md
@@ -1,0 +1,64 @@
+---
+id: "HIVE-119-tool-param-aliases"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-05-31"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HIVE-119-tool-param-aliases
+
+> **Naming**: file lives at `<repo>/specs/HIVE-119-tool-param-aliases/proposal.md`.
+
+## Why
+
+<!-- from 11-tasks.md: — DX: clients repeatedly guess wrong MCP tool parameter names (75 `unexpected_keyword_argument` rejections; [#151](https://github.com/mlorentedev/hive/issues/151)). Hybrid fix (2026-05-30): tighten docstrings + accept real aliases only (`subpath→path`, `old_string/new_string→find/replace`, `regex→use_regex`, `identifier→path/section`); phantom params NOT added. Touches public contract → SDD-gated. Spec: `specs/HIVE-119-tool-param-aliases/`. -->
+
+Across the maintainer's live debug logs (`~/.local/share/hive/hive-*.log`) there are **75** `Invalid arguments … unexpected_keyword_argument` rejections where a client (Claude itself included) calls a hive tool with the wrong parameter name. The call fails, the agent retries with a corrected name, and from the user's seat hive *appears* flaky/slow even though the per-call path is healthy. The wrong names are not random typos — they cluster into a few highly guessable patterns (Edit-tool muscle memory, plausible synonyms, sibling-tool bleed), which makes them fixable rather than inherent. This is issue [#151](https://github.com/mlorentedev/hive/issues/151), a DX finding surfaced during the 2026-05-29 concurrency-slowness investigation.
+
+## What
+
+After this PR, the highest-frequency wrong parameter names are **accepted as aliases** that normalize to the canonical parameter before the tool body runs, and every affected tool's docstring **leads with the canonical name and explicitly calls out the common wrong name**. Concretely, all of the following stop raising `unexpected_keyword_argument` and behave identically to their canonical form:
+
+| Tool | Accepted alias | Normalizes to |
+|---|---|---|
+| `vault_list` | `subpath` | `path` |
+| `vault_patch` | `old_string` / `new_string` | `find` / `replace` |
+| `vault_search` | `regex` (bool) | `use_regex` |
+| `vault_query` | `identifier` | `path` |
+
+When both the canonical parameter and its alias are supplied, the **canonical value wins** and the alias is ignored (documented, deterministic). The JSON Schema for every tool stays `anyOf`-free — aliases are simple-typed with empty-value defaults (`str = ""`, `bool = False`), never `| None`, per [[pattern-mcp-tool-design]].
+
+## Out of scope
+
+- **Phantom params are NOT added.** Wrong guesses that map to no real parameter on the target tool — `vault_commit(project=)`, `session_briefing(days=)`, `capture_lesson(commit=)`, `vault_list(scope=)` — are addressed by docstring clarification only. Adding them as real params would lie in the schema and could *encourage* misuse.
+- No change to tool *behavior* beyond accepting the alias (same return shape, same side effects).
+- No process/transport/middleware changes — argument interception at the FastMCP boundary is explicitly rejected here (it couples to FastMCP internals); that operating-model layer is Phase C / HIVE-118.
+- No alias for `section` on `vault_query` (the `identifier` alias maps to `path` only — see Risks).
+
+## Risks / open questions
+
+- **`identifier` → `path` vs `section` ambiguity (RESOLVED).** "identifier" reads as a file identifier, so it maps to `path`. Mapping to `section` would break when the value is a real path. Decision: alias to `path` only; docstring tells callers to use `section` for shortcuts.
+- **Bool alias cannot distinguish unset from `False`.** `regex=False` is indistinguishable from "not passed". Mitigated by OR semantics: `use_regex = use_regex or regex` — the alias can only *force on*, never override an explicit canonical `True`. Acceptable because nobody passes `regex=False` meaningfully.
+- **Schema surface grows by 5 params across 4 tools.** Accepted trade-off (the chosen hybrid). Docstrings mark each as an alias so the canonical name stays preferred. No `anyOf` introduced (verified by a schema-introspection test).
+- **Regression surface.** Aliases are additive with empty defaults, so existing callers are unaffected; covered by asserting alias-call == canonical-call for each tool.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] `vault_list(project=P, subpath=X)` returns byte-identical output to `vault_list(project=P, path=X)` and raises no validation error.
+- [ ] `vault_patch(project=P, path=F, old_string=A, new_string=B)` behaves identically to `vault_patch(project=P, path=F, find=A, replace=B)`.
+- [ ] `vault_search(query=Q, regex=True)` behaves identically to `vault_search(query=Q, use_regex=True)`.
+- [ ] `vault_query(project=P, identifier=X)` behaves identically to `vault_query(project=P, path=X)`.
+- [ ] When both canonical and alias are supplied, the canonical value wins (alias ignored) — asserted for at least one tool.
+- [ ] Every affected tool's JSON Schema contains no `anyOf` (schema-introspection test over the registered tools).
+- [ ] Docstrings of `vault_list`, `vault_query`, `vault_search`, `vault_patch`, `vault_commit`, `session_briefing`, `capture_lesson` name the canonical param(s) and call out the common wrong name.
+
+## References
+
+- Vault: `10_projects/hive/11-tasks.md` (backlog entry **HIVE-119**)
+- GitHub issue: [#151](https://github.com/mlorentedev/hive/issues/151)
+- Related patterns: `00_meta/patterns/pattern-mcp-tool-design.md` (the `| None` ban / schema-clean rule)
+- Related: `.claude/CLAUDE.md` "MCP tool schema rules (load-bearing)"

--- a/specs/HIVE-119-tool-param-aliases/tasks.md
+++ b/specs/HIVE-119-tool-param-aliases/tasks.md
@@ -1,0 +1,48 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-05-31"
+---
+
+# Tasks - HIVE-119-tool-param-aliases
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [x] Branch created from main: `feat/HIVE-119-tool-param-aliases`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions" (`identifier→path`, bool-alias OR-semantics, conflict→canonical-wins all decided)
+
+## Implementation
+
+> Inline normalization at the top of each tool body (`canonical = canonical or alias`). No middleware, no FastMCP-boundary interception. Aliases are simple-typed (`str = ""`, `bool = False`) so the JSON Schema stays `anyOf`-free. New tests live in `tests/test_tool_param_aliases.py`.
+
+- [ ] Write failing test: `vault_list(project=P, subpath="sub")` == `vault_list(project=P, path="sub")`, no validation error
+- [ ] Implement `vault_list` `subpath` alias (`path = path or subpath`) in `src/hive/_vault_read.py`
+- [ ] Write failing test: `vault_patch(... old_string=A, new_string=B)` == `vault_patch(... find=A, replace=B)`
+- [ ] Implement `vault_patch` `old_string`/`new_string` aliases in `src/hive/_vault_write.py`
+- [ ] Write failing test: `vault_search(query=Q, regex=True)` == `vault_search(query=Q, use_regex=True)`
+- [ ] Implement `vault_search` `regex` alias (`use_regex = use_regex or regex`) in `src/hive/_vault_read.py`
+- [ ] Write failing test: `vault_query(project=P, identifier=X)` == `vault_query(project=P, path=X)`
+- [ ] Implement `vault_query` `identifier` alias (`path = path or identifier`) in `src/hive/_vault_read.py`
+- [ ] Write failing test: conflict — `vault_list(path="canon", subpath="alias")` resolves to `canon` (canonical wins)
+- [ ] Write failing test: schema guard — every registered tool's `inputSchema` contains no `anyOf` (introspect via FastMCP)
+- [ ] Write failing test: docstrings of the 7 affected tools name the canonical param AND mention the common wrong name
+- [ ] Tighten docstrings (`vault_list`, `vault_query`, `vault_search`, `vault_patch`, `vault_commit`, `session_briefing`, `capture_lesson`) to make it pass
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [ ] Type checks pass (`mypy --strict src/`)
+- [ ] Lint passes (`ruff check src/ tests/`)
+- [ ] Full suite green (`make test`)
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder, closes #151
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` following [[pattern-feature-list-as-primitive]]. Each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state`, `evidence`.
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state.

--- a/specs/HIVE-119-tool-param-aliases/verification.md
+++ b/specs/HIVE-119-tool-param-aliases/verification.md
@@ -1,0 +1,46 @@
+---
+tags: [spec, verification, templates]
+created: "2026-05-31"
+---
+
+# Verification - HIVE-119-tool-param-aliases
+
+## Evidence
+
+All tests live in `tests/test_tool_param_aliases.py` (7 tests, all green).
+
+- [x] `vault_list(subpath=)` == `vault_list(path=)` -> test `TestRealAliases::test_vault_list_subpath_aliases_path`
+- [x] `vault_patch(old_string=/new_string=)` == `find`/`replace` -> test `TestRealAliases::test_vault_patch_old_new_string_alias`
+- [x] `vault_search(regex=True)` == `use_regex=True` -> test `TestRealAliases::test_vault_search_regex_aliases_use_regex`
+- [x] `vault_query(identifier=)` == `vault_query(path=)` -> test `TestRealAliases::test_vault_query_identifier_aliases_path`
+- [x] Conflict — canonical wins over alias -> test `TestConflictCanonicalWins::test_vault_list_path_beats_subpath`
+- [x] No `anyOf` in any registered tool schema -> test `TestSchemaClean::test_no_tool_schema_contains_anyof`
+- [x] Docstrings call out the common wrong name (7 tools) -> test `TestDocstringsCallOutWrongNames::test_descriptions_mention_common_wrong_names`
+
+## Test status
+
+- New suite: `uv run pytest tests/test_tool_param_aliases.py -q` -> **7 passed**
+- Full suite: `make check` (ruff + mypy --strict + pytest --cov) -> **exit 0; 606 passed, 2 skipped, 62 deselected; 87% coverage; 163.94s**
+- No regressions: yes — full suite green with only the 3 source files + 1 test file changed.
+- Diff scope: 35 production LOC across `_vault_read.py`, `_vault_write.py`, `_workers.py` (no unrelated changes).
+
+## Decisions made during implementation
+
+- **Inline normalization, not a FastMCP middleware.** Validation happens at the FastMCP boundary before the handler runs, so the only schema-clean way to *accept* an alias is to add it to the signature and normalize in-body (`canonical = canonical or alias`). Middleware interception was rejected (couples to FastMCP internals; that layer is Phase C).
+- **Phantom params documented, not added.** `vault_commit(project)`, `session_briefing(days)`, `capture_lesson(commit)`, `vault_list(scope)` map to no real parameter — adding them would lie in the schema and could encourage misuse. Docstrings clarify instead.
+- **`identifier` -> `path` only** (not `section`): a value passed as `identifier` reads as a file path; mapping to `section` would break on real paths.
+- **Bool alias OR-semantics:** `use_regex = use_regex or regex` — `regex` can only force-on, never override an explicit canonical `True` (a bool default cannot distinguish unset from `False`).
+- **Docstring test asserts against `fn.__doc__`** (the full docstring SSOT) rather than `tool.description`, because FastMCP splits the docstring into a summary (`description`) plus per-parameter schema descriptions — the alias call-outs live in `Args:` and surface to the model as per-property descriptions.
+
+## Promotion candidates
+
+- [ ] Lesson for `hive/90-lessons.md`? **yes** — "FastMCP rejects unknown kwargs at the validation boundary; aliases must be real signature params normalized in-body, and the `| None` ban means alias params stay simple-typed." Worth capturing post-merge.
+- [ ] ADR-worthy decision? **no** — additive, reversible, no architectural shift.
+- [ ] New pattern for `00_meta/patterns/`? **no** — folds into the existing `pattern-mcp-tool-design`.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HIVE-119-tool-param-aliases/` -> `specs/archive/HIVE-119-tool-param-aliases/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)

--- a/src/hive/_vault_read.py
+++ b/src/hive/_vault_read.py
@@ -159,6 +159,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         project: str = "",
         path: str = "",
         pattern: str = "",
+        subpath: str = "",
     ) -> str:
         """List vault projects, or files within a project.
 
@@ -168,8 +169,12 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         Args:
             project: Project slug. Empty = list all projects.
             path: Subdirectory within the project. Empty = project root.
+                (Use `path`, not `subpath` — `subpath` is accepted as an alias.)
             pattern: Glob pattern to filter files (e.g. 'adr-*', '*.md').
+            subpath: Alias of `path` (#151). Prefer `path`. Note: there is no
+                `scope` parameter here — `scope` lives on `vault_search`.
         """
+        path = path or subpath  # #151: accept `subpath` as alias of `path`
         guard = _vault_guard(ctx)
         if guard:
             return track(ctx, "vault_list", guard)
@@ -254,6 +259,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         path: str = "",
         max_lines: int = 0,
         include_metadata: bool = False,
+        identifier: str = "",
     ) -> str:
         """Read content from a vault project — use instead of direct filesystem access.
 
@@ -261,9 +267,13 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             project: Project slug (directory under 10_projects/), or '_meta' for 00_meta/.
             section: Shortcut name (context, tasks, roadmap, lessons). Ignored if path is set.
             path: Relative path to a specific .md file within the project. Overrides section.
+                (Use `path` for a file, not `identifier` — `identifier` is accepted as an alias.)
             max_lines: Maximum lines to return. 0 = unlimited.
             include_metadata: Prepend a structured metadata line from YAML frontmatter.
+            identifier: Alias of `path` (#151). Prefer `path`; for a section
+                shortcut use `section` instead.
         """
+        path = path or identifier  # #151: accept `identifier` as alias of `path`
         guard = _vault_guard(ctx)
         if guard:
             return track(ctx, "vault_query", guard, project)
@@ -313,6 +323,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         project: str = "",
         scope: str = "",
         rank_by: str = "bm25",
+        regex: bool = False,
     ) -> str:
         """Search the vault: full-text, ranked, or recent changes.
 
@@ -327,7 +338,8 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             type_filter: Only files whose frontmatter type matches.
             status_filter: Only files whose frontmatter status matches.
             tag_filter: Only files that have this frontmatter tag.
-            use_regex: Treat query as regex. Default False.
+            use_regex: Treat query as regex. Default False. (Use `use_regex`,
+                not `regex` — `regex` is accepted as an alias.)
             ranked: Score results by relevance. Default False.
             max_results: Max files when ranked. Default 10.
             since_days: Show recent changes (0 = disabled). Default 0.
@@ -336,7 +348,11 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             rank_by: Lesson ranking ('bm25' default keeps current
                 behaviour; 'reinforcements', 'confidence', 'hybrid' filter
                 to 90-lessons.md only and rank by usage signal).
+            regex: Alias of `use_regex` (#151). Prefer `use_regex`. To narrow
+                by location use `scope` / `project`, not `path_filter` /
+                `path_prefix`.
         """
+        use_regex = use_regex or regex  # #151: accept `regex` as alias of `use_regex`
         guard = _vault_guard(ctx)
         if guard:
             return track(ctx, "vault_search", guard)
@@ -585,7 +601,9 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
 
         Args:
             project: Project slug (directory under 10_projects/). Empty =
-                list available projects so the caller can pick one.
+                list available projects so the caller can pick one. This is the
+                only parameter — there is no `days` argument (the briefing
+                window is fixed).
         """
         guard = _vault_guard(ctx)
         if guard:

--- a/src/hive/_vault_write.py
+++ b/src/hive/_vault_write.py
@@ -348,6 +348,8 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
         replace: str = "",
         patches: list[dict[str, str]] = [],  # noqa: B006
         commit: bool = True,
+        old_string: str = "",
+        new_string: str = "",
     ) -> str:
         """Surgical find-and-replace in a vault file with auto git commit.
 
@@ -366,13 +368,19 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
             project: Project slug or '_meta' for cross-project content.
             path: Relative path to the file within the project.
             find: Exact text to find (single mode). Empty = not set.
+                (Use `find`/`replace`, NOT `old_string`/`new_string` — those
+                are accepted as aliases.)
             replace: Replacement text (single mode). Empty = not set.
             patches: List of {"find", "replace"} dicts (multi mode).
             commit: If True (default), auto-commit. If False, write to disk
                 without committing — useful for batching many patches into
                 one ``vault_commit`` flush. See ``vault_write`` docstring for
                 the durability contract.
+            old_string: Alias of `find` (#151). Prefer `find`.
+            new_string: Alias of `replace` (#151). Prefer `replace`.
         """
+        find = find or old_string  # #151: accept Edit-tool param names as aliases
+        replace = replace or new_string
         guard = _vault_guard(ctx)
         if guard:
             return track(ctx, "vault_patch", guard, project)
@@ -507,6 +515,8 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
 
         Args:
             message: Commit message. Empty defaults to "vault: batch update".
+                This is the only parameter — there is no `project` argument;
+                the commit spans the whole vault working tree.
         """
         guard = _vault_guard(ctx)
         if guard:

--- a/src/hive/_workers.py
+++ b/src/hive/_workers.py
@@ -332,6 +332,9 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
             find: Keyword to look up in existing lesson headings (lookup mode).
             rank_by: Lookup ranking — 'reinforcements' (default), 'confidence',
                 or 'hybrid'. Ignored unless ``find`` is set.
+
+        Note: there is no `commit` parameter here — lesson writes always
+        auto-commit. `commit` lives on ``vault_write`` / ``vault_patch``.
         """
         guard = _vault_guard(ctx)
         if guard:

--- a/tests/test_tool_param_aliases.py
+++ b/tests/test_tool_param_aliases.py
@@ -1,0 +1,167 @@
+"""HIVE-119 — accept high-frequency wrong param names as aliases (#151).
+
+Spec: ``specs/HIVE-119-tool-param-aliases/proposal.md``.
+
+These assert that the four "real" aliases normalize to their canonical
+parameter (identical behaviour, no ``unexpected_keyword_argument``), that the
+canonical value wins on conflict, that no alias introduces an ``anyOf`` in the
+JSON Schema, and that affected docstrings call out the common wrong name.
+
+All alias-equivalence tests fail today: the alias params do not exist, so
+``call_tool`` rejects them at the FastMCP validation boundary.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from hive.server import create_server
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from fastmcp.tools import ToolResult
+
+
+def _text(result: ToolResult) -> str:
+    """Extract text from a ToolResult."""
+    return result.content[0].text  # type: ignore[union-attr]
+
+
+# ── real aliases normalize to the canonical param ────────────────────────
+
+
+class TestRealAliases:
+    async def test_vault_list_subpath_aliases_path(self, mock_vault: Path) -> None:
+        mcp = create_server(vault_path=mock_vault)
+        canonical = _text(
+            await mcp.call_tool(
+                "vault_list", {"project": "testproject", "path": "30-architecture"},
+            )
+        )
+        alias = _text(
+            await mcp.call_tool(
+                "vault_list", {"project": "testproject", "subpath": "30-architecture"},
+            )
+        )
+        assert "adr-001-test.md" in alias
+        assert alias == canonical
+
+    async def test_vault_query_identifier_aliases_path(self, mock_vault: Path) -> None:
+        mcp = create_server(vault_path=mock_vault)
+        target = "30-architecture/adr-001-test.md"
+        canonical = _text(
+            await mcp.call_tool("vault_query", {"project": "testproject", "path": target})
+        )
+        alias = _text(
+            await mcp.call_tool(
+                "vault_query", {"project": "testproject", "identifier": target},
+            )
+        )
+        assert "Test Decision" in alias
+        assert alias == canonical
+
+    async def test_vault_search_regex_aliases_use_regex(self, mock_vault: Path) -> None:
+        mcp = create_server(vault_path=mock_vault)
+        # A pattern that only matches as a regex, never as a literal substring.
+        query = r"Task\s+one"
+        canonical = _text(
+            await mcp.call_tool("vault_search", {"query": query, "use_regex": True})
+        )
+        alias = _text(
+            await mcp.call_tool("vault_search", {"query": query, "regex": True})
+        )
+        assert alias == canonical
+
+    async def test_vault_patch_old_new_string_alias(self, git_vault: Path) -> None:
+        mcp = create_server(vault_path=git_vault)
+        resp = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "old_string": "- [ ] Task one",
+                    "new_string": "- [x] Task one DONE",
+                },
+            )
+        )
+        assert "error" not in resp.lower()
+        readback = _text(
+            await mcp.call_tool(
+                "vault_query", {"project": "testproject", "path": "11-tasks.md"},
+            )
+        )
+        assert "- [x] Task one DONE" in readback
+
+
+# ── conflict resolution: canonical value wins ────────────────────────────
+
+
+class TestConflictCanonicalWins:
+    async def test_vault_list_path_beats_subpath(self, mock_vault: Path) -> None:
+        mcp = create_server(vault_path=mock_vault)
+        result = _text(
+            await mcp.call_tool(
+                "vault_list",
+                {
+                    "project": "testproject",
+                    "path": "30-architecture",
+                    "subpath": "50-troubleshooting",
+                },
+            )
+        )
+        # canonical `path` (30-architecture) won; the alias dir is not listed.
+        assert "adr-001-test.md" in result
+        assert "timeout-fix.md" not in result
+
+
+# ── schema stays anyOf-free (the load-bearing MCP rule) ──────────────────
+
+
+class TestSchemaClean:
+    @staticmethod
+    def _has_anyof(node: object) -> bool:
+        if isinstance(node, dict):
+            if "anyOf" in node:
+                return True
+            return any(TestSchemaClean._has_anyof(v) for v in node.values())
+        if isinstance(node, list):
+            return any(TestSchemaClean._has_anyof(v) for v in node)
+        return False
+
+    async def test_no_tool_schema_contains_anyof(self, mock_vault: Path) -> None:
+        mcp = create_server(vault_path=mock_vault)
+        tools = await mcp.list_tools()
+        offenders = [t.name for t in tools if self._has_anyof(t.parameters)]
+        assert offenders == [], f"anyOf leaked into tool schema(s): {offenders}"
+
+
+# ── docstrings name the canonical param and call out the wrong name ──────
+
+
+class TestDocstringsCallOutWrongNames:
+    # tool -> wrong names that MUST be mentioned in its description
+    WRONG_NAMES = {
+        "vault_list": ["subpath"],
+        "vault_query": ["identifier"],
+        "vault_search": ["regex"],
+        "vault_patch": ["old_string", "new_string"],
+        "vault_commit": ["project"],
+        "session_briefing": ["days"],
+        "capture_lesson": ["commit"],
+    }
+
+    async def test_descriptions_mention_common_wrong_names(self, mock_vault: Path) -> None:
+        # FastMCP splits the docstring into a summary (`description`) plus
+        # per-parameter schema descriptions; ``fn.__doc__`` is the full SSOT
+        # both are derived from, so we assert against it.
+        mcp = create_server(vault_path=mock_vault)
+        by_name = {t.name: t for t in await mcp.list_tools()}
+        missing: list[str] = []
+        for tool, wrong in self.WRONG_NAMES.items():
+            doc = by_name[tool].fn.__doc__ or ""
+            for token in wrong:
+                if token not in doc:
+                    missing.append(f"{tool}:{token}")
+        assert missing == [], f"docstrings missing wrong-name call-outs: {missing}"


### PR DESCRIPTION
## Summary

Clients (Claude itself included) repeatedly call hive tools with the **wrong parameter name**, producing `unexpected_keyword_argument` validation errors (**75** across live debug logs). The call fails, the agent retries — so hive *appears* flaky even though the per-call path is healthy. This is the hybrid fix for #151.

## What changed

Accept the highest-frequency **real** aliases, normalized in-body before the handler runs (`canonical = canonical or alias`):

| Tool | Alias accepted | Normalizes to |
|---|---|---|
| `vault_list` | `subpath` | `path` |
| `vault_patch` | `old_string` / `new_string` | `find` / `replace` |
| `vault_search` | `regex` (bool) | `use_regex` |
| `vault_query` | `identifier` | `path` |

- **Canonical value wins on conflict** (alias only fills when canonical is empty).
- Aliases are simple-typed with empty defaults → JSON Schema stays **`anyOf`-free** (the `| None` ban holds; guarded by a schema-introspection test).
- **Phantom params NOT added** (`vault_commit project`, `session_briefing days`, `capture_lesson commit`, `vault_list scope`) — those map to no real parameter, so they would lie in the schema. Docstrings clarify them instead.
- All 7 affected tool docstrings now name the canonical param and call out the common wrong name (surfaced to the model via per-parameter schema descriptions).

## Why not a FastMCP middleware

Validation happens at the FastMCP boundary *before* the handler runs, so the only schema-clean way to accept an alias is to add it to the signature and normalize in-body. Argument interception at the boundary couples to FastMCP internals and is deferred to the Phase C operating-model layer (HIVE-118).

## Tests

- New: `tests/test_tool_param_aliases.py` — 7 tests (4 alias-equivalence, 1 conflict, 1 schema-clean guard, 1 docstring call-out).
- `make check`: **606 passed, 2 skipped, 87% coverage**; ruff + mypy --strict clean.

## Spec

Spec-driven per `specs/HIVE-119-tool-param-aliases/` (proposal + tasks + features.json + verification). Vault-gated under backlog entry **HIVE-119**.

Closes #151.