### PR TITLE
refactor: centralize the meta scope key in a META_SCOPE constant

### DIFF
--- a/src/hive/_helpers.py
+++ b/src/hive/_helpers.py
@@ -140,6 +140,12 @@ SECTION_SHORTCUTS: dict[str, str] = {
     "lessons": "90-lessons.md",
 }
 
+# The scope KEY (not directory) that holds cross-project content. Several
+# tools special-case it: project auto-scan and health enumeration skip it,
+# and it is reached via the ``_meta`` slug shortcut. Centralised here so the
+# literal is not duplicated across the resolver / read / health modules.
+META_SCOPE = "meta"
+
 
 def _default_scopes() -> dict[str, str]:
     """Fallback scopes when a caller does not pass an explicit mapping.
@@ -153,7 +159,6 @@ def _default_scopes() -> dict[str, str]:
     from hive.config import settings
 
     return settings.vault_scopes
-
 
 _FENCED_CODE_RE = re.compile(
     r"(?ms)^(?P<fence>`{3,}|~{3,})[^\n]*\n.*?^(?P=fence)[^\n]*$",
@@ -310,13 +315,13 @@ def _resolve_project_dir(
 
     # _meta special case → meta scope root
     if project == "_meta":
-        meta_dir_name = scopes.get("meta", "00_meta")
+        meta_dir_name = scopes.get(META_SCOPE, "00_meta")
         d = vault / meta_dir_name
         if not d.is_dir():
             return None
         if _check_path_boundary(d, vault) is not None:
             return None
-        return (d, "meta")
+        return (d, META_SCOPE)
 
     explicit_scope, slug = _parse_project_ref(project)
 
@@ -329,7 +334,7 @@ def _resolve_project_dir(
 
     # Auto-scan: iterate scopes, first match wins, skip missing dirs
     for scope_name, dir_name in scopes.items():
-        if scope_name == "meta":
+        if scope_name == META_SCOPE:
             continue  # meta is not a project container
         scope_dir = vault / dir_name
         result = _search_scope(scope_dir, slug, scope_name, vault)

--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from hive._helpers import (
     _READ_ONLY,
+    META_SCOPE,
     SECTION_SHORTCUTS,
     _resolve_project_dir,
     _safe_read,
@@ -197,7 +198,7 @@ def health_report_text(ctx: ServerContext, filter_project: str = "") -> str:
     found_any = False
 
     for scope_name, dir_name in ctx.scopes.items():
-        if scope_name == "meta":
+        if scope_name == META_SCOPE:
             continue
         scope_dir = ctx.vault / dir_name
         if not scope_dir.is_dir():
@@ -237,7 +238,7 @@ def health_report_text(ctx: ServerContext, filter_project: str = "") -> str:
     # ── Duplicate name warnings ──
     dup_lines: list[str] = []
     for scope_name, dir_name in ctx.scopes.items():
-        if scope_name == "meta":
+        if scope_name == META_SCOPE:
             continue
         scope_dir = ctx.vault / dir_name
         if not scope_dir.is_dir():
@@ -365,7 +366,7 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                 project_dirs.append(resolved)
             else:
                 for scope_name, dir_name in ctx.scopes.items():
-                    if scope_name == "meta":
+                    if scope_name == META_SCOPE:
                         continue
                     scope_dir = ctx.vault / dir_name
                     if not scope_dir.is_dir():
@@ -388,7 +389,7 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                 # also get an `_meta/`-prefixed form (the slug Obsidian/Hive
                 # users type in wikilinks).
                 scope_dir_names = set(ctx.scopes.values())
-                meta_dir_name = ctx.scopes.get("meta")
+                meta_dir_name = ctx.scopes.get(META_SCOPE)
                 try:
                     md_files = list(ctx.vault.rglob("*.md"))
                 except OSError:

--- a/src/hive/_vault_read.py
+++ b/src/hive/_vault_read.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from hive._helpers import (
     _READ_ONLY,
+    META_SCOPE,
     SECTION_SHORTCUTS,
     _format_metadata,
     _git_log,
@@ -122,7 +123,7 @@ def list_projects_text(ctx: ServerContext) -> str:
     lines = ["# Vault Projects", ""]
     found_any = False
     for scope_name, dir_name in ctx.scopes.items():
-        if scope_name == "meta":
+        if scope_name == META_SCOPE:
             continue
         scope_dir = ctx.vault / dir_name
         if not scope_dir.is_dir():


### PR DESCRIPTION
## What

Replaces the hardcoded `"meta"` scope-key magic string at **5 consumer sites** with a single `META_SCOPE = "meta"` constant defined in `_helpers.py`.

## Why

The "is this the meta scope?" check was duplicated across three modules:
- `_helpers.py` — `_meta` resolution + auto-scan skip
- `_vault_read.py` — `vault_list` enumeration skip
- `_vault_health.py` — health enumeration skip (×3) + meta-dir lookup

The whole "which scope is special / not a project container" rule was encoded as scattered `== "meta"` literals. Miss one site and meta-scope handling silently breaks. Centralizing removes that footgun.

## Scope

- Consumer checks → `META_SCOPE`.
- The mapping **declarations** (`config.py` `vault_scopes` default and the `_DEFAULT_SCOPES` fallback) keep the literal as the canonical source.
- Out of scope (left as literals, different concepts): the `_meta` user-facing slug and `_vault_write.py`'s `00_meta` display string.

## Verification

Pure refactor, no behaviour change. `make check` → **599 passed, 2 skipped**, lint + typecheck clean.

Follow-up from the debt audit on #154.