### PR TITLE
feat: daemon startup self-heal + single-owner lock (HIVE-118)

### DIFF
--- a/specs/HIVE-118-phase-c-daemon-model/features.json
+++ b/specs/HIVE-118-phase-c-daemon-model/features.json
@@ -62,6 +62,15 @@
       "supports": "supervised-recovery"
     },
     {
+      "id": "startup-self-heal",
+      "ac": "Startup self-heal + single-owner guard",
+      "behavior": "On startup the daemon acquires a singleton advisory lock on <state_dir>/daemon.lock; a second `hive serve` -- even on a different auto-port -- declines cleanly (exit 0) instead of double-owning the SQLite DBs + git tree. Holding that lock proves single ownership, so the daemon then clears a stale `.git/index.lock` left by a prior unclean exit (a lock naming a live PID is spared), letting writes commit again.",
+      "verification": "uv run pytest tests/test_daemon.py -k \"self_heals_stale_index_lock or declines_when_state_owned\"",
+      "state": "planned",
+      "evidence": "Slice 1.2 (2026-06-01): src/hive/_daemon.py _acquire_singleton_lock (filelock, non-blocking timeout=0, kernel-released on crash so a supervised restart re-acquires) + _startup_self_heal (clears a stale .git/index.lock under the proven single-owner invariant; _index_lock_is_live spares a live external committer). Closes the auto-port single-owner gap (_free_port lets two daemons bind different ports). Two TDD tests green locally via make check (661 passed, mypy --strict + ruff clean): a planted dead-PID index.lock is cleared and the next write commits; a second daemon on a different port declines exit 0 without binding. Awaiting harness pass-state.",
+      "supports": "supervised-recovery"
+    },
+    {
       "id": "supervised-recovery",
       "ac": "Supervised recovery",
       "behavior": "Killing the daemon (SIGKILL) triggers supervisor auto-restart; durable state (SQLite + git) is intact, and in-flight clients reconnect or fall back.",

--- a/specs/HIVE-118-phase-c-daemon-model/tasks.md
+++ b/specs/HIVE-118-phase-c-daemon-model/tasks.md
@@ -43,7 +43,8 @@ created: "2026-05-29"
 - [ ] **Resilience:** structured single-daemon logging with `correlation_id` + `session_id` (replace per-PID logs)
 - [x] **Resilience:** liveness + readiness probes — unauthenticated `GET /health` → 200 `{status, ready, version, uptime_s}` (liveness=200, readiness=`ready` via vault resolvability); metrics/budget stay token-gated on `/status`. The contract the supervised unit, restart-on-upgrade wait, and the client reconnect probe consume. (2026-05-31, slice 1.1)
 - [ ] **DR:** write failing test — `SIGKILL` under load -> supervisor restart, durable state (SQLite+git) intact, clients reconnect/fallback
-- [ ] **DR:** startup self-heal (clear own stale locks/zombie state from prior unclean exit) + restart-on-upgrade drain/swap
+- [x] **DR:** startup self-heal — singleton `daemon.lock` flock (closes the auto-port single-owner gap: two `hive serve` on different free ports collide on one advisory lock; the loser declines cleanly, exit 0) + clear a stale `.git/index.lock` from a prior unclean exit, safe under the now-proven single-owner invariant. A live-PID lock is spared; 0-byte WAL is handled by `_clean_stale_wal_files`, non-empty WAL untouched. (2026-06-01, `feat/daemon-startup-self-heal`)
+- [ ] **DR:** restart-on-upgrade drain/swap (waits for `/health` ready before swapping; the supervised-restart half of this slice)
 - [ ] **Post-mortem:** in-memory black-box ring buffer of last-N requests + lock events
 - [ ] **Post-mortem:** write failing test — abnormal exit flushes a crash artifact with required fields AND no secrets/API keys
 - [ ] **Post-mortem:** `hive status --verbose` / debug endpoint dumps live state (active requests, lock holders, queue depths) from a running daemon

--- a/specs/HIVE-118-phase-c-daemon-model/verification.md
+++ b/specs/HIVE-118-phase-c-daemon-model/verification.md
@@ -29,6 +29,7 @@ Map every acceptance criterion from `proposal.md` to concrete proof (commit hash
 Brief log of non-obvious trade-offs or course corrections taken during the work.
 
 - 2026-05-29 (pre-implementation): telemetry showed the latency-tail gate for Phase C does NOT fire (lock contention ~0, WAL tiny, 0 timeouts). Phase C re-justified on operating-model grounds (observability + shared state + lifecycle), not latency. The acute concurrency symptom was traced to `uvx --upgrade` startup serialisation and mitigated separately (dropped `--upgrade` in `~/.claude.json` + daily `uv tool upgrade` cron). This decoupling means Phase C is a deliberate v2.0 architecture choice, not a forced firefight.
+- 2026-06-01 (slice 1.2, startup self-heal): a singleton collision (second `hive serve` on a different auto-port) declines with **exit 0**, not a non-zero code. Rationale: consistency with the existing port-in-use guard ("exits cleanly"), and a no-op start that exits 0 will not loop under systemd `Restart=on-failure` (a non-zero would, unless the unit also set `RestartPreventExitStatus=`, coupling code to unit config). The decline reason is carried by a `hive.daemon.singleton.declined` WARNING + a stderr line, not the exit code. Index.lock self-heal is gated on the singleton lock (proves single ownership) and spares a lock naming a live PID via `_index_lock_is_live` — real git index.locks carry no parseable PID, so they read as stale and clear, while a rare tool-written live PID is preserved.
 -
 
 ## Promotion candidates

--- a/src/hive/_daemon.py
+++ b/src/hive/_daemon.py
@@ -12,12 +12,16 @@ resilience/observability pillar (ADR-011 §4) lands in later slices.
 
 from __future__ import annotations
 
+import logging
 import os
 import secrets
 import socket
 import subprocess
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import filelock
 
 from hive.config import settings
 
@@ -28,6 +32,10 @@ DEFAULT_HOST = "127.0.0.1"
 MCP_PATH = "/mcp"
 TOKEN_FILENAME = "daemon.token"
 PORT_FILENAME = "daemon.port"
+LOCK_FILENAME = "daemon.lock"
+
+_log = logging.getLogger(__name__)
+IS_WINDOWS = sys.platform == "win32"
 
 
 def daemon_state_dir() -> Path:
@@ -41,6 +49,10 @@ def token_file_path() -> Path:
 
 def port_file_path() -> Path:
     return daemon_state_dir() / PORT_FILENAME
+
+
+def lock_file_path() -> Path:
+    return daemon_state_dir() / LOCK_FILENAME
 
 
 def _free_port() -> int:
@@ -75,6 +87,97 @@ def _token_verifier(token: str) -> AuthProvider:
     return StaticTokenVerifier({token: {"client_id": "hive-daemon", "scopes": []}})
 
 
+# ── Single-owner guard + startup self-heal (ADR-011 §1, §4) ──────────────
+
+
+def _acquire_singleton_lock() -> filelock.BaseFileLock | None:
+    """Non-blocking acquire of the per-state-dir singleton ``daemon.lock``.
+
+    Returns the HELD lock (the caller keeps the reference alive for the whole
+    process lifetime) or ``None`` when another daemon already owns this state
+    dir. This closes the auto-port single-owner gap: two ``hive serve``
+    invocations pick different free ports, so the OS port-in-use guard never
+    fires, yet they collide here on one advisory lock. The lock is kernel-owned
+    by fd, so a crashed daemon's lock frees automatically for the supervised
+    restart — no stale lock blocks recovery.
+    """
+    lock_path = lock_file_path()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock = filelock.FileLock(str(lock_path))
+    try:
+        lock.acquire(timeout=0)
+    except filelock.Timeout:
+        return None
+    return lock
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort: is *pid* a currently-live process?"""
+    if pid <= 0:
+        return False
+    if IS_WINDOWS:
+        try:
+            import psutil
+        except ImportError:
+            return False
+        return psutil.pid_exists(pid)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by another user
+    return True
+
+
+def _index_lock_is_live(lock_path: Path) -> bool:
+    """True only when the lock names a parseable, currently-alive PID.
+
+    A real git ``index.lock`` holds the in-progress index (no PID) or is empty,
+    so this returns ``False`` for it — correctly treating a leftover lock as
+    stale. It returns ``True`` only in the narrow, defensive case where a tool
+    wrote a live PID, sparing a live external committer mid-commit.
+    """
+    try:
+        lines = lock_path.read_text(encoding="utf-8").strip().splitlines()
+    except (OSError, UnicodeDecodeError):
+        return False
+    if not lines:
+        return False
+    try:
+        pid = int(lines[0].strip())
+    except ValueError:
+        return False
+    return _pid_alive(pid)
+
+
+def _startup_self_heal(vault: Path) -> None:
+    """Clear a stale ``.git/index.lock`` left by a prior unclean exit.
+
+    Safe ONLY because the caller already holds the singleton ``daemon.lock``:
+    no sibling hive daemon owns this tree, and we have issued no git op of our
+    own yet, so any pre-existing ``index.lock`` is from a dead prior run. A lock
+    naming a live PID is spared. Stale 0-byte WAL files are handled separately
+    by ``create_server`` via ``_clean_stale_wal_files``; non-empty WAL is never
+    touched (SQLite recovers it).
+    """
+    lock_path = vault / ".git" / "index.lock"
+    if not lock_path.exists():
+        return
+    if _index_lock_is_live(lock_path):
+        _log.info(
+            "hive.daemon.self_heal index.lock held by a live process; leaving %s",
+            lock_path,
+        )
+        return
+    try:
+        lock_path.unlink()
+    except OSError as exc:
+        _log.warning("hive.daemon.self_heal could not clear index.lock: %s", exc)
+        return
+    _log.info("hive.daemon.self_heal cleared stale index.lock at %s", lock_path)
+
+
 def run_serve(host: str = DEFAULT_HOST, port: int = 0) -> None:
     """Run hive as a single-owner daemon over loopback Streamable-HTTP + token.
 
@@ -84,20 +187,42 @@ def run_serve(host: str = DEFAULT_HOST, port: int = 0) -> None:
     """
     from hive.server import create_server
 
-    resolved_port = port or _free_port()
-    token = secrets.token_urlsafe(32)
-    # Each startup republishes a fresh token + port, overwriting any state a
-    # prior daemon left behind. We deliberately do NOT clean these up on stop:
-    # uvicorn's SIGTERM handling exits the process via the signal (rc -15),
-    # bypassing `finally`/`atexit`, and SIGTERM is exactly how systemd / kill
-    # stop the daemon. Stale state is benign — the client's TCP liveness probe
-    # falls back (`daemon_unreachable`) and a restart overwrites it. See ADR-011
-    # startup self-heal for the crash path.
-    write_owner_only(token_file_path(), token)
-    write_owner_only(port_file_path(), str(resolved_port))
+    # Single-owner guard (ADR-011 §1). A second daemon — even on a different
+    # auto-port — collides here and declines cleanly rather than double-owning
+    # the SQLite DBs + git tree. Exit 0 keeps a no-op start from looping under
+    # systemd `Restart=on-failure`; the WARNING + stderr line carry the "why".
+    singleton = _acquire_singleton_lock()
+    if singleton is None:
+        _log.warning(
+            "hive.daemon.singleton.declined state_dir=%s another daemon owns it",
+            daemon_state_dir(),
+        )
+        print(
+            "hive: another daemon already owns this state dir; declining to start",
+            file=sys.stderr,
+        )
+        return
 
-    server = create_server(auth=_token_verifier(token))
-    server.run(
-        transport="http", host=host, port=resolved_port,
-        path=MCP_PATH, show_banner=False,
-    )
+    try:
+        # Single ownership is now proven, so clearing a prior crash's stale
+        # locks cannot race a live sibling daemon (ADR-011 startup self-heal).
+        _startup_self_heal(settings.vault_path)
+
+        resolved_port = port or _free_port()
+        token = secrets.token_urlsafe(32)
+        # Each startup republishes a fresh token + port, overwriting any state a
+        # prior daemon left behind. We deliberately do NOT clean these up on stop:
+        # uvicorn's SIGTERM handling exits the process via the signal (rc -15),
+        # bypassing `finally`/`atexit`, and SIGTERM is exactly how systemd / kill
+        # stop the daemon. Stale state is benign — the client's TCP liveness probe
+        # falls back (`daemon_unreachable`) and a restart overwrites it.
+        write_owner_only(token_file_path(), token)
+        write_owner_only(port_file_path(), str(resolved_port))
+
+        server = create_server(auth=_token_verifier(token))
+        server.run(
+            transport="http", host=host, port=resolved_port,
+            path=MCP_PATH, show_banner=False,
+        )
+    finally:
+        singleton.release()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -420,6 +420,98 @@ def test_health_probe_is_unauthenticated_and_reports_ready(
             daemon.kill()
 
 
+def test_daemon_self_heals_stale_index_lock(
+    daemon_env: tuple[dict[str, str], Path],
+) -> None:
+    """A prior daemon crashed mid-commit, leaving a stale `.git/index.lock`
+    owned by a now-dead PID. On startup — holding the singleton `daemon.lock`,
+    so single ownership is proven — the daemon clears the stale lock, and a
+    subsequent vault_write COMMITS normally instead of silently failing on a
+    lock git will never release on its own (the write succeeds to disk either
+    way; the discriminator is whether the commit lands)."""
+    env, state_dir = daemon_env
+    vault = state_dir / "vault"
+    _seed_demo_project(vault)
+    _git_init_vault(vault)
+
+    # A crashed prior daemon's lock: an implausible, certainly-dead PID.
+    stale_lock = vault / ".git" / "index.lock"
+    stale_lock.write_text("999999\n", encoding="utf-8")
+
+    port = _free_port()
+    daemon = _spawn_daemon(env, port)
+    try:
+        assert _wait_ready(port), "daemon did not bind its loopback port"
+
+        done = asyncio.run(_client_appends(env, ["HEAL-MARKER"]))
+        assert done == 1, "vault_write did not complete"
+
+        assert not stale_lock.exists(), (
+            "startup self-heal did not clear the stale .git/index.lock"
+        )
+        # The write committed: git log grew past `init`. If the stale lock had
+        # survived, the daemon's best-effort commit would have failed silently
+        # and the log would still be a single `init` commit.
+        log = subprocess.run(
+            ["git", "log", "--oneline"],
+            cwd=vault, capture_output=True, text=True, check=True,
+        ).stdout
+        assert len(log.splitlines()) >= 2, f"write did not commit: {log!r}"
+        content = (vault / "10_projects" / "demo" / "00-context.md").read_text(
+            encoding="utf-8",
+        )
+        assert "HEAL-MARKER" in content
+    finally:
+        daemon.terminate()
+        try:
+            daemon.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            daemon.kill()
+
+
+def test_second_daemon_declines_when_state_owned(
+    daemon_env: tuple[dict[str, str], Path],
+) -> None:
+    """Two `hive serve` invocations with auto-port bind DIFFERENT free ports, so
+    the OS port-in-use guard never fires — both would end up owning the same
+    SQLite DBs + git tree (a single-owner violation, ADR-011 §1). A singleton
+    flock on `daemon.lock` closes the gap: the second daemon, even on a
+    different port, finds the state dir already owned and declines cleanly
+    (exit 0) without binding a second port.
+
+    Explicit distinct ports stand in deterministically for the `_free_port()`
+    race the auto-port path would produce.
+    """
+    env, state_dir = daemon_env
+    (state_dir / "vault" / "10_projects").mkdir(parents=True, exist_ok=True)
+
+    port_a = _free_port()
+    daemon_a = _spawn_daemon(env, port_a)
+    daemon_b: subprocess.Popen[bytes] | None = None
+    try:
+        assert _wait_ready(port_a), "first daemon did not bind its loopback port"
+
+        port_b = _free_port()
+        assert port_b != port_a, "test setup: ports must differ"
+        daemon_b = _spawn_daemon(env, port_b)
+
+        # The second daemon must decline promptly, not run forever.
+        rc = daemon_b.wait(timeout=15)
+        assert rc == 0, f"second daemon did not decline cleanly: rc={rc}"
+        assert not _wait_ready(port_b, deadline_s=2.0), (
+            "second daemon bound a port despite the singleton lock"
+        )
+    finally:
+        for d in (daemon_a, daemon_b):
+            if d is None:
+                continue
+            d.terminate()
+            try:
+                d.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                d.kill()
+
+
 def test_status_aggregates_across_sessions(
     daemon_env: tuple[dict[str, str], Path],
 ) -> None:


### PR DESCRIPTION
## What

Closes the daemon's single-owner gap and adds startup self-heal (HIVE-118, resilience work).

- **Single-owner guard.** A non-blocking `filelock` on `<state_dir>/daemon.lock`, held for the process lifetime. The auto-port path (`port or _free_port()`) let two `hive serve` invocations bind *different* free ports and both own the same SQLite DBs + git tree — the OS port-in-use guard only fires on the *same* port. Now a second daemon, even on a different port, collides on the lock and **declines cleanly (exit 0)** rather than double-owning state (ADR-011 §1).
- **Startup self-heal.** Holding that lock proves single ownership, which licenses clearing a stale `.git/index.lock` left by a prior unclean exit so writes can commit again. A lock naming a live PID is spared (`_index_lock_is_live`); 0-byte WAL is already handled by `_clean_stale_wal_files`, and a non-empty WAL is never touched (SQLite recovers it).

## Why exit 0 on collision

Consistency with the existing port-in-use guard ("exits cleanly") and supervisor-safety: a no-op start that exits 0 will not loop under `Restart=on-failure` (a non-zero would, unless the unit also set `RestartPreventExitStatus=`, coupling code to unit config). The decline reason is carried by a `hive.daemon.singleton.declined` warning + a stderr line, not the exit code.

`filelock` ownership is kernel-tracked by fd, so a SIGKILL'd daemon's lock auto-frees and a supervised restart re-acquires cleanly — no stale lock blocks recovery.

## Tests (TDD, Red→Green)

- `test_daemon_self_heals_stale_index_lock` — plant a dead-PID `.git/index.lock`, start the daemon, assert it is cleared and a subsequent write commits (the *commit landing* is the discriminator, since a surviving lock lets the write succeed-to-disk while the commit silently fails).
- `test_second_daemon_declines_when_state_owned` — two daemons on different ports; the second declines exit 0 without binding.

`make check`: ruff clean, mypy --strict clean, 661 passed / 2 skipped.

## Spec

`specs/HIVE-118-phase-c-daemon-model/` — self-heal task ticked in `tasks.md`, `features.json` gains `startup-self-heal`, exit-0 rationale logged in `verification.md`.
