### PR TITLE
feat: add `hive serve` daemon entrypoint (HIVE-118)

### DIFF
--- a/src/hive/_daemon.py
+++ b/src/hive/_daemon.py
@@ -1,0 +1,96 @@
+"""``hive serve`` — the Phase C single-owner daemon (ADR-011).
+
+One long-lived process owns the vault git working tree and all SQLite trackers
+and serves thin clients over loopback Streamable-HTTP gated by a per-daemon
+bearer token. The transport + owner-only token model is the one validated
+cross-OS by ``specs/HIVE-118-phase-c-daemon-model/spike/transport_spike.py``.
+
+This first slice provides the entrypoint: write an owner-only token + port
+state file, then run ``create_server()`` over HTTP with a token verifier. The
+resilience/observability pillar (ADR-011 §4) lands in later slices.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import socket
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from hive.config import settings
+
+if TYPE_CHECKING:
+    from fastmcp.server.auth import AuthProvider
+
+DEFAULT_HOST = "127.0.0.1"
+MCP_PATH = "/mcp"
+TOKEN_FILENAME = "daemon.token"
+PORT_FILENAME = "daemon.port"
+
+
+def daemon_state_dir() -> Path:
+    """Directory holding the token + port state files (beside the SQLite DBs)."""
+    return Path(settings.db_path).parent
+
+
+def token_file_path() -> Path:
+    return daemon_state_dir() / TOKEN_FILENAME
+
+
+def port_file_path() -> Path:
+    return daemon_state_dir() / PORT_FILENAME
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((DEFAULT_HOST, 0))
+        return int(s.getsockname()[1])
+
+
+def write_owner_only(path: Path, content: str) -> None:
+    """Write *content* to *path* so only the current user can read it.
+
+    POSIX: mode ``0600``. Windows: strip inherited ACEs and grant the current
+    user only via ``icacls`` (a bare ``chmod`` cannot express an owner-only ACL
+    on NTFS). Both forms are validated by the transport spike on each OS.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    if os.name == "nt":
+        user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+        subprocess.run(  # noqa: S603,S607 — fixed args, owner derived from env
+            ["icacls", str(path), "/inheritance:r", "/grant:r", f"{user}:(F)"],
+            check=False, capture_output=True, text=True,
+        )
+    else:
+        path.chmod(0o600)
+
+
+def _token_verifier(token: str) -> AuthProvider:
+    """A static bearer-token verifier admitting exactly *token* (ADR-011 §2)."""
+    from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+    return StaticTokenVerifier({token: {"client_id": "hive-daemon", "scopes": []}})
+
+
+def run_serve(host: str = DEFAULT_HOST, port: int = 0) -> None:
+    """Run hive as a single-owner daemon over loopback Streamable-HTTP + token.
+
+    Generates a per-daemon token, publishes it (owner-only) and the chosen port
+    to the state dir, then serves the real ``create_server()`` instance. A
+    ``port`` of 0 picks a free loopback port.
+    """
+    from hive.server import create_server
+
+    resolved_port = port or _free_port()
+    token = secrets.token_urlsafe(32)
+    write_owner_only(token_file_path(), token)
+    write_owner_only(port_file_path(), str(resolved_port))
+
+    server = create_server(auth=_token_verifier(token))
+    server.run(
+        transport="http", host=host, port=resolved_port,
+        path=MCP_PATH, show_banner=False,
+    )

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import logging.handlers
+import sys
 import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -16,6 +17,8 @@ from fastmcp import FastMCP  # noqa: E402
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from fastmcp.server.auth import AuthProvider
 
 from hive._context import ServerContext  # noqa: E402
 from hive._diagnostics import LifecycleMiddleware  # noqa: E402
@@ -50,8 +53,14 @@ def create_server(
     relevance_tracker: RelevanceTracker | None = None,
     lesson_tracker: LessonReinforcementTracker | None = None,
     lock_eviction_tracker: LockEvictionTracker | None = None,
+    auth: AuthProvider | None = None,
 ) -> FastMCP:
