### PR TITLE
feat: add `hive client` stdio shim that proxies to the daemon (HIVE-118)

### DIFF
--- a/specs/HIVE-118-phase-c-daemon-model/features.json
+++ b/specs/HIVE-118-phase-c-daemon-model/features.json
@@ -24,9 +24,9 @@
       "id": "transparent-fallback",
       "ac": "Transparent fallback",
       "behavior": "With no daemon running, a client call still succeeds via in-process stdio and the response/health flags degraded (non-daemon) mode.",
-      "verification": "pytest tests/test_daemon_fallback.py -k no_daemon",
+      "verification": "uv run pytest tests/test_daemon.py -k client_falls_back",
       "state": "planned",
-      "evidence": null
+      "evidence": "Implemented in slice 2 (src/hive/_client.py: `hive client` shim falls back to in-process create_server() when no live daemon is reachable). Tests green locally via `make check` (exit 0): test_client_falls_back_without_daemon (no state files) + test_client_falls_back_on_stale_state (dead port behind stale state). Degraded mode surfaced via the `hive.client.mode=fallback reason={no_daemon_state,daemon_unreachable}` startup log. Awaiting harness pass-state."
     },
     {
       "id": "transport-cross-os",

--- a/specs/HIVE-118-phase-c-daemon-model/tasks.md
+++ b/specs/HIVE-118-phase-c-daemon-model/tasks.md
@@ -23,15 +23,17 @@ created: "2026-05-29"
 - [x] **Spike (transport):** loopback Streamable-HTTP + bearer-token round-trip. **Linux + Windows: DONE** (`spike/transport_spike.py`, 5/5 both — round-trip, missing/wrong-token 401, owner-only token file via `0600`/`icacls`). Closed ADR-011's transport residual.
 - [x] **Spike (load/concurrency):** N parallel sessions → one daemon owning a shared SQLite. **Linux + Windows: DONE** (`spike/load_spike.py`, 4/4 both — zero failures, no lost writes, no head-of-line blocking). Pre-validated the single-owner concurrency model (ADR-011 §1).
 - [x] **Spike (idempotency / resilience / robustness):** **Linux + Windows: DONE** — `idempotency_spike.py` 3/3 (§6.2 at-most-once incl. concurrent dupes → one row), `resilience_spike.py` 4/4 (§4 — state durable + `integrity_check=ok` after `SIGKILL`/`TerminateProcess`, reconnect, disconnect survival), `robustness_spike.py` 3/3 (1 MB payload, auth unbypassable, port-in-use exits cleanly). De-risked §6.2 + §4 + transport edges before building.
-- [ ] Write failing test: daemon starts, owns the SQLite DBs, answers a `tools/list`
-- [ ] Implement `hive serve` daemon entrypoint (long-lived; single owner of `ServerContext`)
-- [ ] Write failing test: thin client connects over transport and round-trips one `vault_query`
-- [ ] Implement client/stdio-shim that forwards MCP over the transport
+- [x] Write failing test: daemon starts, owns the SQLite DBs, answers a `tools/list` — **#164** (`tests/test_daemon.py::test_hive_serve_answers_tools_list`)
+- [x] Implement `hive serve` daemon entrypoint (long-lived; single owner of `ServerContext`) — **#164** (`src/hive/_daemon.py`)
+- [x] Write failing test: thin client connects over transport and round-trips one `vault_query` — slice 2 (`test_client_forwards_to_daemon`)
+- [x] Implement client/stdio-shim that forwards MCP over the transport — slice 2 (`src/hive/_client.py`: `hive client` → `create_proxy` over token-gated HTTP)
 - [ ] Write failing test: 2 concurrent clients, single daemon process owns DBs+git (multi-client integration)
 - [ ] Write failing test: cross-session aggregated metrics survive a client disconnect
 - [ ] Implement cross-session observability surface (`hive status` / `/status` / extended `worker_status`) over an internal metrics core
-- [ ] Write failing test: no daemon -> client falls back to in-process stdio, response flags degraded mode
-- [ ] Implement transparent fallback path + client auto-reconnect when daemon returns
+- [x] Write failing test: no daemon -> client falls back to in-process stdio, response flags degraded mode — **pulled forward into slice 2** (`test_client_falls_back_without_daemon` + `test_client_falls_back_on_stale_state`); degraded mode surfaced via the `hive.client.mode=fallback reason=...` startup log, not an MCP-visible flag (the rich surface is the observability slice above)
+- [~] Implement transparent fallback path **[done — slice 2]** + client auto-reconnect when daemon returns **[deferred — resilience slice]**: the shim picks its mode once at startup (TCP liveness probe of the published port); mid-session reconnect when a dead daemon returns lands with the supervised-restart work below
+
+> **Reorder note (2026-05-31, slice 2):** the fallback test + transparent-fallback path were pulled ahead of the multi-client / observability steps. Reason: a forwarding-only shim wired into `~/.claude.json` would break every session whenever the daemon is down, so fallback is a safety prerequisite for shipping the shim at all, not a later refinement. Auto-reconnect (mid-session daemon recovery) stays deferred to the resilience slice.
 - [ ] **Resilience:** structured single-daemon logging with `correlation_id` + `session_id` (replace per-PID logs)
 - [ ] **Resilience:** liveness + readiness probes
 - [ ] **DR:** write failing test — `SIGKILL` under load -> supervisor restart, durable state (SQLite+git) intact, clients reconnect/fallback

--- a/src/hive/_client.py
+++ b/src/hive/_client.py
@@ -1,0 +1,112 @@
+"""``hive client`` — the thin stdio shim Claude Code spawns (HIVE-118 / ADR-011).
+
+Claude Code keeps its v1 stdio MCP contract (``~/.claude.json`` unchanged): it
+spawns this shim over stdio exactly as it spawns ``hive`` today. The shim then
+chooses a backend at startup:
+
+* **daemon mode** — a single-owner ``hive serve`` daemon is reachable on its
+  published loopback port. The shim becomes a transparent FastMCP *proxy* that
+  forwards every request to the daemon over the token-gated Streamable-HTTP
+  transport (ADR-011 §2). One daemon owns SQLite + git; N shims proxy into it.
+  The shim re-implements no tools — it forwards the protocol, so the daemon is
+  the single source of truth for the tool surface.
+* **fallback mode** — no daemon is reachable (none started, or a crashed daemon
+  left stale state files behind a dead port). The shim serves
+  ``create_server()`` in-process over stdio — exactly today's per-session
+  behavior — so a daemon outage *degrades* rather than *breaks* hive (proposal
+  item 4 / the "Transparent fallback" acceptance criterion).
+
+The chosen mode is logged once at startup as ``hive.client.mode=<mode> ...`` so
+an operator can confirm which path a session took. This is deliberately a log
+signal, not an MCP-visible flag: slice 2 must not change the tool surface (the
+richer cross-session ``hive status`` observability surface is a later slice).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import socket
+
+from hive._daemon import DEFAULT_HOST, MCP_PATH, port_file_path, token_file_path
+
+_log = logging.getLogger("hive")
+
+# How long to wait for the daemon's loopback port to accept a TCP connection
+# before declaring it unreachable and falling back. This probe runs on *every*
+# session spawn, so a dead daemon must not stall Claude Code's startup; yet it
+# must tolerate a momentarily busy machine. 500 ms is the spike's proven budget.
+_PROBE_TIMEOUT_S = 0.5
+
+
+def _read_state() -> tuple[int, str] | None:
+    """Read the daemon's published port + token, or ``None`` if either is absent.
+
+    A missing/garbage port or empty token means no daemon ever published state
+    here — the caller treats that as the ``no_daemon_state`` fallback reason.
+    """
+    try:
+        port = int(port_file_path().read_text(encoding="utf-8").strip())
+        token = token_file_path().read_text(encoding="utf-8").strip()
+    except (OSError, ValueError):
+        return None
+    if port <= 0 or not token:
+        return None
+    return port, token
+
+
+def _daemon_reachable(host: str, port: int) -> bool:
+    """Return True if a process is accepting connections at ``host:port``.
+
+    A cheap TCP connect — enough to distinguish a live daemon from stale state
+    files left by a crash (the connect is refused when nothing is listening).
+    The bearer token still guards against *using* a wrong server, so a deeper
+    MCP handshake is left to the auto-reconnect slice.
+    """
+    with contextlib.suppress(OSError), socket.create_connection(
+        (host, port), timeout=_PROBE_TIMEOUT_S,
+    ):
+        return True
+    return False
+
+
+def _serve_in_process() -> None:
+    """Fallback: run the v1 in-process stdio server (today's behavior)."""
+    from hive.server import create_server
+
+    create_server().run()
+
+
+def _serve_proxy(host: str, port: int, token: str) -> None:
+    """Daemon mode: forward stdio MCP to the daemon over token-gated HTTP."""
+    from fastmcp.client.transports import StreamableHttpTransport
+    from fastmcp.server import create_proxy
+
+    transport = StreamableHttpTransport(
+        f"http://{host}:{port}{MCP_PATH}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    create_proxy(transport).run()
+
+
+def run_client(host: str = DEFAULT_HOST) -> None:
+    """Run the thin stdio shim: proxy to a live daemon, else serve in-process.
+
+    Decision order: no published state -> ``no_daemon_state`` fallback; state
+    present but the port is dead -> ``daemon_unreachable`` fallback; otherwise
+    proxy to the daemon. The mode is logged once before the server loop starts.
+    """
+    state = _read_state()
+    if state is None:
+        _log.info("hive.client.mode=fallback reason=no_daemon_state")
+        _serve_in_process()
+        return
+
+    port, token = state
+    if not _daemon_reachable(host, port):
+        _log.info("hive.client.mode=fallback reason=daemon_unreachable")
+        _serve_in_process()
+        return
+
+    _log.info("hive.client.mode=daemon endpoint=%s:%d", host, port)
+    _serve_proxy(host, port, token)

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -495,13 +495,28 @@ def _run_serve(argv: list[str]) -> None:
     run_serve(host=opts.host, port=opts.port)
 
 
+def _run_client(argv: list[str]) -> None:
+    """``hive client`` — thin stdio shim: proxy to the daemon, else fallback."""
+    import argparse
+
+    from hive._client import run_client
+    from hive._daemon import DEFAULT_HOST
+
+    parser = argparse.ArgumentParser(prog="hive client")
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    opts = parser.parse_args(argv)
+    run_client(host=opts.host)
+
+
 def main() -> None:
     """Entry point for the hive CLI command.
 
     Bare ``hive`` runs the stdio MCP server (the v1 per-session contract).
     ``hive serve`` runs the Phase C single-owner daemon over loopback HTTP +
-    bearer token (ADR-011). ``create_server()`` is called here rather than at
-    module import so importing ``hive.server`` is side-effect free.
+    bearer token (ADR-011). ``hive client`` runs the thin stdio shim that
+    proxies to that daemon (falling back to the in-process server when none is
+    reachable). ``create_server()`` is called here rather than at module import
+    so importing ``hive.server`` is side-effect free.
     """
     _setup_file_logging()
     _log = logging.getLogger("hive")
@@ -509,6 +524,8 @@ def main() -> None:
     try:
         if argv and argv[0] == "serve":
             _run_serve(argv[1:])
+        elif argv and argv[0] == "client":
+            _run_client(argv[1:])
         else:
             create_server().run()
     except BaseException as exc:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -52,6 +52,48 @@ async def _list_tools(url: str, token: str) -> list[str]:
         return [t.name for t in await client.list_tools()]
 
 
+# ── client shim (stdio) helpers ──────────────────────────────────────────
+
+_DEMO_MARKER = "DAEMON-FORWARD-MARKER"
+
+
+def _seed_demo_project(vault: Path) -> dict[str, str]:
+    """Create a `demo` project with known content; return vault_query args."""
+    ctx = vault / "10_projects" / "demo" / "00-context.md"
+    ctx.parent.mkdir(parents=True, exist_ok=True)
+    ctx.write_text(f"---\ntitle: demo\n---\n{_DEMO_MARKER}\n", encoding="utf-8")
+    return {"project": "demo", "section": "context"}
+
+
+async def _drive_shim(
+    env: dict[str, str], tool: str, args: dict[str, str],
+) -> tuple[list[str], str]:
+    """Spawn the `hive client` stdio shim and drive it with a fastmcp client.
+
+    Returns (tool names the shim exposes, text of the forwarded tool call).
+    """
+    from fastmcp import Client
+    from fastmcp.client.transports import StdioTransport
+
+    transport = StdioTransport(
+        command=sys.executable, args=["-m", "hive.server", "client"], env=env,
+    )
+    async with Client(transport) as client:
+        tools = [t.name for t in await client.list_tools()]
+        result = await client.call_tool(tool, args)
+    return tools, str(getattr(result, "data", result))
+
+
+def _client_mode(state_dir: Path) -> str:
+    """Return the `hive.client.mode=...` value the shim logged, or ''."""
+    marker = "hive.client.mode="
+    for log_file in sorted(state_dir.glob("hive-*.log")):
+        for line in log_file.read_text(errors="replace").splitlines():
+            if marker in line:
+                return line.split(marker, 1)[1].strip()
+    return ""
+
+
 @pytest.fixture
 def daemon_env(tmp_path: Path) -> tuple[dict[str, str], Path]:
     """Env pointing every DB + the vault + daemon state dir at a temp dir."""
@@ -117,3 +159,65 @@ def test_hive_serve_rejects_bad_token(daemon_env: tuple[dict[str, str], Path]) -
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
+
+
+def test_client_forwards_to_daemon(daemon_env: tuple[dict[str, str], Path]) -> None:
+    """With a daemon running, the thin stdio shim connects over the token-gated
+    transport and forwards a `vault_query` to it — reporting `daemon` mode."""
+    env, state_dir = daemon_env
+    args = _seed_demo_project(state_dir / "vault")
+    port = _free_port()
+    daemon = _spawn_daemon(env, port)
+    try:
+        assert _wait_ready(port), "daemon did not bind its loopback port"
+
+        tools, text = asyncio.run(_drive_shim(env, "vault_query", args))
+        assert "vault_query" in tools
+        assert "session_briefing" in tools
+        assert _DEMO_MARKER in text, f"forwarded query did not round-trip: {text!r}"
+
+        mode = _client_mode(state_dir)
+        assert mode.startswith("daemon"), f"shim did not report daemon mode: {mode!r}"
+    finally:
+        daemon.terminate()
+        try:
+            daemon.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            daemon.kill()
+
+
+def test_client_falls_back_without_daemon(
+    daemon_env: tuple[dict[str, str], Path],
+) -> None:
+    """With no daemon (no state files), the shim serves the query in-process and
+    flags degraded (`fallback`) mode — today's behavior, transparently."""
+    env, state_dir = daemon_env
+    args = _seed_demo_project(state_dir / "vault")
+
+    tools, text = asyncio.run(_drive_shim(env, "vault_query", args))
+    assert "vault_query" in tools
+    assert _DEMO_MARKER in text, f"in-process query failed: {text!r}"
+
+    mode = _client_mode(state_dir)
+    assert mode.startswith("fallback"), f"expected fallback mode, got {mode!r}"
+    assert "no_daemon_state" in mode, f"unexpected fallback reason: {mode!r}"
+
+
+def test_client_falls_back_on_stale_state(
+    daemon_env: tuple[dict[str, str], Path],
+) -> None:
+    """A crashed daemon leaves stale port/token files but a dead port. The shim
+    probes liveness, finds nothing listening, and falls back rather than hang."""
+    env, state_dir = daemon_env
+    args = _seed_demo_project(state_dir / "vault")
+    dead_port = _free_port()  # bound + closed → nothing is listening
+    (state_dir / "daemon.port").write_text(str(dead_port), encoding="utf-8")
+    (state_dir / "daemon.token").write_text("stale-token", encoding="utf-8")
+
+    tools, text = asyncio.run(_drive_shim(env, "vault_query", args))
+    assert "vault_query" in tools
+    assert _DEMO_MARKER in text, f"in-process query failed: {text!r}"
+
+    mode = _client_mode(state_dir)
+    assert mode.startswith("fallback"), f"expected fallback mode, got {mode!r}"
+    assert "daemon_unreachable" in mode, f"unexpected fallback reason: {mode!r}"


### PR DESCRIPTION
## Summary

Adds the thin stdio **`hive client`** shim — the client half of the single-owner daemon model (ADR-011, spec `specs/HIVE-118-phase-c-daemon-model/`). Claude Code keeps its v1 stdio MCP contract (`~/.claude.json` unchanged): it spawns the shim over stdio, which then chooses a backend at startup.

- **Proxy mode** — a reachable `hive serve` daemon: the shim becomes a transparent FastMCP proxy (`create_proxy`) forwarding every request over the token-gated loopback Streamable-HTTP transport. No tool is re-implemented, so the daemon stays the single source of truth for the tool surface.
- **Fallback mode** — no daemon reachable: serves the in-process `create_server()` over stdio (today's per-session behavior). Two reasons are distinguished: `no_daemon_state` (no published port/token) and `daemon_unreachable` (stale state behind a dead port, caught by a 500 ms TCP liveness probe). A daemon outage **degrades** rather than **breaks** hive.

The chosen mode is logged once at startup as `hive.client.mode=<mode> reason=...`. This is deliberately a log signal, not an MCP-visible flag — the tool surface is unchanged; the richer cross-session `hive status` surface is a later slice.

## Acceptance criteria touched

- `transparent-fallback` (proposal AC + `features.json`): with no daemon, a client call still succeeds in-process and the degraded mode is observable. Implemented + tested here. Pulled ahead of the multi-client/observability steps because a forwarding-only shim wired into `~/.claude.json` would break every session when the daemon is down — fallback is a safety prerequisite, not a later refinement (reorder note in `tasks.md`).

## Tests

Black-box, subprocess-spawned (the production analogue of `spike/transport_spike.py`):

- `test_client_forwards_to_daemon` — daemon up → shim forwards a `vault_query` round-trip; reports `daemon` mode.
- `test_client_falls_back_without_daemon` — no state files → in-process success + `fallback reason=no_daemon_state`.
- `test_client_falls_back_on_stale_state` — stale port/token behind a dead port → in-process success + `fallback reason=daemon_unreachable`.

`make check` green locally: ruff + `mypy --strict` + 642 passed / 2 skipped.

> Coverage note: `_client.py` and `_daemon.py` report 0% line coverage because both are exercised by subprocess-spawned black-box tests (coverage does not instrument child processes without the `COVERAGE_PROCESS_START` hook). This matches the established pattern from the slice-1 daemon entrypoint; behavior is fully tested.

## Scope / deferred

- Multi-client integration, cross-session observability (`hive status`), and **mid-session auto-reconnect** (when a dead daemon returns) stay in later slices per the frozen `tasks.md`. The shim picks its mode once at startup.

Spec: `specs/HIVE-118-phase-c-daemon-model/` · ADR-011 (accepted)