### PR TITLE
fix: harden scope configuration against misconfiguration

### DIFF
--- a/site/src/content/docs/configuration.mdx
+++ b/site/src/content/docs/configuration.mdx
@@ -62,7 +62,7 @@ When a tool call is cancelled mid-flight (slow worker, client timeout), the serv
 | `HIVE_RELEVANCE_ALPHA` | `0.3` | EMA learning rate for adaptive context scoring |
 | `HIVE_RELEVANCE_DECAY` | `0.9` | Session decay factor for relevance scores |
 | `HIVE_RELEVANCE_EPSILON` | `0.15` | Exploration ratio for session_briefing (epsilon-greedy) |
-| `HIVE_VAULT_SCOPES` | `{"projects": "10_projects", "meta": "00_meta", "work": "50_work", "agents": "80_agents"}` | JSON mapping of scope names to vault subdirectories. Scopes support hierarchical resolution (BFS). The `agents` scope holds AI-agent inboxes; auto-scan tries scopes in insertion order, so `agents` is listed last to avoid shadowing existing project names. |
+| `HIVE_VAULT_SCOPES` | `{"projects": "10_projects", "meta": "00_meta", "work": "50_work", "agents": "80_agents"}` | JSON mapping of scope names to vault subdirectories. Scopes support hierarchical resolution (BFS). The `agents` scope holds AI-agent inboxes; auto-scan tries scopes in insertion order, so `agents` is listed last to avoid shadowing existing project names. Each directory must be a unique relative path inside the vault — duplicate, absolute, or escaping (`..`) values are rejected at startup. |
 | `HIVE_LOG_PATH` | `~/.local/share/hive/hive.log` | File path for persistent debug log (1MB rotating) |
 | `HIVE_LOG_LEVEL` | `INFO` | Log level for the persistent log file. Captures `hive`, `fastmcp` and `mcp` loggers. Set to `DEBUG` for transport-level diagnostics, `WARNING` to suppress lifecycle events. |
 