-    """Create and configure the Hive MCP server."""
+    """Create and configure the Hive MCP server.
+
+    ``auth`` gates the transport: ``None`` (stdio default) leaves the server
+    open as today; the ``hive serve`` daemon passes a bearer-token verifier so
+    the loopback HTTP port is owner-gated (ADR-011 §2).
+    """
     resolved_path = vault_path or settings.vault_path
     # The single boundary where the default scope mapping is applied (#159):
     # _resolve_project_dir requires an explicit scopes arg, so no other code
@@ -115,6 +124,7 @@ def create_server(
 
     mcp = FastMCP(
         "Hive",
+        auth=auth,
         middleware=[LifecycleMiddleware()],
         instructions=(
             "Hive provides on-demand access to an Obsidian vault.\n\n"
@@ -472,20 +482,35 @@ def _setup_file_logging() -> None:
         logger.setLevel(level)
 
 
+def _run_serve(argv: list[str]) -> None:
+    """``hive serve`` — run the Phase C single-owner daemon (ADR-011)."""
+    import argparse
+
+    from hive._daemon import DEFAULT_HOST, run_serve
+
+    parser = argparse.ArgumentParser(prog="hive serve")
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=0, help="0 = pick a free port")
+    opts = parser.parse_args(argv)
+    run_serve(host=opts.host, port=opts.port)
+
+
 def main() -> None:
     """Entry point for the hive CLI command.
 
-    ``create_server()`` is called here rather than at module import
-    so importing ``hive.server`` (e.g. from tests, from typing tools,
-    or from a future ``hive serve --http`` entry point) is side-effect
-    free. The previous import-time instantiation cost every ``uvx
-    hive-vault`` spawn ~300-600 ms before main() even ran.
+    Bare ``hive`` runs the stdio MCP server (the v1 per-session contract).
+    ``hive serve`` runs the Phase C single-owner daemon over loopback HTTP +
+    bearer token (ADR-011). ``create_server()`` is called here rather than at
+    module import so importing ``hive.server`` is side-effect free.
     """
     _setup_file_logging()
     _log = logging.getLogger("hive")
-    server = create_server()
+    argv = sys.argv[1:]
     try:
-        server.run()
+        if argv and argv[0] == "serve":
+            _run_serve(argv[1:])
+        else:
+            create_server().run()
     except BaseException as exc:
         _log.critical("hive server exiting: %r", exc, exc_info=True)
         raise

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,119 @@
+"""Integration tests for the `hive serve` daemon (HIVE-118 / ADR-011).
+
+Black-box: spawns the real daemon over the token-gated loopback Streamable-HTTP
+transport (the path validated by `specs/.../spike/transport_spike.py`) and
+drives it with a thin `fastmcp.Client` — the production analogue of the spike.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import stat
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+HOST = "127.0.0.1"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((HOST, 0))
+        return int(s.getsockname()[1])
+
+
+def _wait_ready(port: int, deadline_s: float = 20.0) -> bool:
+    end = time.monotonic() + deadline_s
+    while time.monotonic() < end:
+        try:
+            with socket.create_connection((HOST, port), timeout=0.5):
+                return True
+        except OSError:
+            time.sleep(0.1)
+    return False
+
+
+async def _list_tools(url: str, token: str) -> list[str]:
+    from fastmcp import Client
+    from fastmcp.client.transports import StreamableHttpTransport
+
+    transport = StreamableHttpTransport(
+        url, headers={"Authorization": f"Bearer {token}"},
+    )
+    async with Client(transport) as client:
+        return [t.name for t in await client.list_tools()]
+
+
+@pytest.fixture
+def daemon_env(tmp_path: Path) -> tuple[dict[str, str], Path]:
+    """Env pointing every DB + the vault + daemon state dir at a temp dir."""
+    vault = tmp_path / "vault"
+    (vault / "10_projects").mkdir(parents=True)
+    env = {
+        **os.environ,
+        "HIVE_DB_PATH": str(tmp_path / "worker.db"),
+        "HIVE_RELEVANCE_DB_PATH": str(tmp_path / "relevance.db"),
+        "HIVE_LESSON_DB_PATH": str(tmp_path / "lesson.db"),
+        "HIVE_LOG_PATH": str(tmp_path / "hive.log"),
+        "VAULT_PATH": str(vault),
+    }
+    return env, tmp_path
+
+
+def _spawn_daemon(env: dict[str, str], port: int) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        [sys.executable, "-m", "hive.server", "serve", "--port", str(port)],
+        env=env,
+    )
+
+
+def test_hive_serve_answers_tools_list(daemon_env: tuple[dict[str, str], Path]) -> None:
+    """The daemon binds loopback, writes an owner-only token, and a
+    token-authenticated client gets the full hive tool list."""
+    env, state_dir = daemon_env
+    port = _free_port()
+    proc = _spawn_daemon(env, port)
+    try:
+        assert _wait_ready(port), "daemon did not bind its loopback port"
+        token = (state_dir / "daemon.token").read_text(encoding="utf-8").strip()
+        assert token, "daemon did not write a token"
+
+        tools = asyncio.run(_list_tools(f"http://{HOST}:{port}/mcp", token))
+        assert "vault_query" in tools
+        assert "session_briefing" in tools
+
+        if os.name != "nt":
+            mode = stat.S_IMODE((state_dir / "daemon.token").stat().st_mode)
+            assert mode == 0o600, f"token file not owner-only: {oct(mode)}"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_hive_serve_rejects_bad_token(daemon_env: tuple[dict[str, str], Path]) -> None:
+    """A request without the matching token is refused — the bare loopback
+    port is not open."""
+    env, _ = daemon_env
+    port = _free_port()
+    proc = _spawn_daemon(env, port)
+    try:
+        assert _wait_ready(port)
+        with pytest.raises(Exception):  # noqa: B017, PT011 — any auth refusal
+            asyncio.run(_list_tools(f"http://{HOST}:{port}/mcp", "not-the-token"))
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
First implementation slice of the Phase C single-owner daemon ([ADR-011](https://github.com/mlorentedev/hive/blob/master/docs/adr/adr-011-phase-c-daemon-model.md)). Built on the transport validated cross-OS by the [HIVE-118 spikes](https://github.com/mlorentedev/hive/tree/master/specs/HIVE-118-phase-c-daemon-model/spike) (transport 5/5, load 4/4, idempotency 3/3, resilience 4/4, robustness 3/3 on Linux **and** Windows).

## What

`hive serve` runs the **real** `create_server()` over loopback Streamable-HTTP, gated by a per-daemon bearer token. Bare `hive` is unchanged (stdio v1 contract).

- `create_server(auth=...)` — optional `AuthProvider`; `None` (stdio default) leaves the server open as today, the daemon passes a token verifier.
- `src/hive/_daemon.py` — `run_serve()` writes an **owner-only** token + port state file (POSIX `0600` / Windows `icacls` ACL, the model the transport spike validated on each OS) then serves over HTTP.
- `main()` routes `hive serve [--host --port]` to the daemon; default path stays stdio.

## Test

`tests/test_daemon.py` (black-box, the production analogue of `transport_spike.py`):
- the daemon binds its loopback port, a token-authenticated client gets the full tool list (`vault_query`, `session_briefing`, …);
- a request with a wrong token is refused;
- the token file is owner-only (`0600` on POSIX).

Full suite: **639 passed, 2 skipped** (85% cov). `ruff` + `mypy --strict` clean.

## Scope

This is slice 1 of the frozen `tasks.md` TDD sequence. Not yet the complete daemon — subsequent PRs add the thin stdio shim, multi-client, observability (`/status` + metrics core), resilience (supervised restart, fallback, restart-on-upgrade), post-mortem, and three-plane telemetry. The five spikes are the executable spec these slices port into `tests/`.