--- a/site/src/content/docs/es/configuration.mdx
+++ b/site/src/content/docs/es/configuration.mdx
@@ -62,7 +62,7 @@ Cuando una llamada a una herramienta se cancela a mitad de ejecución (worker le
 | `HIVE_RELEVANCE_ALPHA` | `0.3` | Tasa de aprendizaje EMA para puntuación adaptativa |
 | `HIVE_RELEVANCE_DECAY` | `0.9` | Factor de decaimiento por sesión para puntuaciones de relevancia |
 | `HIVE_RELEVANCE_EPSILON` | `0.15` | Ratio de exploración para session_briefing (epsilon-greedy) |
-| `HIVE_VAULT_SCOPES` | `{"projects": "10_projects", "meta": "00_meta", "work": "50_work", "agents": "80_agents"}` | Mapeo JSON de nombres de scope a subdirectorios del vault. Los scopes soportan resolución jerárquica (BFS). El scope `agents` contiene buzones de agentes de IA; el auto-scan prueba los scopes en orden de inserción, por lo que `agents` va al final para no eclipsar nombres de proyectos existentes. |
+| `HIVE_VAULT_SCOPES` | `{"projects": "10_projects", "meta": "00_meta", "work": "50_work", "agents": "80_agents"}` | Mapeo JSON de nombres de scope a subdirectorios del vault. Los scopes soportan resolución jerárquica (BFS). El scope `agents` contiene buzones de agentes de IA; el auto-scan prueba los scopes en orden de inserción, por lo que `agents` va al final para no eclipsar nombres de proyectos existentes. Cada directorio debe ser una ruta relativa única dentro del vault — los valores duplicados, absolutos o que escapan (`..`) se rechazan al iniciar. |
 | `HIVE_LOG_PATH` | `~/.local/share/hive/hive.log` | Ruta del log persistente de depuración (rotación 1MB) |
 | `HIVE_LOG_LEVEL` | `INFO` | Nivel del log persistente. Captura los loggers `hive`, `fastmcp` y `mcp`. `DEBUG` para diagnóstico a nivel de transporte; `WARNING` para silenciar eventos de ciclo de vida. |
 

--- a/src/hive/_helpers.py
+++ b/src/hive/_helpers.py
@@ -296,7 +296,7 @@ def _parse_project_ref(project: str) -> tuple[str | None, str]:
 
 
 def _resolve_project_dir(
-    vault: Path, project: str, scopes: dict[str, str] | None = None,
+    vault: Path, project: str, scopes: dict[str, str],
 ) -> tuple[Path, str] | None:
     """Resolve a project slug to (directory, scope_name).
 
@@ -309,10 +309,13 @@ def _resolve_project_dir(
     depth.  Slugs containing ``/`` are resolved as literal relative paths
     within the scope directory (no BFS).
 
+    ``scopes`` is required: every production caller passes ``ctx.scopes``
+    and the single default is resolved once at the ``create_server()``
+    boundary, so there is no internal fallback to drift untested (#159).
+    Tests that want the shipped default pass ``_default_scopes()``.
+
     Returns None if the project is not found or escapes the vault boundary.
     """
-    scopes = scopes or _default_scopes()
-
     # _meta special case → meta scope root
     if project == "_meta":
         meta_dir_name = scopes.get(META_SCOPE, "00_meta")
@@ -402,7 +405,7 @@ def _resolve_file(
     project: str,
     section: str,
     path: str,
-    scopes: dict[str, str] | None = None,
+    scopes: dict[str, str],
 ) -> Path | str:
     """Resolve a vault file from project + section/path. Returns Path or error string."""
     result = _resolve_project_dir(vault, project, scopes)

--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -371,6 +371,12 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                     scope_dir = ctx.vault / dir_name
                     if not scope_dir.is_dir():
                         continue
+                    # Only directories are projects. Files directly under a
+                    # scope root (e.g. an ``80_agents/_index.md`` landing page)
+                    # are intentionally skipped — the ``_index.md`` convention
+                    # is optional, so health does not enumerate or validate it
+                    # (decision: #159 item 3; enforcing it would false-flag
+                    # vaults that don't use the convention).
                     for d in sorted(scope_dir.iterdir()):
                         if d.is_dir():
                             project_dirs.append((d, scope_name))

--- a/src/hive/config.py
+++ b/src/hive/config.py
@@ -1,9 +1,14 @@
 """Hive configuration — pydantic-settings with env var overrides."""
 
+import re
 from pathlib import Path
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# A leading drive letter (``C:``) marks a Windows absolute path; checked
+# explicitly because ``str.startswith`` only catches the separator forms.
+_DRIVE_RE = re.compile(r"^[A-Za-z]:")
 
 
 class HiveSettings(BaseSettings):
@@ -59,6 +64,36 @@ class HiveSettings(BaseSettings):
     # thread to escape ``_filelock_with_telemetry``'s ``__exit__`` naturally
     # on the happy path. Default 5.0s matches HIVE_OUTBOX_TICK_S for symmetry.
     post_kill_drain_s: float = Field(default=5.0, ge=0.5, le=30.0)
+
+    @field_validator("vault_scopes")
+    @classmethod
+    def _validate_vault_scopes(cls, value: dict[str, str]) -> dict[str, str]:
+        """Reject scope mappings that would misbehave at runtime (#159).
+
+        A clear startup error beats undefined behaviour later:
+
+        - Two scopes sharing a directory — auto-scan is first-match, so the
+          second key would be silently unreachable.
+        - A directory that is absolute or climbs out of the vault root — a
+          scope dir must be a relative path *inside* the vault. The per-call
+          path-boundary check would catch this lazily; this fails loudly once.
+        """
+        dirs = list(value.values())
+        duplicates = sorted({d for d in dirs if dirs.count(d) > 1})
+        if duplicates:
+            raise ValueError(
+                "vault_scopes maps multiple scopes to the same directory: "
+                f"{duplicates}",
+            )
+        for key, raw in value.items():
+            is_absolute = raw.startswith(("/", "\\")) or bool(_DRIVE_RE.match(raw))
+            segments = re.split(r"[\\/]", raw)
+            if not raw.strip() or is_absolute or ".." in segments:
+                raise ValueError(
+                    f"vault_scopes[{key!r}] must be a relative path inside the "
+                    f"vault, got {raw!r}",
+                )
+        return value
 
 
 settings = HiveSettings()

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -21,6 +21,7 @@ from hive._context import ServerContext  # noqa: E402
 from hive._diagnostics import LifecycleMiddleware  # noqa: E402
 from hive._helpers import (  # noqa: E402
     _clean_stale_wal_files,
+    _default_scopes,
     _resolve_file,
     _safe_read,
     _truncate,
@@ -52,7 +53,10 @@ def create_server(
 ) -> FastMCP:
     """Create and configure the Hive MCP server."""
     resolved_path = vault_path or settings.vault_path
-    scopes = vault_scopes or settings.vault_scopes
+    # The single boundary where the default scope mapping is applied (#159):
+    # _resolve_project_dir requires an explicit scopes arg, so no other code
+    # path carries an internal default that could drift untested.
+    scopes = vault_scopes or _default_scopes()
     tracker = usage_tracker or UsageTracker()
     budget = budget_tracker or BudgetTracker(db_path=settings.db_path)
     ollama = ollama_client or OllamaClient(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -172,6 +172,71 @@ class TestVaultScopes:
         }
 
 
+class TestVaultScopesValidation:
+    """Startup validation of HIVE_VAULT_SCOPES (#159 item 2).
+
+    A clear ValidationError at construction beats undefined behaviour later:
+    two scopes sharing a directory makes the second silently unreachable
+    (auto-scan is first-match), and a directory that escapes the vault root
+    is a foot-gun the path-boundary check would only catch lazily, per call.
+    """
+
+    def test_accepts_valid_custom_mapping(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(
+            "HIVE_VAULT_SCOPES",
+            '{"projects": "10_projects", "nested": "50_work/clients"}',
+        )
+        assert HiveSettings().vault_scopes == {
+            "projects": "10_projects",
+            "nested": "50_work/clients",
+        }
+
+    def test_accepts_empty_mapping(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty mapping (flat vault, no scope routing) is allowed."""
+        monkeypatch.setenv("HIVE_VAULT_SCOPES", "{}")
+        assert HiveSettings().vault_scopes == {}
+
+    def test_rejects_duplicate_directories(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Two scope keys pointing at one directory shadows the second."""
+        monkeypatch.setenv(
+            "HIVE_VAULT_SCOPES",
+            '{"projects": "10_projects", "alias": "10_projects"}',
+        )
+        with pytest.raises(ValidationError, match="same directory"):
+            HiveSettings()
+
+    @pytest.mark.parametrize(
+        "bad_dir",
+        ["../escape", "10_projects/../../etc", "sub/../../out"],
+    )
+    def test_rejects_parent_traversal(
+        self, monkeypatch: pytest.MonkeyPatch, bad_dir: str,
+    ) -> None:
+        monkeypatch.setenv("HIVE_VAULT_SCOPES", f'{{"x": "{bad_dir}"}}')
+        with pytest.raises(ValidationError, match="relative path inside"):
+            HiveSettings()
+
+    @pytest.mark.parametrize("bad_dir", ["/etc", "\\\\windows", "C:/data"])
+    def test_rejects_absolute_directories(
+        self, monkeypatch: pytest.MonkeyPatch, bad_dir: str,
+    ) -> None:
+        monkeypatch.setenv("HIVE_VAULT_SCOPES", f'{{"x": "{bad_dir}"}}')
+        with pytest.raises(ValidationError, match="relative path inside"):
+            HiveSettings()
+
+    @pytest.mark.parametrize("bad_dir", ["", "   "])
+    def test_rejects_blank_directories(
+        self, monkeypatch: pytest.MonkeyPatch, bad_dir: str,
+    ) -> None:
+        monkeypatch.setenv("HIVE_VAULT_SCOPES", f'{{"x": "{bad_dir}"}}')
+        with pytest.raises(ValidationError, match="relative path inside"):
+            HiveSettings()
+
+
 class TestLogPath:
     def test_log_path_default(self) -> None:
         expected = str(Path.home() / ".local" / "share" / "hive" / "hive.log")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from hive._helpers import (
+    _default_scopes,
     _git_commit,
     _match_and_replace,
     _resolve_project_dir,
@@ -171,14 +172,16 @@ class TestResolveProjectDir:
 
     def test_flat_scope_resolves(self, mock_vault: Path) -> None:
         """Standard flat scope: 10_projects/testproject resolves."""
-        result = _resolve_project_dir(mock_vault, "testproject")
+        result = _resolve_project_dir(mock_vault, "testproject", _default_scopes())
         assert result is not None
         assert result[0] == mock_vault / "10_projects" / "testproject"
         assert result[1] == "projects"
 
     def test_explicit_scope_flat(self, mock_vault: Path) -> None:
         """Explicit scope:slug resolves for flat scopes."""
-        result = _resolve_project_dir(mock_vault, "projects:testproject")
+        result = _resolve_project_dir(
+            mock_vault, "projects:testproject", _default_scopes(),
+        )
         assert result is not None
         assert result[0] == mock_vault / "10_projects" / "testproject"
 
@@ -261,15 +264,25 @@ class TestResolveProjectDir:
         assert result[0] == tmp_path / "80_agents" / "Hermes-NaN"
         assert result[1] == "agents"
 
-    def test_agents_in_lazy_default_scopes(self, tmp_path: Path) -> None:
-        """With no explicit scopes, the resolver reads settings.vault_scopes
-        (the SSOT) — which now includes the agents scope. Proves the lazy
-        ``_default_scopes()`` reads the live default, not a stale literal."""
+    def test_agents_in_default_scopes(self, tmp_path: Path) -> None:
+        """``_default_scopes()`` reads settings.vault_scopes (the SSOT) — which
+        includes the agents scope — lazily, not from a stale literal. Callers
+        pass it explicitly now that the resolver requires a scopes mapping."""
+        assert "agents" in _default_scopes()
         (tmp_path / "80_agents" / "Hermes-NaN").mkdir(parents=True)
-        result = _resolve_project_dir(tmp_path, "agents:Hermes-NaN")
+        result = _resolve_project_dir(
+            tmp_path, "agents:Hermes-NaN", _default_scopes(),
+        )
         assert result is not None
         assert result[0] == tmp_path / "80_agents" / "Hermes-NaN"
         assert result[1] == "agents"
+
+    def test_scopes_argument_is_required(self, tmp_path: Path) -> None:
+        """The scopes mapping is a required argument — there is no internal
+        default fallback to drift untested (#159 item 1). The single default
+        lives at the create_server() boundary."""
+        with pytest.raises(TypeError):
+            _resolve_project_dir(tmp_path, "anything")  # type: ignore[call-arg]
 
     def test_agents_appended_last_does_not_shadow(self, tmp_path: Path) -> None:
         """A name present in BOTH projects and agents resolves to projects:
@@ -277,7 +290,7 @@ class TestResolveProjectDir:
         behaviour (req #6, no regression)."""
         (tmp_path / "10_projects" / "shared").mkdir(parents=True)
         (tmp_path / "80_agents" / "shared").mkdir(parents=True)
-        result = _resolve_project_dir(tmp_path, "shared")  # lazy default scopes
+        result = _resolve_project_dir(tmp_path, "shared", _default_scopes())
         assert result is not None
         assert result[1] == "projects"
 
@@ -294,7 +307,7 @@ class TestResolveProjectDir:
 
     def test_meta_unchanged(self, mock_vault: Path) -> None:
         """_meta still resolves to 00_meta scope root."""
-        result = _resolve_project_dir(mock_vault, "_meta")
+        result = _resolve_project_dir(mock_vault, "_meta", _default_scopes())
         assert result is not None
         assert result[0] == mock_vault / "00_meta"
         assert result[1] == "meta"


### PR DESCRIPTION
Closes #159 — the three robustness items from the #154 scope-config debt audit.

## 1. `scopes` is a required argument

`_resolve_project_dir` / `_resolve_file` carried `scopes: dict | None = None` with an internal `scopes or _default_scopes()` fallback. Every production caller already passes `ctx.scopes`, so that branch was **prod-unreachable** and could drift untested. It is now a required parameter; the single default is applied once at the `create_server()` boundary (`vault_scopes or _default_scopes()`). mypy `--strict` enforces the contract at every call site.

## 2. `HIVE_VAULT_SCOPES` is validated at startup

A pydantic `field_validator` now rejects, with a clear `ValidationError`:
- **Duplicate directories** — two scope keys → one dir; under first-match auto-scan the second would be silently unreachable.
- **Absolute / escaping directories** — a scope dir must be a relative path *inside* the vault (`/etc`, `C:/data`, `../escape` all rejected). Cross-platform: catches POSIX `/`, Windows `\`, and drive-letter forms.

An empty mapping (flat vault, no scope routing) stays valid. The per-call path-boundary check is unchanged — this just fails loudly once at startup instead of lazily per call.

## 3. Scope-root `_index.md` — documented decision

`vault_health` enumerates only directories as projects, so a file directly under a scope root (e.g. an optional `80_agents/_index.md` landing page) is skipped. **Decision: intentional.** The `_index.md` convention is optional; enforcing it would false-flag vaults that don't use it. Documented inline at the enumeration site so a future reader doesn't "fix" it. (If a check is wanted later, validate-if-present is the non-noisy option — left as a follow-up.)

## Tests

- New `TestVaultScopesValidation` (8 cases: duplicates, parent-traversal, absolute, blank, valid custom, empty).
- `_resolve_project_dir` callers in `test_helpers.py` pass `_default_scopes()` explicitly; new `test_scopes_argument_is_required` pins the contract.
- Full suite: **630 passed, 2 skipped** (86% coverage). `ruff` + `mypy --strict src/` clean.
- Docs: validation note added to `HIVE_VAULT_SCOPES` (EN + ES).