### PR TITLE
style: adopt ruff format across the repo (#157)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Lint
         run: uv run ruff check src/ tests/
 
+      - name: Format check
+        run: uv run ruff format --check src/ tests/
+
       - name: Type check
         run: uv run mypy src/
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ help: ## Show this help
 install: ## Create venv and install deps
 	uv venv && uv pip install -e ".[dev]"
 
-lint: ## Run ruff linter
+lint: ## Run ruff linter + formatter check
 	uv run ruff check src/ tests/
+	uv run ruff format --check src/ tests/
 
 typecheck: ## Run mypy --strict
 	uv run mypy src/

--- a/src/hive/_client.py
+++ b/src/hive/_client.py
@@ -80,8 +80,12 @@ def _daemon_reachable(host: str, port: int) -> bool:
     The bearer token still guards against *using* a wrong server, so a deeper
     MCP handshake is left to the auto-reconnect slice.
     """
-    with contextlib.suppress(OSError), socket.create_connection(
-        (host, port), timeout=_PROBE_TIMEOUT_S,
+    with (
+        contextlib.suppress(OSError),
+        socket.create_connection(
+            (host, port),
+            timeout=_PROBE_TIMEOUT_S,
+        ),
     ):
         return True
     return False

--- a/src/hive/_compat.py
+++ b/src/hive/_compat.py
@@ -134,8 +134,7 @@ def _make_patched_exit(original_exit: Any) -> Any:  # noqa: ARG001 (kept for sym
                 cancelled_cls = anyio.get_cancelled_exc_class()
                 if self._completed and isinstance(exc, cancelled_cls):
                     _log.debug(
-                        "Swallowed spurious cancellation on completed "
-                        "responder %s (issue #75)",
+                        "Swallowed spurious cancellation on completed responder %s (issue #75)",
                         self.request_id,
                     )
                     return
@@ -181,7 +180,8 @@ def _make_patched_respond(original_respond: Any) -> Any:
                 "mcp.ghost_response.suppressed_after_cancel_ack "
                 "request_id=%s tool=%s — disk state may be mutated; "
                 "verify via vault_query, do not retry.",
-                self.request_id, tool or "<unknown>",
+                self.request_id,
+                tool or "<unknown>",
             )
             return
         await original_respond(self, response)
@@ -222,15 +222,19 @@ def apply() -> None:
     except ImportError as exc:
         _log.warning(
             "Could not import mcp.shared.session.RequestResponder — "
-            "cancellation patch skipped (issue #75): %s", exc,
+            "cancellation patch skipped (issue #75): %s",
+            exc,
         )
         return
 
     if getattr(RequestResponder, _PATCH_APPLIED_ATTR, False):
         return
 
-    missing = [a for a in _REQUIRED_ATTRS if a not in RequestResponder.__dict__
-               and not hasattr(RequestResponder, a)]
+    missing = [
+        a
+        for a in _REQUIRED_ATTRS
+        if a not in RequestResponder.__dict__ and not hasattr(RequestResponder, a)
+    ]
     # Instance attrs aren't in the class dict; we test via __init__ source.
     # A simpler heuristic: just check __exit__ exists, then trust it at call
     # time — our patch only short-circuits when the attrs are set on the
@@ -238,7 +242,8 @@ def apply() -> None:
     if not hasattr(RequestResponder, "__exit__"):
         _log.warning(
             "RequestResponder has no __exit__ — cancellation patch skipped "
-            "(issue #75). Missing attrs hint: %s", missing,
+            "(issue #75). Missing attrs hint: %s",
+            missing,
         )
         return
 

--- a/src/hive/_daemon.py
+++ b/src/hive/_daemon.py
@@ -89,7 +89,9 @@ def write_owner_only(path: Path, content: str) -> None:
         user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
         subprocess.run(  # noqa: S603,S607 — fixed args, owner derived from env
             ["icacls", str(path), "/inheritance:r", "/grant:r", f"{user}:(F)"],
-            check=False, capture_output=True, text=True,
+            check=False,
+            capture_output=True,
+            text=True,
         )
     else:
         path.chmod(0o600)
@@ -266,7 +268,9 @@ async def _serve_until_drift_or_signal(uv_server: uvicorn.Server) -> bool:
     """Run *uv_server* alongside a drift watcher; True iff an upgrade stopped it."""
     watcher = asyncio.create_task(
         _watch_for_upgrade(
-            uv_server, boot=_current_version(), poll_s=settings.upgrade_poll_s,
+            uv_server,
+            boot=_current_version(),
+            poll_s=settings.upgrade_poll_s,
         ),
     )
     try:

--- a/src/hive/_deadline.py
+++ b/src/hive/_deadline.py
@@ -178,13 +178,15 @@ def _cleanup_index_lock(vault: Path, our_pids: list[int]) -> None:
         # Lock file present but unparseable PID — never touch.
         _log.debug(
             "index.lock at %s has unparseable owner %r; leaving in place",
-            lock_path, contents,
+            lock_path,
+            contents,
         )
         return
     if owner not in our_pids:
         _log.info(
             "mcp.index_lock.skip_cleanup owner_pid=%s our_pids=%s",
-            owner, our_pids,
+            owner,
+            our_pids,
         )
         return
     try:
@@ -249,7 +251,10 @@ async def bounded_call[T](
         _log.warning(
             "mcp.bounded_call.deadline_exceeded tool=%s elapsed_s=%.1f "
             "deadline_s=%.1f killed_pids=%s",
-            tool_name or "<unknown>", elapsed, deadline_s, killed,
+            tool_name or "<unknown>",
+            elapsed,
+            deadline_s,
+            killed,
         )
         # HIVE-116 AC-1: cooperative filelock eviction. Mirrors the
         # ``tool_span`` branch; both supervisors share the eviction
@@ -260,7 +265,8 @@ async def bounded_call[T](
             from hive._helpers import _drain_and_evict
 
             await _drain_and_evict(
-                vault_for_index_cleanup, killed,
+                vault_for_index_cleanup,
+                killed,
                 tool_name or "<unknown>",
             )
         raise TimeoutError(

--- a/src/hive/_diagnostics.py
+++ b/src/hive/_diagnostics.py
@@ -50,7 +50,10 @@ class LifecycleMiddleware(Middleware):
             _record(tool, elapsed_ms, ok=False)
             _log.info(
                 "mcp cancelled method=%s tool=%s id=%s elapsed_ms=%.0f",
-                method, tool, request_id, elapsed_ms,
+                method,
+                tool,
+                request_id,
+                elapsed_ms,
             )
             raise
         except Exception as exc:
@@ -58,7 +61,11 @@ class LifecycleMiddleware(Middleware):
             _record(tool, elapsed_ms, ok=False)
             _log.warning(
                 "mcp error method=%s tool=%s id=%s elapsed_ms=%.0f exc=%r",
-                method, tool, request_id, elapsed_ms, exc,
+                method,
+                tool,
+                request_id,
+                elapsed_ms,
+                exc,
             )
             raise
         else:
@@ -68,7 +75,10 @@ class LifecycleMiddleware(Middleware):
                 METRICS.record_session_start()
             _log.info(
                 "mcp ok method=%s tool=%s id=%s elapsed_ms=%.0f",
-                method, tool, request_id, elapsed_ms,
+                method,
+                tool,
+                request_id,
+                elapsed_ms,
             )
             return result
 

--- a/src/hive/_helpers.py
+++ b/src/hive/_helpers.py
@@ -58,10 +58,7 @@ def synthesize_external_termination_stderr(original_stderr: bytes) -> str:
     ts = datetime.now(UTC).isoformat(timespec="seconds")
     n = len(original_stderr)
     detail = "empty" if n == 0 else f"{n} bytes"
-    return (
-        f"[external_termination] killed by supervisor at {ts} ; "
-        f"original stderr: {detail}"
-    )
+    return f"[external_termination] killed by supervisor at {ts} ; original stderr: {detail}"
 
 
 # HIVE-116 AC-5/AC-6: contextvar threading partial-state signals from the
@@ -75,8 +72,8 @@ def synthesize_external_termination_stderr(original_stderr: bytes) -> str:
 #     the partial-state response instead of the generic "timed out" string.
 # The CV value is the *same dict reference* in the awaiting coroutine and
 # the to_thread worker (CPython propagates the context).
-_PARTIAL_STATE_CV: contextvars.ContextVar[dict[str, bool] | None] = (
-    contextvars.ContextVar("_PARTIAL_STATE", default=None)
+_PARTIAL_STATE_CV: contextvars.ContextVar[dict[str, bool] | None] = contextvars.ContextVar(
+    "_PARTIAL_STATE", default=None
 )
 
 # HIVE-116 AC-1: contextvar propagating the vault path that ``tool_span``
@@ -85,8 +82,8 @@ _PARTIAL_STATE_CV: contextvars.ContextVar[dict[str, bool] | None] = (
 # read by ``tool_span``'s except branch to call ``evict_filelock``. Kept
 # as a CV instead of a positional arg so the wide call surface of
 # ``tool_span`` does not need to change.
-_VAULT_FOR_EVICTION_CV: contextvars.ContextVar[Path | None] = (
-    contextvars.ContextVar("_VAULT_FOR_EVICTION", default=None)
+_VAULT_FOR_EVICTION_CV: contextvars.ContextVar[Path | None] = contextvars.ContextVar(
+    "_VAULT_FOR_EVICTION", default=None
 )
 
 # Tools that opt in to partial-state response formatting. Read-path tools
@@ -130,6 +127,7 @@ def project_not_found(project: str) -> str:
     """Standard error string for unresolvable project slugs."""
     return f"Project '{project}' not found in vault."
 
+
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, idempotentHint=True)
 _WRITE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False)
 
@@ -159,6 +157,7 @@ def _default_scopes() -> dict[str, str]:
     from hive.config import settings
 
     return settings.vault_scopes
+
 
 _FENCED_CODE_RE = re.compile(
     r"(?ms)^(?P<fence>`{3,}|~{3,})[^\n]*\n.*?^(?P=fence)[^\n]*$",
@@ -252,6 +251,7 @@ def find_lesson_heading(content: str, line_no: int) -> str | None:
             return m.group(1)
     return None
 
+
 _VAULT_NOT_FOUND_MSG = (
     "Vault not found at {path}.\n\n"
     "Set the vault path when registering the MCP server:\n\n"
@@ -296,7 +296,9 @@ def _parse_project_ref(project: str) -> tuple[str | None, str]:
 
 
 def _resolve_project_dir(
-    vault: Path, project: str, scopes: dict[str, str],
+    vault: Path,
+    project: str,
+    scopes: dict[str, str],
 ) -> tuple[Path, str] | None:
     """Resolve a project slug to (directory, scope_name).
 
@@ -348,7 +350,10 @@ def _resolve_project_dir(
 
 
 def _search_scope(
-    scope_dir: Path, slug: str, scope_name: str, vault: Path,
+    scope_dir: Path,
+    slug: str,
+    scope_name: str,
+    vault: Path,
 ) -> tuple[Path, str] | None:
     """Search for a slug within a scope directory.
 
@@ -616,14 +621,9 @@ def format_io_error(exc: BaseException, path: object, action: str) -> str:
             "Check the path is correct and the parent directory exists."
         )
     if isinstance(exc, IsADirectoryError):
-        return (
-            f"Cannot {action} '{path}': target is a directory, expected a file."
-        )
+        return f"Cannot {action} '{path}': target is a directory, expected a file."
     if isinstance(exc, UnicodeDecodeError):
-        return (
-            f"Cannot read '{path}': file is not valid UTF-8 "
-            "(hive only supports UTF-8 markdown)."
-        )
+        return f"Cannot read '{path}': file is not valid UTF-8 (hive only supports UTF-8 markdown)."
     if isinstance(exc, OSError):
         errno = exc.errno or "?"
         strerror = exc.strerror or str(exc)
@@ -647,7 +647,11 @@ def _safe_read(f: Path) -> str | None:
 
 
 def track(
-    ctx: ServerContext, tool: str, result: str, project: str = "", section: str = "",
+    ctx: ServerContext,
+    tool: str,
+    result: str,
+    project: str = "",
+    section: str = "",
 ) -> str:
     """Log a tool call and return the result unchanged."""
     ctx.tracker.log_call(tool, project, len(result.splitlines()))
@@ -670,9 +674,9 @@ _WRITE_LOCK = threading.Lock()
 # thread sees the same list the async supervisor will iterate).
 # Default ``None`` = legacy unsupervised call (e.g. ``_git_log`` /
 # ``_git_recent`` read paths that retain ``subprocess.run`` per m1).
-_GIT_REGISTRY_CV: contextvars.ContextVar[
-    list[subprocess.Popen[bytes]] | None
-] = contextvars.ContextVar("_GIT_REGISTRY", default=None)
+_GIT_REGISTRY_CV: contextvars.ContextVar[list[subprocess.Popen[bytes]] | None] = (
+    contextvars.ContextVar("_GIT_REGISTRY", default=None)
+)
 
 
 _GIT_LOCK_WAIT_HISTORY: deque[int] = deque(maxlen=100)
@@ -967,7 +971,8 @@ def evict_filelock(vault_path: Path) -> bool:
 
 @asynccontextmanager
 async def tool_span(
-    tool_name: str, timeout_seconds: float,
+    tool_name: str,
+    timeout_seconds: float,
 ) -> AsyncIterator[None]:
     """Enforce a hard deadline AND register a Popen kill-set for the body.
 
@@ -1022,13 +1027,19 @@ async def tool_span(
                 "%s timed out after %.1fs (deadline %.0fs); killed %d "
                 "subprocess(es) "
                 "[mcp.tool_span.deadline_exceeded killed_pids=%s]",
-                tool_name, elapsed, timeout_seconds, len(killed), killed,
+                tool_name,
+                elapsed,
+                timeout_seconds,
+                len(killed),
+                killed,
             )
             # HIVE-116 AC-1: cooperative filelock eviction
             vault_for_eviction = _VAULT_FOR_EVICTION_CV.get()
             if vault_for_eviction is not None and killed:
                 await _drain_and_evict(
-                    vault_for_eviction, killed, tool_name,
+                    vault_for_eviction,
+                    killed,
+                    tool_name,
                 )
             raise
         else:
@@ -1063,21 +1074,27 @@ async def _drain_and_evict(
             _log.info(
                 "mcp.lock_eviction lock=_git_filelock vault=%s "
                 "killed_pids=%s drain_s=%.1f tool=%s cancelled=true",
-                vault_path, killed_pids, drain_s, tool_name,
+                vault_path,
+                killed_pids,
+                drain_s,
+                tool_name,
             )
         raise
     evicted = evict_filelock(vault_path)
     if evicted:
         _log.info(
-            "mcp.lock_eviction lock=_git_filelock vault=%s "
-            "killed_pids=%s drain_s=%.1f tool=%s",
-            vault_path, killed_pids, drain_s, tool_name,
+            "mcp.lock_eviction lock=_git_filelock vault=%s killed_pids=%s drain_s=%.1f tool=%s",
+            vault_path,
+            killed_pids,
+            drain_s,
+            tool_name,
         )
         _record_lock_eviction(vault_path, killed_pids)
 
 
 def _record_lock_eviction(
-    vault_path: Path, killed_pids: list[int],
+    vault_path: Path,
+    killed_pids: list[int],
 ) -> None:
     """Persist the eviction event for vault_health telemetry (T-2.5).
 
@@ -1168,10 +1185,12 @@ async def run_sync_tool(
             and state.get("disk_write_done")
         ):
             return _PARTIAL_STATE_TIMEOUT_FMT.format(
-                tool=tool_name, timeout=timeout_seconds,
+                tool=tool_name,
+                timeout=timeout_seconds,
             )
         return _GENERIC_TIMEOUT_FMT.format(
-            tool=tool_name, timeout=timeout_seconds,
+            tool=tool_name,
+            timeout=timeout_seconds,
         )
     finally:
         if state_token is not None:
@@ -1179,7 +1198,8 @@ async def run_sync_tool(
 
 
 def wrap_sync_tool(
-    ctx: ServerContext, tool_name: str,
+    ctx: ServerContext,
+    tool_name: str,
 ) -> Callable[[Callable[..., str]], Callable[..., object]]:
     """Decorator: convert a sync MCP tool handler into async-with-timeout.
 
@@ -1210,14 +1230,15 @@ def wrap_sync_tool(
         @functools.wraps(fn)
         async def wrapper(*args: object, **kwargs: object) -> str:
             vault_token: contextvars.Token[Path | None] | None = None
-            if (
-                tool_name in _PARTIAL_STATE_TOOLS
-                and ctx.vault.is_dir()
-            ):
+            if tool_name in _PARTIAL_STATE_TOOLS and ctx.vault.is_dir():
                 vault_token = _VAULT_FOR_EVICTION_CV.set(ctx.vault)
             try:
                 return await run_sync_tool(
-                    tool_name, ctx.tool_timeout, fn, *args, **kwargs,
+                    tool_name,
+                    ctx.tool_timeout,
+                    fn,
+                    *args,
+                    **kwargs,
                 )
             finally:
                 if vault_token is not None:
@@ -1290,11 +1311,7 @@ def _run_git(
                 # Best-effort drain of whatever the kernel buffered before
                 # the kill. Failures here are unrecoverable.
                 stdout_b, stderr_b = proc.communicate()
-        rc = (
-            proc.returncode
-            if proc.returncode is not None
-            else RC_EXTERNAL_TERMINATION
-        )
+        rc = proc.returncode if proc.returncode is not None else RC_EXTERNAL_TERMINATION
         # HIVE-116 AC-3: an external-termination rc must be remapped from
         # whatever the OS reported (Linux SIGTERM = -15, Windows = 1) to
         # our named sentinel so callers can predicate on the constant. The
@@ -1316,7 +1333,9 @@ def _run_git(
 
 
 def _git_commit(
-    vault_path: Path, rel_paths: list[Path], message: str,
+    vault_path: Path,
+    rel_paths: list[Path],
+    message: str,
 ) -> None:
     """Stage one or more files and commit them in a single git invocation.
 
@@ -1354,7 +1373,8 @@ def _git_commit(
     if not _acquire_with_telemetry(_GIT_LOCK, "_GIT_LOCK"):
         _log.warning(
             "git commit skipped for %s: thread lock timeout (%ds)",
-            path_strs, _lock_timeout(),
+            path_strs,
+            _lock_timeout(),
         )
         return
     try:
@@ -1362,42 +1382,44 @@ def _git_commit(
             with _filelock_with_telemetry(_git_filelock(vault_path), "_git_filelock"):
                 rc, _, err = _run_git(["add", *path_strs], vault_path)
                 if rc != 0:
-                    cause = (
-                        "external_termination"
-                        if rc == RC_EXTERNAL_TERMINATION
-                        else "git_error"
-                    )
+                    cause = "external_termination" if rc == RC_EXTERNAL_TERMINATION else "git_error"
                     _log.warning(
                         "git add failed for %s rc=%s cause=%s err=%s",
-                        path_strs, rc, cause, err.strip(),
+                        path_strs,
+                        rc,
+                        cause,
+                        err.strip(),
                     )
                     return
                 rc, _, err = _run_git(["commit", "-m", safe_msg], vault_path)
                 if rc != 0:
-                    cause = (
-                        "external_termination"
-                        if rc == RC_EXTERNAL_TERMINATION
-                        else "git_error"
-                    )
+                    cause = "external_termination" if rc == RC_EXTERNAL_TERMINATION else "git_error"
                     _log.warning(
                         "git commit failed for %s rc=%s cause=%s err=%s",
-                        path_strs, rc, cause, err.strip(),
+                        path_strs,
+                        rc,
+                        cause,
+                        err.strip(),
                     )
         except filelock.Timeout:
             _log.warning(
                 "git commit skipped for %s: inter-process lock timeout (%ds)",
-                path_strs, _lock_timeout(),
+                path_strs,
+                _lock_timeout(),
             )
         except Exception as exc:
             _log.warning(
-                "git commit unexpected error for %s: %s", path_strs, exc,
+                "git commit unexpected error for %s: %s",
+                path_strs,
+                exc,
             )
     finally:
         _GIT_LOCK.release()
 
 
 def _git_commit_all(
-    vault_path: Path, message: str,
+    vault_path: Path,
+    message: str,
 ) -> tuple[str, str]:
     """Stage every change in the vault and create one commit.
 
@@ -1416,12 +1438,11 @@ def _git_commit_all(
         try:
             with _filelock_with_telemetry(_git_filelock(vault_path), "_git_filelock"):
                 rc, porcelain_out, porcelain_err = _run_git(
-                    ["status", "--porcelain"], vault_path,
+                    ["status", "--porcelain"],
+                    vault_path,
                 )
                 if rc != 0:
-                    return "error", (
-                        f"git status rc={rc}: {porcelain_err.strip() or '<empty>'}"
-                    )
+                    return "error", (f"git status rc={rc}: {porcelain_err.strip() or '<empty>'}")
                 if not porcelain_out.strip():
                     return "clean", ""
                 rc, _, err = _run_git(["add", "-A"], vault_path)
@@ -1476,7 +1497,8 @@ def _is_external_committer_healthy(
     except Exception as exc:  # noqa: BLE001
         _log.debug(
             "mcp.detect_and_defer.git_log_failed vault=%s exc=%s",
-            vault_path, exc,
+            vault_path,
+            exc,
         )
         return False
     try:
@@ -1498,7 +1520,8 @@ def _is_external_committer_healthy(
     except Exception as exc:  # noqa: BLE001
         _log.debug(
             "mcp.detect_and_defer.git_status_failed vault=%s exc=%s",
-            vault_path, exc,
+            vault_path,
+            exc,
         )
         return False
     return porcelain.returncode == 0 and porcelain.stdout.strip() == ""
@@ -1538,9 +1561,7 @@ def _vault_write_deferral_suffix(
 
     if not _should_defer_to_external_committer(vault_path):
         return ""
-    return (
-        " (deferred to obsidian-git; will be picked up on its next tick)"
-    )
+    return " (deferred to obsidian-git; will be picked up on its next tick)"
 
 
 def detect_obsidian_git(vault_path: Path) -> dict[str, int] | None:
@@ -1596,9 +1617,13 @@ def _current_head_sha(vault_path: Path) -> str:
     if head_text.startswith("ref:"):
         ref = head_text.split(":", 1)[1].strip()
         try:
-            return (vault_path / ".git" / ref).read_text(
-                encoding="utf-8",
-            ).strip()
+            return (
+                (vault_path / ".git" / ref)
+                .read_text(
+                    encoding="utf-8",
+                )
+                .strip()
+            )
         except OSError:
             return ""
     return head_text  # already a detached SHA
@@ -1618,10 +1643,7 @@ def _git_log(vault_path: Path, n: int) -> str:
             entry = _git_log_cache.get(key)
             if entry is not None:
                 cached_at, cached_sha, value = entry
-                if (
-                    cached_sha == sha
-                    and time.monotonic() - cached_at < _GIT_CACHE_TTL_S
-                ):
+                if cached_sha == sha and time.monotonic() - cached_at < _GIT_CACHE_TTL_S:
                     return value
     try:
         result = subprocess.run(
@@ -1654,15 +1676,11 @@ def _git_recent(vault_path: Path, since_days: int) -> list[str]:
             entry = _git_recent_cache.get(key)
             if entry is not None:
                 cached_at, cached_sha, value = entry
-                if (
-                    cached_sha == sha
-                    and time.monotonic() - cached_at < _GIT_CACHE_TTL_S
-                ):
+                if cached_sha == sha and time.monotonic() - cached_at < _GIT_CACHE_TTL_S:
                     return list(value)
     try:
         result = subprocess.run(
-            ["git", "log", f"--since={since_days} days ago",
-             "--name-only", "--pretty=format:"],
+            ["git", "log", f"--since={since_days} days ago", "--name-only", "--pretty=format:"],
             cwd=vault_path,
             capture_output=True,
             text=True,
@@ -1672,10 +1690,9 @@ def _git_recent(vault_path: Path, since_days: int) -> list[str]:
         return []
     if result.returncode != 0:
         return []
-    value = sorted({
-        line.strip() for line in result.stdout.splitlines()
-        if line.strip().endswith(".md")
-    })
+    value = sorted(
+        {line.strip() for line in result.stdout.splitlines() if line.strip().endswith(".md")}
+    )
     if sha:
         with _GIT_CACHE_LOCK:
             _git_recent_cache[key] = (time.monotonic(), sha, value)
@@ -1735,7 +1752,8 @@ def count_stale_from(
 
 
 def count_stale(
-    project_dir: Path, threshold: date,
+    project_dir: Path,
+    threshold: date,
 ) -> list[str]:
     """Return list of stale file paths in a project directory.
 

--- a/src/hive/_idempotency.py
+++ b/src/hive/_idempotency.py
@@ -57,8 +57,7 @@ class IdempotencyStore(_SqliteTracker):
         iso = _dt.datetime.now(_dt.UTC).isoformat(timespec="microseconds")
         with self._lock:
             cur = self._conn.execute(
-                "INSERT OR IGNORE INTO applied_keys (idem_key, applied_iso) "
-                "VALUES (?, ?)",
+                "INSERT OR IGNORE INTO applied_keys (idem_key, applied_iso) VALUES (?, ?)",
                 (key, iso),
             )
             self._conn.commit()
@@ -74,6 +73,7 @@ class IdempotencyStore(_SqliteTracker):
         """
         with self._lock:
             self._conn.execute(
-                "DELETE FROM applied_keys WHERE idem_key = ?", (key,),
+                "DELETE FROM applied_keys WHERE idem_key = ?",
+                (key,),
             )
             self._conn.commit()

--- a/src/hive/_lesson_reinforcement.py
+++ b/src/hive/_lesson_reinforcement.py
@@ -92,8 +92,7 @@ CREATE TABLE IF NOT EXISTS lesson_reinforcement (
         )
         self._outbox: Outbox[tuple[str, str]] = Outbox()
         self._outbox_tick_s = (
-            outbox_tick_s if outbox_tick_s is not None
-            else _default_outbox_tick_s()
+            outbox_tick_s if outbox_tick_s is not None else _default_outbox_tick_s()
         )
         self._stop_reconciler = threading.Event()
         self._reconciler_thread: threading.Thread | None = None
@@ -165,17 +164,15 @@ CREATE TABLE IF NOT EXISTS lesson_reinforcement (
                 "  reinforcements = reinforcements + 1, "
                 "  confidence = MIN(1.0, confidence + ? * (1.0 - confidence)), "
                 "  last_referenced = date('now')",
-                [
-                    (project, heading, bumped, _GROWTH_RATE)
-                    for project, heading in pending
-                ],
+                [(project, heading, bumped, _GROWTH_RATE) for project, heading in pending],
             )
             target.commit()
         except sqlite3.OperationalError as exc:
             # Lock contention or other operational issue — re-queue.
             _log.warning(
                 "mcp.lesson_reconciler.flush_blocked entries=%d exc=%s",
-                len(pending), exc,
+                len(pending),
+                exc,
             )
             self._outbox.extend(pending)
             raise
@@ -218,7 +215,8 @@ CREATE TABLE IF NOT EXISTS lesson_reinforcement (
         except sqlite3.Error as exc:
             _log.warning(
                 "mcp.lesson_reconciler.connect_failed db=%s exc=%s",
-                self._db_path, exc,
+                self._db_path,
+                exc,
             )
             return
 
@@ -307,7 +305,9 @@ CREATE TABLE IF NOT EXISTS lesson_reinforcement (
         }
 
     def lookup(
-        self, project: str, headings: list[str],
+        self,
+        project: str,
+        headings: list[str],
     ) -> dict[str, dict[str, object]]:
         """Batch metadata fetch for a list of headings (for hybrid ranking)."""
         if not headings:
@@ -352,10 +352,7 @@ CREATE TABLE IF NOT EXISTS lesson_reinforcement (
             return self._top_by_confidence(project, limit)
         if by == "hybrid":
             return self._top_by_hybrid(project, limit, bm25_scores or {})
-        msg = (
-            f"Unknown rank_by={by!r}. Expected one of: "
-            f"reinforcements, confidence, hybrid."
-        )
+        msg = f"Unknown rank_by={by!r}. Expected one of: reinforcements, confidence, hybrid."
         raise ValueError(msg)
 
     def _top_by_counter(self, project: str, limit: int) -> list[str]:
@@ -385,21 +382,22 @@ CREATE TABLE IF NOT EXISTS lesson_reinforcement (
         return [row[0] for row in rows]
 
     def _top_by_hybrid(
-        self, project: str, limit: int, bm25_scores: dict[str, float],
+        self,
+        project: str,
+        limit: int,
+        bm25_scores: dict[str, float],
     ) -> list[str]:
         with self._lock:
             with contextlib.suppress(sqlite3.OperationalError):
                 self._flush_locked()
             rows = self._conn.execute(
-                "SELECT heading, confidence FROM lesson_reinforcement "
-                "WHERE project = ?",
+                "SELECT heading, confidence FROM lesson_reinforcement WHERE project = ?",
                 (project,),
             ).fetchall()
         scored = [
             (
                 heading,
-                _HYBRID_ALPHA * bm25_scores.get(heading, 0.0)
-                + (1.0 - _HYBRID_ALPHA) * confidence,
+                _HYBRID_ALPHA * bm25_scores.get(heading, 0.0) + (1.0 - _HYBRID_ALPHA) * confidence,
             )
             for heading, confidence in rows
         ]

--- a/src/hive/_lock_eviction.py
+++ b/src/hive/_lock_eviction.py
@@ -57,9 +57,9 @@ class LockEvictionTracker(_SqliteTracker):
 
     def count_last_30d(self) -> int:
         """Number of eviction events in the trailing 30 days."""
-        cutoff = (
-            _dt.datetime.now(_dt.UTC) - _dt.timedelta(days=30)
-        ).isoformat(timespec="microseconds")
+        cutoff = (_dt.datetime.now(_dt.UTC) - _dt.timedelta(days=30)).isoformat(
+            timespec="microseconds"
+        )
         with self._lock:
             cur = self._conn.execute(
                 "SELECT COUNT(*) FROM lock_evictions WHERE iso_ts >= ?",
@@ -72,8 +72,7 @@ class LockEvictionTracker(_SqliteTracker):
         """ISO-8601 timestamp of the most recent eviction, or None."""
         with self._lock:
             cur = self._conn.execute(
-                "SELECT iso_ts FROM lock_evictions "
-                "ORDER BY iso_ts DESC LIMIT 1",
+                "SELECT iso_ts FROM lock_evictions ORDER BY iso_ts DESC LIMIT 1",
             )
             row = cur.fetchone()
         return str(row[0]) if row else None

--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -67,19 +67,23 @@ def identity_block_text(ctx: ServerContext) -> str:
     )
     openrouter_present = ctx.openrouter is not None
     backends = (
-        '{"ollama": ' + ("true" if ollama_present else "false")
-        + ', "openrouter": ' + ("true" if openrouter_present else "false")
+        '{"ollama": '
+        + ("true" if ollama_present else "false")
+        + ', "openrouter": '
+        + ("true" if openrouter_present else "false")
         + "}"
     )
-    return "\n".join([
-        "## server",
-        f"- version: {_hive_version()}",
-        f"- python: {sys.version.split()[0]}",
-        f"- vault_path: {ctx.vault}",
-        f"- backends: {backends}",
-        f"- started_at: {ctx.started_at_iso}",
-        "",
-    ])
+    return "\n".join(
+        [
+            "## server",
+            f"- version: {_hive_version()}",
+            f"- python: {sys.version.split()[0]}",
+            f"- vault_path: {ctx.vault}",
+            f"- backends: {backends}",
+            f"- started_at: {ctx.started_at_iso}",
+            "",
+        ]
+    )
 
 
 def _registered_tool_names(mcp: FastMCP) -> list[str]:
@@ -97,7 +101,7 @@ def _registered_tool_names(mcp: FastMCP) -> list[str]:
         if not isinstance(key, str) or not key.startswith("tool:"):
             continue
         # key shape is `tool:<name>@<scope>` — strip both prefix and suffix.
-        rest = key[len("tool:"):]
+        rest = key[len("tool:") :]
         names.add(rest.split("@", 1)[0])
     return sorted(names)
 
@@ -140,8 +144,7 @@ def runtime_block_text(ctx: ServerContext, mcp: FastMCP) -> str:
     lines = [
         "## runtime",
         f"- uptime_s: {uptime_s:.1f}",
-        f"- tools_registered: {len(tools)} "
-        f"({', '.join(tools) if tools else '<empty>'})",
+        f"- tools_registered: {len(tools)} ({', '.join(tools) if tools else '<empty>'})",
         f"- wal_size_bytes: {wal_size}",
         f"- competing_pid_count: {competing}",
         "- last_git_lock_wait_ms:",
@@ -176,10 +179,7 @@ def _find_duplicate_names(scope_dir: Path) -> list[tuple[str, list[str]]]:
                 name_paths[d.name].append(rel)
     except OSError:
         return []
-    return [
-        (name, paths) for name, paths in sorted(name_paths.items())
-        if len(paths) > 1
-    ]
+    return [(name, paths) for name, paths in sorted(name_paths.items()) if len(paths) > 1]
 
 
 def health_report_text(ctx: ServerContext, filter_project: str = "") -> str:
@@ -212,15 +212,15 @@ def health_report_text(ctx: ServerContext, filter_project: str = "") -> str:
                 continue
             found_any = True
             md_files, contents, frontmatters = scan_project(project_dir)
-            total_lines = sum(
-                len(c.splitlines()) for c in contents.values() if c is not None
-            )
+            total_lines = sum(len(c.splitlines()) for c in contents.values() if c is not None)
             stale_files = count_stale_from(
-                project_dir, md_files, frontmatters, stale_threshold,
+                project_dir,
+                md_files,
+                frontmatters,
+                stale_threshold,
             )
             missing = [
-                s for s, fname in SECTION_SHORTCUTS.items()
-                if not (project_dir / fname).exists()
+                s for s, fname in SECTION_SHORTCUTS.items() if not (project_dir / fname).exists()
             ]
 
             lines.append(f"## {scope_name}/{project_dir.name}")
@@ -230,8 +230,7 @@ def health_report_text(ctx: ServerContext, filter_project: str = "") -> str:
                 lines.append(f"- Missing sections: {', '.join(missing)}")
             if stale_files:
                 lines.append(
-                    f"- Stale files (>{ctx.stale_days}d): "
-                    f"{', '.join(sorted(stale_files))}"
+                    f"- Stale files (>{ctx.stale_days}d): {', '.join(sorted(stale_files))}"
                 )
             lines.append("")
 
@@ -272,6 +271,7 @@ def health_report_text(ctx: ServerContext, filter_project: str = "") -> str:
 
     # ── Ghost-response counter (HIVE-104 Fase C + HIVE-115 PR-3 source) ──
     from hive._compat import GHOST_RESPONSES
+
     snap = GHOST_RESPONSES.snapshot()
     if isinstance(snap.get("total"), int) and snap["total"] > 0:  # type: ignore[operator]
         found_any = True
@@ -281,9 +281,7 @@ def health_report_text(ctx: ServerContext, filter_project: str = "") -> str:
         lines.append(f"- last_tool: {snap['last_tool'] or '<unknown>'}")
         by_source = snap.get("by_source")
         if isinstance(by_source, dict) and by_source:
-            breakdown = ", ".join(
-                f"{src}={count}" for src, count in sorted(by_source.items())
-            )
+            breakdown = ", ".join(f"{src}={count}" for src, count in sorted(by_source.items()))
             lines.append(f"- by_source: {breakdown}")
         lines.append(
             "- note: ErrorData ack does NOT imply rollback — verify state "
@@ -346,20 +344,23 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
             if unknown:
                 valid_names = ", ".join(sorted(_ALL_CHECKS))
                 return track(
-                    ctx, "vault_health",
-                    f"Unknown check(s): {', '.join(sorted(unknown))}. "
-                    f"Valid: {valid_names}",
+                    ctx,
+                    "vault_health",
+                    f"Unknown check(s): {', '.join(sorted(unknown))}. Valid: {valid_names}",
                     project,
                 )
 
             project_dirs: list[tuple[Path, str]] = []
             if project:
                 resolved = _resolve_project_dir(
-                    ctx.vault, project, ctx.scopes,
+                    ctx.vault,
+                    project,
+                    ctx.scopes,
                 )
                 if resolved is None:
                     return track(
-                        ctx, "vault_health",
+                        ctx,
+                        "vault_health",
                         project_not_found(project),
                         project,
                     )
@@ -383,7 +384,9 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
 
             if not project_dirs:
                 return track(
-                    ctx, "vault_health", "No projects found in vault.",
+                    ctx,
+                    "vault_health",
+                    "No projects found in vault.",
                 )
 
             all_stems: set[str] = set()
@@ -405,9 +408,7 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                         continue
                     all_stems.add(f.stem)
                     with contextlib.suppress(ValueError):
-                        vault_rel = (
-                            f.relative_to(ctx.vault).with_suffix("").as_posix()
-                        )
+                        vault_rel = f.relative_to(ctx.vault).with_suffix("").as_posix()
                         all_paths.add(vault_rel)
                         if "/" in vault_rel:
                             leading, rest = vault_rel.split("/", 1)
@@ -433,21 +434,17 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                     content = _safe_read(f)
                     if content is None:
                         issues.append(
-                            f"[error] {proj_name}/{rel}: "
-                            "File unreadable (I/O or encoding error)",
+                            f"[error] {proj_name}/{rel}: File unreadable (I/O or encoding error)",
                         )
                         continue
 
                     fm = parse_frontmatter(content)
-                    in_memory_dir = "memory" in (
-                        f.relative_to(project_dir).parts
-                    )
+                    in_memory_dir = "memory" in (f.relative_to(project_dir).parts)
 
                     if "frontmatter" in active_checks and not in_memory_dir:
                         if fm is None:
                             issues.append(
-                                f"[error] {proj_name}/{rel}: "
-                                "Missing or invalid frontmatter"
+                                f"[error] {proj_name}/{rel}: Missing or invalid frontmatter"
                             )
                             continue
                         missing_fields = {"id", "type", "status"} - fm.raw.keys()
@@ -459,8 +456,7 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                             )
                         if fm.created and parse_date(fm.created) is None:
                             issues.append(
-                                f"[warning] {proj_name}/{rel}: "
-                                f"Unparseable date: '{fm.created}'"
+                                f"[warning] {proj_name}/{rel}: Unparseable date: '{fm.created}'"
                             )
 
                     if (
@@ -468,25 +464,21 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                         and fm is not None
                         and fm.status not in _TERMINAL_STATUSES
                     ):
-                            created_date = (
-                                parse_date(fm.created)
-                                if fm.created
-                                else None
-                            )
-                            if created_date is None:
-                                try:
-                                    created_date = date.fromtimestamp(
-                                        f.stat().st_mtime,
-                                    )
-                                except OSError:
-                                    continue
-                            if created_date < stale_threshold:
-                                issues.append(
-                                    f"[warning] {proj_name}/{rel}: "
-                                    f"Stale (active since "
-                                    f"{created_date.isoformat()}, "
-                                    f">{ctx.stale_days}d)"
+                        created_date = parse_date(fm.created) if fm.created else None
+                        if created_date is None:
+                            try:
+                                created_date = date.fromtimestamp(
+                                    f.stat().st_mtime,
                                 )
+                            except OSError:
+                                continue
+                        if created_date < stale_threshold:
+                            issues.append(
+                                f"[warning] {proj_name}/{rel}: "
+                                f"Stale (active since "
+                                f"{created_date.isoformat()}, "
+                                f">{ctx.stale_days}d)"
+                            )
 
                     if "links" in active_checks:
                         body = _strip_code(extract_body(content))
@@ -494,13 +486,9 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                             target = m.group(1).strip().rstrip("\\").strip()
                             if _POSIX_CLASS_RE.match(target):
                                 continue
-                            if (
-                                target not in all_stems
-                                and target not in all_paths
-                            ):
+                            if target not in all_stems and target not in all_paths:
                                 issues.append(
-                                    f"[warning] {proj_name}/{rel}: "
-                                    f"Broken link [[{target}]]"
+                                    f"[warning] {proj_name}/{rel}: Broken link [[{target}]]"
                                 )
                                 if len(issues) >= max_issues:
                                     break
@@ -516,20 +504,11 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
                     f"({', '.join(sorted(active_checks))})."
                 )
             else:
-                errors = sum(
-                    1 for i in issues if i.startswith("[error]")
-                )
-                warnings = sum(
-                    1 for i in issues if i.startswith("[warning]")
-                )
-                header = (
-                    f"Found {len(issues)} issues "
-                    f"({errors} errors, {warnings} warnings)"
-                )
+                errors = sum(1 for i in issues if i.startswith("[error]"))
+                warnings = sum(1 for i in issues if i.startswith("[warning]"))
+                header = f"Found {len(issues)} issues ({errors} errors, {warnings} warnings)"
                 if len(issues) >= max_issues:
-                    header += (
-                        f" — truncated at {max_issues}, more may exist"
-                    )
+                    header += f" — truncated at {max_issues}, more may exist"
                 validate_lines = [header, ""]
                 validate_lines.extend(issues)
                 parts.append("\n".join(validate_lines))
@@ -537,19 +516,14 @@ def register_vault_health(mcp: FastMCP, ctx: ServerContext) -> None:
         if include_usage:
             stats = ctx.tracker.stats(usage_days)
             if stats["total_calls"] == 0:
-                parts.append(
-                    f"\nNo vault tool calls recorded "
-                    f"in the last {usage_days} days."
-                )
+                parts.append(f"\nNo vault tool calls recorded in the last {usage_days} days.")
             else:
                 usage_parts: list[str] = [
                     f"\n# Vault Usage (last {usage_days} days)",
                     "",
                     f"- Total calls: {stats['total_calls']}",
-                    f"- Total response lines: "
-                    f"{stats['total_response_lines']}",
-                    f"- Estimated tokens served: "
-                    f"~{stats['total_response_lines'] * 10}",
+                    f"- Total response lines: {stats['total_response_lines']}",
+                    f"- Estimated tokens served: ~{stats['total_response_lines'] * 10}",
                     "",
                 ]
                 if stats["by_tool"]:

--- a/src/hive/_vault_read.py
+++ b/src/hive/_vault_read.py
@@ -83,13 +83,12 @@ def _vault_search_by_rank(
         if per_heading_hits:
             # Normalise raw hit counts to [0, 1] per project for hybrid blend.
             max_h = max(per_heading_hits.values())
-            bm25_per_project[project_slug] = {
-                h: cnt / max_h for h, cnt in per_heading_hits.items()
-            }
+            bm25_per_project[project_slug] = {h: cnt / max_h for h, cnt in per_heading_hits.items()}
 
     if not hits:
         return track(
-            ctx, "vault_search",
+            ctx,
+            "vault_search",
             f"No lessons found for '{query}'.",
         )
 
@@ -103,7 +102,9 @@ def _vault_search_by_rank(
         relevant_headings = {h for p, h in hits if p == project_slug}
         bm25_scores = bm25_per_project.get(project_slug, {})
         ranked = ctx.lessons.top(
-            project_slug, by=rank_by, limit=len(relevant_headings),
+            project_slug,
+            by=rank_by,
+            limit=len(relevant_headings),
             bm25_scores=bm25_scores,
         )
         ordered = [h for h in ranked if h in relevant_headings]
@@ -135,8 +136,7 @@ def list_projects_text(ctx: ServerContext) -> str:
         for project_dir in projects:
             found_any = True
             sections = [
-                s for s, filename in SECTION_SHORTCUTS.items()
-                if (project_dir / filename).exists()
+                s for s, filename in SECTION_SHORTCUTS.items() if (project_dir / filename).exists()
             ]
             try:
                 md_count = len(list(project_dir.rglob("*.md")))
@@ -185,8 +185,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
 
         resolved = _resolve_project_dir(ctx.vault, project, ctx.scopes)
         if resolved is None:
-            return track(ctx, "vault_list",
-                         project_not_found(project), project)
+            return track(ctx, "vault_list", project_not_found(project), project)
         project_dir, _ = resolved
 
         from hive._helpers import _check_path_boundary
@@ -196,9 +195,9 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         if boundary_error:
             return track(ctx, "vault_list", boundary_error, project)
         if not target.is_dir():
-            return track(ctx, "vault_list",
-                         f"Path '{path}' not found in project '{project}'.",
-                         project)
+            return track(
+                ctx, "vault_list", f"Path '{path}' not found in project '{project}'.", project
+            )
 
         lines: list[str] = [
             f"# Files: {project}/{path}" if path else f"# Files: {project}",
@@ -209,25 +208,28 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         if pattern:
             if ".." in pattern:
                 return track(
-                    ctx, "vault_list",
+                    ctx,
+                    "vault_list",
                     "Pattern must not contain '..'.",
                     project,
                 )
             try:
                 files = sorted(
-                    f for f in target.rglob(pattern)
-                    if f.is_file()
-                    and _check_path_boundary(f, ctx.vault) is None
+                    f
+                    for f in target.rglob(pattern)
+                    if f.is_file() and _check_path_boundary(f, ctx.vault) is None
                 )
             except OSError:
                 return track(
-                    ctx, "vault_list",
+                    ctx,
+                    "vault_list",
                     f"Error reading directory for pattern '{pattern}'.",
                     project,
                 )
             if not files:
                 return track(
-                    ctx, "vault_list",
+                    ctx,
+                    "vault_list",
                     f"No files matching '{pattern}' in {project}/{path}.",
                     project,
                 )
@@ -239,7 +241,8 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
                 entries = sorted(target.iterdir())
             except OSError:
                 return track(
-                    ctx, "vault_list",
+                    ctx,
+                    "vault_list",
                     f"Error reading directory '{path or project}'.",
                     project,
                 )
@@ -289,9 +292,11 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             content = filepath.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:
             return track(
-                ctx, "vault_query",
+                ctx,
+                "vault_query",
                 format_io_error(exc, resolved_section, "read"),
-                project, resolved_section,
+                project,
+                resolved_section,
             )
 
         if include_metadata:
@@ -306,8 +311,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             for heading in dict.fromkeys(extract_lesson_headings(truncated)):
                 ctx.lessons.increment(project, heading)
 
-        return track(ctx, "vault_query", truncated,
-                     project, resolved_section)
+        return track(ctx, "vault_query", truncated, project, resolved_section)
 
     @mcp.tool(annotations=_READ_ONLY)
     @wrap_sync_tool(ctx, "vault_search")
@@ -359,10 +363,13 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             return track(ctx, "vault_search", guard)
 
         if rank_by != "bm25" and rank_by not in {
-            "reinforcements", "confidence", "hybrid",
+            "reinforcements",
+            "confidence",
+            "hybrid",
         }:
             return track(
-                ctx, "vault_search",
+                ctx,
+                "vault_search",
                 f"Unknown rank_by={rank_by!r}. Expected one of: "
                 f"bm25, reinforcements, confidence, hybrid.",
             )
@@ -374,19 +381,23 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             if scope_dir_name is None:
                 available = ", ".join(sorted(ctx.scopes.keys()))
                 return track(
-                    ctx, "vault_search",
+                    ctx,
+                    "vault_search",
                     f"Unknown scope '{scope}'. Available: {available}",
                 )
             search_root = ctx.vault / scope_dir_name
             if not search_root.is_dir():
                 return track(
-                    ctx, "vault_search",
+                    ctx,
+                    "vault_search",
                     f"Scope directory '{scope_dir_name}' not found in vault.",
                 )
 
         if since_days < 0:
             return track(
-                ctx, "vault_search", "since_days must be a positive number.",
+                ctx,
+                "vault_search",
+                "since_days must be a positive number.",
             )
 
         # ── Recent mode ──
@@ -411,28 +422,27 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
 
             if project:
                 resolved = _resolve_project_dir(
-                    ctx.vault, project, ctx.scopes,
+                    ctx.vault,
+                    project,
+                    ctx.scopes,
                 )
                 if resolved is not None:
-                    prefix = (
-                        resolved[0].relative_to(ctx.vault).as_posix()
-                        + "/"
-                    )
-                    git_paths = {
-                        p for p in git_paths if p.startswith(prefix)
-                    }
+                    prefix = resolved[0].relative_to(ctx.vault).as_posix() + "/"
+                    git_paths = {p for p in git_paths if p.startswith(prefix)}
                 else:
                     git_paths = set()
 
             if not git_paths:
                 return track(
-                    ctx, "vault_search",
+                    ctx,
+                    "vault_search",
                     f"No changes found in the last {since_days} days.",
                     project,
                 )
 
             rlines: list[str] = [
-                f"# Recent Changes (last {since_days} days)", "",
+                f"# Recent Changes (last {since_days} days)",
+                "",
             ]
             for rel_path in sorted(git_paths):
                 full = ctx.vault / rel_path
@@ -453,14 +463,19 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
 
             output = "\n".join(rlines)
             return track(
-                ctx, "vault_search", _truncate(output, max_lines), project,
+                ctx,
+                "vault_search",
+                _truncate(output, max_lines),
+                project,
             )
 
         # ── Ranked mode ──
         if ranked:
             if not query:
                 return track(
-                    ctx, "vault_search", "Query is required for ranked search.",
+                    ctx,
+                    "vault_search",
+                    "Query is required for ranked search.",
                 )
             query_lower = query.lower()
             today = date.today()
@@ -471,11 +486,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
                 if content is None:
                     continue
                 body = extract_body(content)
-                matching = [
-                    ln.strip()
-                    for ln in body.splitlines()
-                    if query_lower in ln.lower()
-                ]
+                matching = [ln.strip() for ln in body.splitlines() if query_lower in ln.lower()]
                 if not matching:
                     continue
                 fm = parse_frontmatter(content)
@@ -486,7 +497,8 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
 
             if not scored:
                 return track(
-                    ctx, "vault_search",
+                    ctx,
+                    "vault_search",
                     f"No matches found for '{query}'.",
                 )
 
@@ -494,7 +506,8 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             scored = scored[:max_results]
 
             results: list[str] = [
-                f"# Ranked Search: '{query}'", "",
+                f"# Ranked Search: '{query}'",
+                "",
             ]
             for score, rel, meta, matching in scored:
                 meta_part = f" [{meta}]" if meta else ""
@@ -506,37 +519,48 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
 
             output = "\n".join(results)
             return track(
-                ctx, "vault_search", _truncate(output, max_lines),
+                ctx,
+                "vault_search",
+                _truncate(output, max_lines),
             )
 
         # ── rank_by mode (HIVE-97) — lessons-only ranked by usage signal ──
         if rank_by != "bm25":
             if not query:
                 return track(
-                    ctx, "vault_search",
+                    ctx,
+                    "vault_search",
                     f"Query is required for rank_by={rank_by!r} search.",
                 )
             return _vault_search_by_rank(
-                ctx, search_root, query, rank_by, max_lines,
+                ctx,
+                search_root,
+                query,
+                rank_by,
+                max_lines,
             )
 
         # ── Standard search ──
         if not query:
             return track(
-                ctx, "vault_search", "Query is required for search.",
+                ctx,
+                "vault_search",
+                "Query is required for search.",
             )
 
         if use_regex:
             if len(query) > 200:
                 return track(
-                    ctx, "vault_search",
+                    ctx,
+                    "vault_search",
                     "Regex pattern too long (max 200 chars).",
                 )
             try:
                 rx_pattern = re.compile(query, re.IGNORECASE)
             except re.error as exc:
                 return track(
-                    ctx, "vault_search",
+                    ctx,
+                    "vault_search",
                     f"Invalid regex '{query}': {exc}",
                 )
 
@@ -564,15 +588,11 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             body = extract_body(content)
             if use_regex:
                 matching_lines = [
-                    line.strip()
-                    for line in body.splitlines()
-                    if rx_pattern.search(line)
+                    line.strip() for line in body.splitlines() if rx_pattern.search(line)
                 ]
             else:
                 matching_lines = [
-                    line.strip()
-                    for line in body.splitlines()
-                    if query_lower in line.lower()
+                    line.strip() for line in body.splitlines() if query_lower in line.lower()
                 ]
             if matching_lines:
                 file_rel = md_file.relative_to(ctx.vault)
@@ -584,7 +604,9 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
 
         if not flat_results:
             return track(
-                ctx, "vault_search", f"No matches found for '{query}'.",
+                ctx,
+                "vault_search",
+                f"No matches found for '{query}'.",
             )
 
         output = f"# Search: '{query}'\n\n" + "\n".join(flat_results)
@@ -620,8 +642,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
 
         resolved = _resolve_project_dir(ctx.vault, project, ctx.scopes)
         if resolved is None:
-            return track(ctx, "session_briefing",
-                         project_not_found(project), project)
+            return track(ctx, "session_briefing", project_not_found(project), project)
         project_dir, _ = resolved
 
         # Decay stale relevance scores at session start
@@ -641,7 +662,11 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
 
         # Lessons
         lessons_result = _resolve_file(
-            ctx.vault, project, "lessons", "", ctx.scopes,
+            ctx.vault,
+            project,
+            "lessons",
+            "",
+            ctx.scopes,
         )
         if not isinstance(lessons_result, str):
             lessons_content = _safe_read(lessons_result)
@@ -658,9 +683,14 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         # Health (always shown, not ranked) — single project scan reused.
         md_files, _, frontmatters = scan_project(project_dir)
         stale_threshold = date.today() - timedelta(days=ctx.stale_days)
-        stale_count = len(count_stale_from(
-            project_dir, md_files, frontmatters, stale_threshold,
-        ))
+        stale_count = len(
+            count_stale_from(
+                project_dir,
+                md_files,
+                frontmatters,
+                stale_threshold,
+            )
+        )
         health_lines = [f"- Files: {len(md_files)}"]
         if stale_count:
             health_lines.append(f"- Stale: {stale_count}")
@@ -671,7 +701,9 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         scores = ctx.relevance.get_scores(project)
         if scores:
             ranked_sections = sorted(
-                sections.keys(), key=lambda s: scores.get(s, 0.0), reverse=True,
+                sections.keys(),
+                key=lambda s: scores.get(s, 0.0),
+                reverse=True,
             )
         else:
             ranked_sections = [s for s in default_order if s in sections]

--- a/src/hive/_vault_write.py
+++ b/src/hive/_vault_write.py
@@ -53,9 +53,7 @@ def _env_truthy(value: str | None) -> bool:
     return value.strip().lower() in {"true", "yes", "1", "on"}
 
 
-_DEFERRED_SUFFIX = (
-    " (deferred to obsidian-git; will be picked up on its next tick)"
-)
+_DEFERRED_SUFFIX = " (deferred to obsidian-git; will be picked up on its next tick)"
 _UNCOMMITTED_SUFFIX = " (uncommitted — call vault_commit to flush)"
 
 # HIVE-116 AC-5: public contract for the partial-state response. Locked
@@ -137,9 +135,7 @@ def _should_defer_to_external_committer(vault_path: Path) -> bool:
     return _is_external_committer_healthy(vault_path, interval)
 
 
-_IDEMPOTENT_NOOP = (
-    "Idempotent no-op — idempotency_key already applied; no change written."
-)
+_IDEMPOTENT_NOOP = "Idempotent no-op — idempotency_key already applied; no change written."
 
 
 def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
@@ -187,15 +183,18 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
             return track(ctx, "vault_write", guard, project)
 
         if operation not in _WRITE_OPERATIONS:
-            return track(ctx, "vault_write", (
-                f"Invalid operation '{operation}'. "
-                f"Valid: {', '.join(sorted(_WRITE_OPERATIONS))}"
-            ), project)
+            return track(
+                ctx,
+                "vault_write",
+                (f"Invalid operation '{operation}'. Valid: {', '.join(sorted(_WRITE_OPERATIONS))}"),
+                project,
+            )
 
         resolved = _resolve_project_dir(ctx.vault, project, ctx.scopes)
         if resolved is None:
             return track(
-                ctx, "vault_write",
+                ctx,
+                "vault_write",
                 project_not_found(project),
                 project,
             )
@@ -205,13 +204,15 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
         if operation == "create":
             if not path:
                 return track(
-                    ctx, "vault_write",
+                    ctx,
+                    "vault_write",
                     "Path is required for create operation.",
                     project,
                 )
             if not doc_type:
                 return track(
-                    ctx, "vault_write",
+                    ctx,
+                    "vault_write",
                     "doc_type is required for create operation.",
                     project,
                 )
@@ -229,11 +230,15 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                         idempotency_key,
                     ):
                         return track(
-                            ctx, "vault_write", _IDEMPOTENT_NOOP, project,
+                            ctx,
+                            "vault_write",
+                            _IDEMPOTENT_NOOP,
+                            project,
                         )
                     if filepath.exists():
                         return track(
-                            ctx, "vault_write",
+                            ctx,
+                            "vault_write",
                             f"File already exists: {path}. "
                             "Use vault_write(operation='replace') to modify.",
                             project,
@@ -242,11 +247,13 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                     try:
                         filepath.parent.mkdir(parents=True, exist_ok=True)
                         filepath.write_text(
-                            frontmatter + content, encoding="utf-8",
+                            frontmatter + content,
+                            encoding="utf-8",
                         )
                     except OSError as exc:
                         return track(
-                            ctx, "vault_write",
+                            ctx,
+                            "vault_write",
                             format_io_error(exc, path, "create"),
                             project,
                         )
@@ -256,35 +263,39 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
 
                     rel = filepath.relative_to(ctx.vault)
                     display = "00_meta" if project == "_meta" else project
-                    should_defer = (
-                        commit
-                        and _should_defer_to_external_committer(ctx.vault)
-                    )
+                    should_defer = commit and _should_defer_to_external_committer(ctx.vault)
                     if commit and not should_defer:
                         _git_commit(
-                            ctx.vault, [rel],
+                            ctx.vault,
+                            [rel],
                             f"vault: create {display}/{path}",
                         )
             except WriteLockTimeout as exc:
                 return track(
-                    ctx, "vault_write",
+                    ctx,
+                    "vault_write",
                     f"Server busy — {exc.reason}. Retry shortly.",
                     project,
                 )
 
             suffix = _commit_status_suffix(
-                commit, should_defer, deadline_killed=_was_deadline_killed(),
+                commit,
+                should_defer,
+                deadline_killed=_was_deadline_killed(),
             )
             return track(
-                ctx, "vault_write",
+                ctx,
+                "vault_write",
                 f"Created {project}/{path} (type: {doc_type}).{suffix}",
-                project, path,
+                project,
+                path,
             )
 
         # ── Append / Replace mode ──
         if not section:
             return track(
-                ctx, "vault_write",
+                ctx,
+                "vault_write",
                 "Section is required for append/replace operations.",
                 project,
             )
@@ -293,7 +304,8 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
         if filename is None:
             available = ", ".join(SECTION_SHORTCUTS)
             return track(
-                ctx, "vault_write",
+                ctx,
+                "vault_write",
                 f"Section '{section}' not found. Available: {available}",
                 project,
             )
@@ -304,7 +316,8 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
             error = validate_frontmatter(content)
             if error:
                 return track(
-                    ctx, "vault_write",
+                    ctx,
+                    "vault_write",
                     f"Frontmatter validation failed: {error}",
                     project,
                 )
@@ -315,23 +328,24 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                     idempotency_key,
                 ):
                     return track(
-                        ctx, "vault_write", _IDEMPOTENT_NOOP, project,
+                        ctx,
+                        "vault_write",
+                        _IDEMPOTENT_NOOP,
+                        project,
                     )
                 try:
                     if operation == "append":
-                        existing = (
-                            filepath.read_text(encoding="utf-8")
-                            if filepath.exists()
-                            else ""
-                        )
+                        existing = filepath.read_text(encoding="utf-8") if filepath.exists() else ""
                         filepath.write_text(
-                            existing + content, encoding="utf-8",
+                            existing + content,
+                            encoding="utf-8",
                         )
                     else:
                         filepath.write_text(content, encoding="utf-8")
                 except (OSError, UnicodeDecodeError) as exc:
                     return track(
-                        ctx, "vault_write",
+                        ctx,
+                        "vault_write",
                         format_io_error(exc, f"{project}/{section}", operation),
                         project,
                     )
@@ -340,29 +354,32 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                     ctx.idempotency.claim(idempotency_key)
 
                 rel = filepath.relative_to(ctx.vault)
-                should_defer = (
-                    commit
-                    and _should_defer_to_external_committer(ctx.vault)
-                )
+                should_defer = commit and _should_defer_to_external_committer(ctx.vault)
                 if commit and not should_defer:
                     _git_commit(
-                        ctx.vault, [rel],
+                        ctx.vault,
+                        [rel],
                         f"vault: update {project}/{section}",
                     )
         except WriteLockTimeout as exc:
             return track(
-                ctx, "vault_write",
+                ctx,
+                "vault_write",
                 f"Server busy — {exc.reason}. Retry shortly.",
                 project,
             )
 
         suffix = _commit_status_suffix(
-            commit, should_defer, deadline_killed=_was_deadline_killed(),
+            commit,
+            should_defer,
+            deadline_killed=_was_deadline_killed(),
         )
         return track(
-            ctx, "vault_write",
+            ctx,
+            "vault_write",
             f"Updated {project}/{section} ({operation}).{suffix}",
-            project, section,
+            project,
+            section,
         )
 
     @mcp.tool(annotations=_WRITE)
@@ -420,16 +437,17 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
 
         if has_single and has_multi:
             return track(
-                ctx, "vault_patch",
-                "Cannot mix find/replace with patches. "
-                "Use one mode or the other.",
+                ctx,
+                "vault_patch",
+                "Cannot mix find/replace with patches. Use one mode or the other.",
                 project,
             )
 
         if has_single:
             if not find or not replace:
                 return track(
-                    ctx, "vault_patch",
+                    ctx,
+                    "vault_patch",
                     "Provide both find and replace for single replacement.",
                     project,
                 )
@@ -440,15 +458,15 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
             patch_list = patches
         else:
             return track(
-                ctx, "vault_patch",
+                ctx,
+                "vault_patch",
                 "Provide find/replace or a patches list.",
                 project,
             )
 
         resolved = _resolve_project_dir(ctx.vault, project, ctx.scopes)
         if resolved is None:
-            return track(ctx, "vault_patch",
-                         project_not_found(project), project)
+            return track(ctx, "vault_patch", project_not_found(project), project)
         project_dir, _ = resolved
 
         filepath = project_dir / path
@@ -456,9 +474,9 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
         if boundary_error:
             return track(ctx, "vault_patch", boundary_error, project)
         if not filepath.exists():
-            return track(ctx, "vault_patch",
-                         f"File '{path}' not found in project '{project}'.",
-                         project)
+            return track(
+                ctx, "vault_patch", f"File '{path}' not found in project '{project}'.", project
+            )
 
         n = 0
         try:
@@ -467,13 +485,17 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                     idempotency_key,
                 ):
                     return track(
-                        ctx, "vault_patch", _IDEMPOTENT_NOOP, project,
+                        ctx,
+                        "vault_patch",
+                        _IDEMPOTENT_NOOP,
+                        project,
                     )
                 try:
                     content = filepath.read_text(encoding="utf-8")
                 except (OSError, UnicodeDecodeError) as exc:
                     return track(
-                        ctx, "vault_patch",
+                        ctx,
+                        "vault_patch",
                         format_io_error(exc, path, "read"),
                         project,
                     )
@@ -484,19 +506,23 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                     if "find" not in patch or "replace" not in patch:
                         label = f"patch {i}: " if len(patch_list) > 1 else ""
                         return track(
-                            ctx, "vault_patch",
-                            f"{label}Each patch must have 'find' and "
-                            f"'replace' keys.",
+                            ctx,
+                            "vault_patch",
+                            f"{label}Each patch must have 'find' and 'replace' keys.",
                             project,
                         )
                     ok, result = _match_and_replace(
-                        working, patch["find"], patch["replace"],
+                        working,
+                        patch["find"],
+                        patch["replace"],
                     )
                     if not ok:
                         label = f"patch {i}: " if len(patch_list) > 1 else ""
                         return track(
-                            ctx, "vault_patch",
-                            f"{label}{result}", project,
+                            ctx,
+                            "vault_patch",
+                            f"{label}{result}",
+                            project,
                         )
                     working = result
 
@@ -504,7 +530,8 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                     filepath.write_text(working, encoding="utf-8")
                 except OSError as exc:
                     return track(
-                        ctx, "vault_patch",
+                        ctx,
+                        "vault_patch",
                         format_io_error(exc, path, "write"),
                         project,
                     )
@@ -514,29 +541,30 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
 
                 rel = filepath.relative_to(ctx.vault)
                 n = len(patch_list)
-                should_defer = (
-                    commit
-                    and _should_defer_to_external_committer(ctx.vault)
-                )
+                should_defer = commit and _should_defer_to_external_committer(ctx.vault)
                 if commit and not should_defer:
                     _git_commit(
-                        ctx.vault, [rel],
+                        ctx.vault,
+                        [rel],
                         f"vault: patch {project}/{path}",
                     )
         except WriteLockTimeout as exc:
             return track(
-                ctx, "vault_patch",
+                ctx,
+                "vault_patch",
                 f"Server busy — {exc.reason}. Retry shortly.",
                 project,
             )
 
         noun = "patch" if n == 1 else "patches"
         suffix = _commit_status_suffix(
-            commit, should_defer, deadline_killed=_was_deadline_killed(),
+            commit,
+            should_defer,
+            deadline_killed=_was_deadline_killed(),
         )
-        return track(ctx, "vault_patch",
-                     f"Applied {n} {noun} to {project}/{path}.{suffix}",
-                     project, path)
+        return track(
+            ctx, "vault_patch", f"Applied {n} {noun} to {project}/{path}.{suffix}", project, path
+        )
 
     @mcp.tool(annotations=_WRITE)
     @wrap_sync_tool(ctx, "vault_commit")
@@ -565,7 +593,8 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
                 status, detail = _git_commit_all(ctx.vault, message)
         except WriteLockTimeout as exc:
             return track(
-                ctx, "vault_commit",
+                ctx,
+                "vault_commit",
                 f"Server busy — {exc.reason}. Retry shortly.",
             )
 
@@ -573,7 +602,8 @@ def register_vault_write(mcp: FastMCP, ctx: ServerContext) -> None:
             return track(ctx, "vault_commit", f"Committed {detail}.")
         if status == "clean":
             return track(
-                ctx, "vault_commit",
+                ctx,
+                "vault_commit",
                 "Working tree clean — nothing to commit.",
             )
         return track(ctx, "vault_commit", f"Commit failed: {detail}")

--- a/src/hive/_workers.py
+++ b/src/hive/_workers.py
@@ -52,8 +52,7 @@ SUSPECT_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"</invoke>"),
 )
 _CORRUPTION_COMMENT = (
-    "<!-- POSSIBLE_CORRUPTION: detected XML-tag leak in input; "
-    "review and clean manually -->\n"
+    "<!-- POSSIBLE_CORRUPTION: detected XML-tag leak in input; review and clean manually -->\n"
 )
 
 
@@ -125,11 +124,13 @@ def _write_lesson(
     entry_lines = [f"\n### [{date.today().isoformat()}] {title}\n"]
     if corruption_detected:
         entry_lines.append(_CORRUPTION_COMMENT)
-    entry_lines.extend([
-        f"**Context:** {context}\n",
-        f"**Problem:** {problem}\n",
-        f"**Solution:** {solution}\n",
-    ])
+    entry_lines.extend(
+        [
+            f"**Context:** {context}\n",
+            f"**Problem:** {problem}\n",
+            f"**Solution:** {solution}\n",
+        ]
+    )
     if tag_str:
         entry_lines.append(f"**Tags:** {tag_str}\n")
     entry = "".join(entry_lines)
@@ -138,7 +139,8 @@ def _write_lesson(
         if not lessons_file.exists():
             frontmatter = _make_frontmatter(f"{project}-lessons", "lesson")
             lessons_file.write_text(
-                frontmatter + "# Lessons Learned\n" + entry, encoding="utf-8",
+                frontmatter + "# Lessons Learned\n" + entry,
+                encoding="utf-8",
             )
         else:
             with lessons_file.open("a", encoding="utf-8") as f:
@@ -163,9 +165,7 @@ def _parse_lessons_json(raw: str) -> list[dict[str, object]]:
     text = raw.strip()
     if text.startswith("```"):
         lines = text.splitlines()
-        inner = "\n".join(
-            ln for ln in lines[1:] if not ln.strip().startswith("```")
-        )
+        inner = "\n".join(ln for ln in lines[1:] if not ln.strip().startswith("```"))
         text = inner.strip()
     if not text.startswith("["):
         match = re.search(r"\[.*\]", text, re.DOTALL)
@@ -191,37 +191,40 @@ def _capture_lesson_lookup(
     """
     if rank_by not in {"reinforcements", "confidence", "hybrid"}:
         return track(
-            ctx, "capture_lesson",
-            f"Unknown rank_by={rank_by!r}. Expected one of: "
-            f"reinforcements, confidence, hybrid.",
+            ctx,
+            "capture_lesson",
+            f"Unknown rank_by={rank_by!r}. Expected one of: reinforcements, confidence, hybrid.",
             project,
         )
 
     lessons_file = project_dir / "90-lessons.md"
     if not lessons_file.exists():
         return track(
-            ctx, "capture_lesson",
+            ctx,
+            "capture_lesson",
             f"No 90-lessons.md found for project '{project}'.",
-            project, "lessons",
+            project,
+            "lessons",
         )
     content = _safe_read(lessons_file)
     if content is None:
         return track(
-            ctx, "capture_lesson",
+            ctx,
+            "capture_lesson",
             f"Could not read 90-lessons.md for project '{project}'.",
-            project, "lessons",
+            project,
+            "lessons",
         )
 
     find_lower = find.lower()
-    matched = [
-        h for h in extract_lesson_headings(content)
-        if find_lower in h.lower()
-    ]
+    matched = [h for h in extract_lesson_headings(content) if find_lower in h.lower()]
     if not matched:
         return track(
-            ctx, "capture_lesson",
+            ctx,
+            "capture_lesson",
             f"No lessons matching '{find}' in project '{project}'.",
-            project, "lessons",
+            project,
+            "lessons",
         )
 
     # Per-call dedup + increment (one read per surfaced lesson).
@@ -231,7 +234,9 @@ def _capture_lesson_lookup(
 
     bm25_scores = {h: 1.0 for h in matched_set}
     ranked = ctx.lessons.top(
-        project, by=rank_by, limit=max_lessons,
+        project,
+        by=rank_by,
+        limit=max_lessons,
         bm25_scores=bm25_scores,
     )
     ordered = [h for h in ranked if h in matched_set][:max_lessons]
@@ -243,7 +248,11 @@ def _capture_lesson_lookup(
     for heading in ordered:
         rendered.append(f"- {heading}")
     return track(
-        ctx, "capture_lesson", "\n".join(rendered), project, "lessons",
+        ctx,
+        "capture_lesson",
+        "\n".join(rendered),
+        project,
+        "lessons",
     )
 
 
@@ -274,17 +283,24 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
         try:
             if provider == "ollama":
                 resp = await ctx.ollama.generate(
-                    prompt, context=context, max_tokens=max_tokens,
+                    prompt,
+                    context=context,
+                    max_tokens=max_tokens,
                 )
             elif ctx.openrouter is None:
                 return None, "OpenRouter not configured"
             elif model:
                 resp = await ctx.openrouter.generate(
-                    prompt, context=context, model=model, max_tokens=max_tokens,
+                    prompt,
+                    context=context,
+                    model=model,
+                    max_tokens=max_tokens,
                 )
             else:
                 resp = await ctx.openrouter.generate(
-                    prompt, context=context, max_tokens=max_tokens,
+                    prompt,
+                    context=context,
+                    max_tokens=max_tokens,
                 )
             _record(resp)
             return resp, ""
@@ -294,7 +310,9 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
         except Exception as exc:
             label = f"OpenRouter ({model})" if model else provider.capitalize()
             _log.warning(
-                "_try_worker unexpected error for %s: %r", label, exc,
+                "_try_worker unexpected error for %s: %r",
+                label,
+                exc,
             )
             return None, f"{label}: unexpected error ({type(exc).__name__})"
 
@@ -345,7 +363,8 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                 resolved = _resolve_project_dir(ctx.vault, project, ctx.scopes)
                 if resolved is None:
                     return track(
-                        ctx, "capture_lesson",
+                        ctx,
+                        "capture_lesson",
                         project_not_found(project),
                         project,
                     )
@@ -354,8 +373,12 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                 # ── Lookup mode (HIVE-97 find=) ──
                 if find:
                     return _capture_lesson_lookup(
-                        ctx, project_dir, project, find,
-                        rank_by, max_lessons,
+                        ctx,
+                        project_dir,
+                        project,
+                        find,
+                        rank_by,
+                        max_lessons,
                     )
 
                 # ── Batch mode (worker extraction) ──
@@ -380,19 +403,18 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
 
                     if resp is None:
                         resp, err = await _try_worker(
-                            prompt, 2000, "openrouter",
+                            prompt,
+                            2000,
+                            "openrouter",
                         )
                         if resp is None:
                             errors.append(err)
 
                     if resp is None:
-                        reasons = (
-                            "; ".join(errors)
-                            if errors
-                            else "no workers configured"
-                        )
+                        reasons = "; ".join(errors) if errors else "no workers configured"
                         return track(
-                            ctx, "capture_lesson",
+                            ctx,
+                            "capture_lesson",
                             f"All workers unavailable [{reasons}]. "
                             "Cannot extract lessons without a worker model.",
                             project,
@@ -403,22 +425,24 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                     except (json.JSONDecodeError, ValueError):
                         snippet = resp.text[:200]
                         return track(
-                            ctx, "capture_lesson",
-                            f"Could not parse worker response as JSON: "
-                            f"{snippet}",
+                            ctx,
+                            "capture_lesson",
+                            f"Could not parse worker response as JSON: {snippet}",
                             project,
                         )
 
                     if not isinstance(lessons_raw, list):
                         return track(
-                            ctx, "capture_lesson",
+                            ctx,
+                            "capture_lesson",
                             "Worker returned non-array JSON.",
                             project,
                         )
 
                     if not lessons_raw:
                         return track(
-                            ctx, "capture_lesson",
+                            ctx,
+                            "capture_lesson",
                             "No lessons found in text.",
                             project,
                         )
@@ -451,14 +475,20 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                         l_sol = str(lesson.get("solution", ""))
                         l_sol = l_sol.replace("\n", " ").replace("\r", " ")
                         raw_tags = lesson.get("tags", [])
-                        l_tags = [
-                            str(t).replace("\n", " ").replace("\r", " ")
-                            for t in raw_tags
-                        ] if isinstance(raw_tags, list) else []
+                        l_tags = (
+                            [str(t).replace("\n", " ").replace("\r", " ") for t in raw_tags]
+                            if isinstance(raw_tags, list)
+                            else []
+                        )
 
                         status, msg = _write_lesson(
-                            project_dir, project,
-                            l_title, l_ctx, l_prob, l_sol, l_tags,
+                            project_dir,
+                            project,
+                            l_title,
+                            l_ctx,
+                            l_prob,
+                            l_sol,
+                            l_tags,
                         )
                         if status == "written":
                             written.append(l_title)
@@ -472,18 +502,17 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                         elif status == "error":
                             _log.warning(
                                 "capture_lesson: failed to write '%s': %s",
-                                l_title, msg,
+                                l_title,
+                                msg,
                             )
                             skipped.append(f"{l_title} (write error: {msg})")
 
                     if written:
-                        rel = (
-                            project_dir / "90-lessons.md"
-                        ).relative_to(ctx.vault)
+                        rel = (project_dir / "90-lessons.md").relative_to(ctx.vault)
                         _git_commit(
-                            ctx.vault, [rel],
-                            f"vault: capture_lesson {project} "
-                            f"— {len(written)} lessons",
+                            ctx.vault,
+                            [rel],
+                            f"vault: capture_lesson {project} — {len(written)} lessons",
                         )
 
                     parts: list[str] = []
@@ -500,21 +529,30 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
 
                     summary = ". ".join(parts) + "."
                     return track(
-                        ctx, "capture_lesson", summary, project, "lessons",
+                        ctx,
+                        "capture_lesson",
+                        summary,
+                        project,
+                        "lessons",
                     )
 
                 # ── Inline mode ──
                 if not title:
                     return track(
-                        ctx, "capture_lesson",
-                        "Title is required for inline mode. "
-                        "Provide text for batch extraction.",
+                        ctx,
+                        "capture_lesson",
+                        "Title is required for inline mode. Provide text for batch extraction.",
                         project,
                     )
 
                 status, msg = _write_lesson(
-                    project_dir, project,
-                    title, context, problem, solution, tags,
+                    project_dir,
+                    project,
+                    title,
+                    context,
+                    problem,
+                    solution,
+                    tags,
                 )
                 if status == "error":
                     return track(ctx, "capture_lesson", msg, project)
@@ -522,19 +560,22 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                     return track(ctx, "capture_lesson", msg, project, "lessons")
 
                 ctx.lessons.ensure(
-                    project, f"[{date.today().isoformat()}] {title}",
+                    project,
+                    f"[{date.today().isoformat()}] {title}",
                 )
 
                 rel = (project_dir / "90-lessons.md").relative_to(ctx.vault)
                 _git_commit(
-                    ctx.vault, [rel],
+                    ctx.vault,
+                    [rel],
                     f"vault: capture_lesson {project} — {title}",
                 )
 
                 return track(ctx, "capture_lesson", msg, project, "lessons")
         except TimeoutError:
             return track(
-                ctx, "capture_lesson",
+                ctx,
+                "capture_lesson",
                 f"Tool timed out after {ctx.tool_timeout:.0f}s. "
                 "Worker may be slow or unresponsive.",
                 project,
@@ -574,7 +615,11 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                 # ── Vault summarize mode ──
                 if project:
                     result = _resolve_file(
-                        ctx.vault, project, section, path, ctx.scopes,
+                        ctx.vault,
+                        project,
+                        section,
+                        path,
+                        ctx.scopes,
                     )
                     if isinstance(result, str):
                         return track(ctx, "delegate_task", result, project)
@@ -584,7 +629,10 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                         file_content = filepath.read_text(encoding="utf-8")
                     except (OSError, UnicodeDecodeError) as exc:
                         return track(
-                            ctx, "delegate_task", f"File I/O error: {exc}", project,
+                            ctx,
+                            "delegate_task",
+                            f"File I/O error: {exc}",
+                            project,
                         )
                     fm = parse_frontmatter(file_content)
                     body = extract_body(file_content)
@@ -594,7 +642,10 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
 
                     if line_count <= _SUMMARIZE_THRESHOLD:
                         return track(
-                            ctx, "delegate_task", f"{header}{file_content}", project,
+                            ctx,
+                            "delegate_task",
+                            f"{header}{file_content}",
+                            project,
                         )
 
                     # Large file: try auto-delegation (free tiers only)
@@ -608,7 +659,10 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                     summary_errors: list[str] = []
                     if await ctx.ollama.is_available():
                         summary_resp, err = await _try_worker(
-                            summary_prompt, max_tokens, "ollama", summary_ctx,
+                            summary_prompt,
+                            max_tokens,
+                            "ollama",
+                            summary_ctx,
                         )
                         if err:
                             summary_errors.append(err)
@@ -616,31 +670,37 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                         summary_errors.append("Ollama: offline")
                     if summary_resp is None:
                         summary_resp, err = await _try_worker(
-                            summary_prompt, max_tokens, "openrouter", summary_ctx,
+                            summary_prompt,
+                            max_tokens,
+                            "openrouter",
+                            summary_ctx,
                         )
                         if err:
                             summary_errors.append(err)
                     if summary_resp is not None:
                         return track(
-                            ctx, "delegate_task",
+                            ctx,
+                            "delegate_task",
                             f"{header}{_format_response(summary_resp)}",
                             project,
                         )
                     # Workers unavailable — return raw content with notice
                     reasons = (
-                        "; ".join(summary_errors) if summary_errors
-                        else "no workers configured"
+                        "; ".join(summary_errors) if summary_errors else "no workers configured"
                     )
                     _log.warning(
                         "delegate_task summarize fallback for %s: %s",
-                        project, reasons,
+                        project,
+                        reasons,
                     )
                     fallback_notice = (
-                        f"**Note:** Summarization failed ({reasons}). "
-                        "Returning raw content.\n\n"
+                        f"**Note:** Summarization failed ({reasons}). Returning raw content.\n\n"
                     )
                     return track(
-                        ctx, "delegate_task", f"{header}{fallback_notice}{file_content}", project,
+                        ctx,
+                        "delegate_task",
+                        f"{header}{fallback_notice}{file_content}",
+                        project,
                     )
 
                 if not prompt:
@@ -664,7 +724,10 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                     if not ctx.budget.can_spend(ctx.openrouter_budget, max_cost_per_request):
                         return track(ctx, _tn, f"Monthly budget exhausted. {_REJECT_MSG}")
                     resp, err = await _try_worker(
-                        prompt, max_tokens, "openrouter", context,
+                        prompt,
+                        max_tokens,
+                        "openrouter",
+                        context,
                         model=ctx.openrouter_paid_model,
                     )
                     if resp:
@@ -672,7 +735,11 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                     return track(ctx, _tn, f"{err}. {_REJECT_MSG}")
                 if model != "auto":
                     resp, err = await _try_worker(
-                        prompt, max_tokens, "openrouter", context, model=model,
+                        prompt,
+                        max_tokens,
+                        "openrouter",
+                        context,
+                        model=model,
                     )
                     if resp:
                         return track(ctx, _tn, _format_response(resp))
@@ -703,7 +770,10 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                     and ctx.budget.can_spend(ctx.openrouter_budget, max_cost_per_request)
                 ):
                     resp, err = await _try_worker(
-                        prompt, max_tokens, "openrouter", context,
+                        prompt,
+                        max_tokens,
+                        "openrouter",
+                        context,
                         model=ctx.openrouter_paid_model,
                     )
                     if resp is not None:
@@ -715,7 +785,8 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                 return track(ctx, _tn, f"All workers unavailable. [{reasons}]. {_REJECT_MSG}")
         except TimeoutError:
             return track(
-                ctx, "delegate_task",
+                ctx,
+                "delegate_task",
                 f"Tool timed out after {ctx.tool_timeout:.0f}s. "
                 "Worker may be slow or unresponsive.",
             )
@@ -772,12 +843,10 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                             models = await ctx.openrouter.list_models()
                             for m in models:
                                 cost = (
-                                    "free" if m.is_free
-                                    else f"${m.cost_per_million_input:.2f}/M in"
+                                    "free" if m.is_free else f"${m.cost_per_million_input:.2f}/M in"
                                 )
                                 lines.append(
-                                    f"- **{m.id}** — {m.name}, "
-                                    f"ctx: {m.context_length}, {cost}",
+                                    f"- **{m.id}** — {m.name}, ctx: {m.context_length}, {cost}",
                                 )
                         except (ConnectionError, RuntimeError, TimeoutError) as exc:
                             lines.append(f"- Error fetching models: {exc}")

--- a/src/hive/config.py
+++ b/src/hive/config.py
@@ -86,16 +86,14 @@ class HiveSettings(BaseSettings):
         duplicates = sorted({d for d in dirs if dirs.count(d) > 1})
         if duplicates:
             raise ValueError(
-                "vault_scopes maps multiple scopes to the same directory: "
-                f"{duplicates}",
+                f"vault_scopes maps multiple scopes to the same directory: {duplicates}",
             )
         for key, raw in value.items():
             is_absolute = raw.startswith(("/", "\\")) or bool(_DRIVE_RE.match(raw))
             segments = re.split(r"[\\/]", raw)
             if not raw.strip() or is_absolute or ".." in segments:
                 raise ValueError(
-                    f"vault_scopes[{key!r}] must be a relative path inside the "
-                    f"vault, got {raw!r}",
+                    f"vault_scopes[{key!r}] must be a relative path inside the vault, got {raw!r}",
                 )
         return value
 

--- a/src/hive/relevance.py
+++ b/src/hive/relevance.py
@@ -51,7 +51,11 @@ CREATE TABLE IF NOT EXISTS relevance_meta (
         self._access_buffer: list[tuple[str, str, float]] = []
 
     def record_access(
-        self, project: str, section: str, *, is_write: bool = False,
+        self,
+        project: str,
+        section: str,
+        *,
+        is_write: bool = False,
     ) -> None:
         """Record a section access, updating EMA score.
 
@@ -140,8 +144,7 @@ CREATE TABLE IF NOT EXISTS relevance_meta (
     def _top_sections(self, project: str, n: int = 5) -> list[str]:
         """Internal — caller MUST hold self._lock and have flushed buffer."""
         rows = self._conn.execute(
-            "SELECT section FROM section_scores "
-            "WHERE project = ? ORDER BY score DESC LIMIT ?",
+            "SELECT section FROM section_scores WHERE project = ? ORDER BY score DESC LIMIT ?",
             (project, n),
         ).fetchall()
         return [row[0] for row in rows]
@@ -181,8 +184,7 @@ CREATE TABLE IF NOT EXISTS relevance_meta (
         with self._lock:
             self._flush_access_locked()
             rows = self._conn.execute(
-                "SELECT section, score FROM section_scores "
-                "WHERE project = ? ORDER BY score DESC",
+                "SELECT section, score FROM section_scores WHERE project = ? ORDER BY score DESC",
                 (project,),
             ).fetchall()
         return {section: score for section, score in rows}

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -122,7 +122,8 @@ def create_server(
     tracker = usage_tracker or UsageTracker()
     budget = budget_tracker or BudgetTracker(db_path=settings.db_path)
     ollama = ollama_client or OllamaClient(
-        endpoint=settings.ollama_endpoint, model=settings.ollama_model,
+        endpoint=settings.ollama_endpoint,
+        model=settings.ollama_model,
         timeout=settings.http_timeout,
     )
     openrouter: OpenRouterClient | None = None
@@ -130,7 +131,8 @@ def create_server(
         openrouter = openrouter_client
     elif settings.openrouter_api_key:
         openrouter = OpenRouterClient(
-            api_key=settings.openrouter_api_key, default_model=settings.openrouter_model,
+            api_key=settings.openrouter_api_key,
+            default_model=settings.openrouter_model,
             timeout=settings.http_timeout,
         )
     relevance = relevance_tracker or RelevanceTracker(
@@ -556,7 +558,10 @@ def _setup_file_logging() -> None:
     template.parent.mkdir(parents=True, exist_ok=True)
     log_file = template.with_name(f"{template.stem}-{os.getpid()}{template.suffix}")
     handler = logging.handlers.RotatingFileHandler(
-        log_file, maxBytes=1_000_000, backupCount=1, encoding="utf-8",
+        log_file,
+        maxBytes=1_000_000,
+        backupCount=1,
+        encoding="utf-8",
     )
     handler.setFormatter(
         logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"),
@@ -610,7 +615,8 @@ def _run_service(argv: list[str]) -> int:
     sub = parser.add_subparsers(dest="action", required=True)
     install = sub.add_parser("install", help="install + enable the service")
     install.add_argument(
-        "--no-enable", action="store_true",
+        "--no-enable",
+        action="store_true",
         help="write the unit/task only; do not start it",
     )
     sub.add_parser("uninstall", help="stop + remove the service")

--- a/src/hive/usage.py
+++ b/src/hive/usage.py
@@ -56,8 +56,7 @@ CREATE TABLE IF NOT EXISTS tool_calls (
         batch = self._buffer
         self._buffer = []
         self._conn.executemany(
-            "INSERT INTO tool_calls (tool, project, response_lines) "
-            "VALUES (?, ?, ?)",
+            "INSERT INTO tool_calls (tool, project, response_lines) VALUES (?, ?, ?)",
             batch,
         )
         self._conn.commit()
@@ -108,8 +107,7 @@ CREATE TABLE IF NOT EXISTS tool_calls (
                 by_project[project] = count
 
             total_lines_row = self._conn.execute(
-                "SELECT COALESCE(SUM(response_lines), 0) FROM tool_calls "
-                f"{since_clause}",
+                f"SELECT COALESCE(SUM(response_lines), 0) FROM tool_calls {since_clause}",
                 (since_param,),
             ).fetchone()
             total_lines = total_lines_row[0] if total_lines_row else 0

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -74,6 +74,7 @@ def _completeness(truncated: str, full: str) -> float:
 
 # ── Synthetic vault ───────────────────────────────────────────────
 
+
 def _generate_realistic_content(line_count: int, prefix: str = "content") -> str:
     """Generate markdown content that matches real vault patterns."""
     lines = []
@@ -189,13 +190,9 @@ class TestContextBenchmark:
         static_tokens = _count_file_tokens(bench_vault / "static_baseline.md")
         total_ondemand = 0
 
-        r1 = await mcp.call_tool(
-            "vault_query", {"project": "medium-project", "section": "context"}
-        )
+        r1 = await mcp.call_tool("vault_query", {"project": "medium-project", "section": "context"})
         total_ondemand += _tokens(_text(r1))
-        r2 = await mcp.call_tool(
-            "vault_query", {"project": "medium-project", "section": "tasks"}
-        )
+        r2 = await mcp.call_tool("vault_query", {"project": "medium-project", "section": "tasks"})
         total_ondemand += _tokens(_text(r2))
         r3 = await mcp.call_tool("vault_search", {"query": "deploy", "max_lines": 50})
         total_ondemand += _tokens(_text(r3))
@@ -232,22 +229,23 @@ class TestMaxLinesSweep:
         print(f"\n{'=' * 72}")
         print("MAX_LINES SWEEP: vault_search(query='paragraph')")
         print(f"{'=' * 72}")
-        print(f"{'max_lines':>10s}  {'tokens':>8s}  {'% of full':>10s}  "
-              f"{'completeness':>13s}  {'signal/noise':>13s}")
+        print(
+            f"{'max_lines':>10s}  {'tokens':>8s}  {'% of full':>10s}  "
+            f"{'completeness':>13s}  {'signal/noise':>13s}"
+        )
         print(f"{'-' * 72}")
 
         for ml in MAX_LINES_SWEEP:
-            result = await mcp.call_tool(
-                "vault_search", {"query": "paragraph", "max_lines": ml}
-            )
+            result = await mcp.call_tool("vault_search", {"query": "paragraph", "max_lines": ml})
             text = _text(result)
             tokens = _tokens(text)
             pct_of_full = (tokens / baseline_tokens * 100) if baseline_tokens else 0
             compl = _completeness(text, baseline_text) * 100
             snr = _signal_ratio(text) * 100
             label = "unlimited" if ml == 0 else str(ml)
-            print(f"{label:>10s}  {tokens:>8d}  {pct_of_full:>9.1f}%  "
-                  f"{compl:>12.1f}%  {snr:>12.1f}%")
+            print(
+                f"{label:>10s}  {tokens:>8d}  {pct_of_full:>9.1f}%  {compl:>12.1f}%  {snr:>12.1f}%"
+            )
 
         # Verify sweep ordering: more lines = more tokens
         assert baseline_tokens > 0
@@ -265,8 +263,10 @@ class TestMaxLinesSweep:
         print(f"\n{'=' * 72}")
         print("MAX_LINES SWEEP: vault_query(project='large-project', section='lessons')")
         print(f"{'=' * 72}")
-        print(f"{'max_lines':>10s}  {'tokens':>8s}  {'% of full':>10s}  "
-              f"{'completeness':>13s}  {'signal/noise':>13s}")
+        print(
+            f"{'max_lines':>10s}  {'tokens':>8s}  {'% of full':>10s}  "
+            f"{'completeness':>13s}  {'signal/noise':>13s}"
+        )
         print(f"{'-' * 72}")
 
         for ml in MAX_LINES_SWEEP:
@@ -280,8 +280,9 @@ class TestMaxLinesSweep:
             compl = _completeness(text, baseline_text) * 100
             snr = _signal_ratio(text) * 100
             label = "unlimited" if ml == 0 else str(ml)
-            print(f"{label:>10s}  {tokens:>8d}  {pct_of_full:>9.1f}%  "
-                  f"{compl:>12.1f}%  {snr:>12.1f}%")
+            print(
+                f"{label:>10s}  {tokens:>8d}  {pct_of_full:>9.1f}%  {compl:>12.1f}%  {snr:>12.1f}%"
+            )
 
         assert baseline_tokens > 0
 
@@ -317,27 +318,38 @@ class TestSignalToNoise:
         mcp = create_server(vault_path=bench_vault)
 
         tools = [
-            ("vault_query (context)", "vault_query",
-             {"project": "large-project", "section": "context"}),
-            ("vault_query (tasks)", "vault_query",
-             {"project": "large-project", "section": "tasks"}),
-            ("vault_query (lessons)", "vault_query",
-             {"project": "large-project", "section": "lessons"}),
-            ("vault_search (100)", "vault_search",
-             {"query": "paragraph", "max_lines": 100}),
-            ("vault_search (500)", "vault_search",
-             {"query": "paragraph", "max_lines": 500}),
-            ("vault_search (ranked)", "vault_search",
-             {"query": "paragraph", "ranked": True, "max_lines": 100}),
-            ("session_briefing", "session_briefing",
-             {"project": "large-project"}),
+            (
+                "vault_query (context)",
+                "vault_query",
+                {"project": "large-project", "section": "context"},
+            ),
+            (
+                "vault_query (tasks)",
+                "vault_query",
+                {"project": "large-project", "section": "tasks"},
+            ),
+            (
+                "vault_query (lessons)",
+                "vault_query",
+                {"project": "large-project", "section": "lessons"},
+            ),
+            ("vault_search (100)", "vault_search", {"query": "paragraph", "max_lines": 100}),
+            ("vault_search (500)", "vault_search", {"query": "paragraph", "max_lines": 500}),
+            (
+                "vault_search (ranked)",
+                "vault_search",
+                {"query": "paragraph", "ranked": True, "max_lines": 100},
+            ),
+            ("session_briefing", "session_briefing", {"project": "large-project"}),
         ]
 
         print(f"\n{'=' * 72}")
         print("SIGNAL-TO-NOISE BY TOOL")
         print(f"{'=' * 72}")
-        print(f"{'Tool':<30s}  {'tokens':>8s}  {'lines':>7s}  "
-              f"{'signal':>7s}  {'noise':>7s}  {'S/N':>7s}")
+        print(
+            f"{'Tool':<30s}  {'tokens':>8s}  {'lines':>7s}  "
+            f"{'signal':>7s}  {'noise':>7s}  {'S/N':>7s}"
+        )
         print(f"{'-' * 72}")
 
         for label, tool_name, args in tools:
@@ -348,8 +360,10 @@ class TestSignalToNoise:
             snr = _signal_ratio(text)
             signal_lines = int(total_lines * snr)
             noise_lines = total_lines - signal_lines
-            print(f"{label:<30s}  {tokens:>8d}  {total_lines:>7d}  "
-                  f"{signal_lines:>7d}  {noise_lines:>7d}  {snr:>6.1%}")
+            print(
+                f"{label:<30s}  {tokens:>8d}  {total_lines:>7d}  "
+                f"{signal_lines:>7d}  {noise_lines:>7d}  {snr:>6.1%}"
+            )
 
         # All tools should have >50% signal
         for label, tool_name, args in tools:
@@ -396,9 +410,14 @@ class TestSessionSimulations:
                 ("session_briefing", {"project": "large-project"}),
                 ("vault_query", {"project": "large-project", "section": "tasks"}),
                 ("vault_search", {"query": "deploy", "max_lines": 300}),
-                ("vault_query", {
-                    "project": "large-project", "section": "lessons", "max_lines": 200,
-                }),
+                (
+                    "vault_query",
+                    {
+                        "project": "large-project",
+                        "section": "lessons",
+                        "max_lines": 200,
+                    },
+                ),
             ],
             "Exploration (heavy)": [
                 ("session_briefing", {"project": "large-project"}),
@@ -415,16 +434,20 @@ class TestSessionSimulations:
         print(f"{'=' * 72}")
         print(f"Static baseline: {static_tokens:,} tokens")
         print(f"{'-' * 72}")
-        print(f"{'Session type':<25s}  {'queries':>8s}  {'tokens':>8s}  "
-              f"{'vs static':>10s}  {'savings':>8s}  {'avg S/N':>8s}")
+        print(
+            f"{'Session type':<25s}  {'queries':>8s}  {'tokens':>8s}  "
+            f"{'vs static':>10s}  {'savings':>8s}  {'avg S/N':>8s}"
+        )
         print(f"{'-' * 72}")
 
         for session_name, queries in sessions.items():
             total, avg_snr = await self._run_session(mcp, session_name, queries)
             ratio = total / static_tokens
             savings = (1 - ratio) * 100
-            print(f"{session_name:<25s}  {len(queries):>8d}  {total:>8d}  "
-                  f"{ratio:>9.2f}x  {savings:>7.1f}%  {avg_snr:>7.1%}")
+            print(
+                f"{session_name:<25s}  {len(queries):>8d}  {total:>8d}  "
+                f"{ratio:>9.2f}x  {savings:>7.1f}%  {avg_snr:>7.1%}"
+            )
 
         # Even the heaviest session should save tokens vs static
         for session_name, queries in sessions.items():
@@ -448,7 +471,8 @@ class TestWriteThroughputBenchmark:
         return 10
 
     async def test_per_write_vs_batched_commit(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """N writes with default commit=True vs commit=False + one vault_commit."""
         import time
@@ -462,9 +486,9 @@ class TestWriteThroughputBenchmark:
             await mcp.call_tool(
                 "vault_write",
                 {
-                    "project": "medium-project" if (git_vault / "10_projects"
-                                                   / "medium-project").exists()
-                               else "testproject",
+                    "project": "medium-project"
+                    if (git_vault / "10_projects" / "medium-project").exists()
+                    else "testproject",
                     "section": "tasks",
                     "operation": "append",
                     "content": f"\n- [ ] baseline write {i}\n",
@@ -479,9 +503,9 @@ class TestWriteThroughputBenchmark:
             await mcp.call_tool(
                 "vault_write",
                 {
-                    "project": "medium-project" if (git_vault / "10_projects"
-                                                   / "medium-project").exists()
-                               else "testproject",
+                    "project": "medium-project"
+                    if (git_vault / "10_projects" / "medium-project").exists()
+                    else "testproject",
                     "section": "tasks",
                     "operation": "append",
                     "content": f"\n- [ ] batched write {i}\n",
@@ -491,7 +515,8 @@ class TestWriteThroughputBenchmark:
         batched_writes_total = time.perf_counter() - t0
         t0 = time.perf_counter()
         await mcp.call_tool(
-            "vault_commit", {"message": "vault: batched throughput bench"},
+            "vault_commit",
+            {"message": "vault: batched throughput bench"},
         )
         flush_total = time.perf_counter() - t0
         batched_total = batched_writes_total + flush_total
@@ -502,21 +527,26 @@ class TestWriteThroughputBenchmark:
         print("HIVE-104 write throughput — per-write vs batched commit")
         print(f"{'=' * 72}")
         print(f"  N writes              : {n}")
-        print(f"  Baseline (commit=True): "
-              f"{baseline_total * 1000:.1f} ms total "
-              f"({baseline_per_call * 1000:.1f} ms / call)")
-        print(f"  Batched (commit=False): "
-              f"{batched_writes_total * 1000:.1f} ms writes + "
-              f"{flush_total * 1000:.1f} ms flush = "
-              f"{batched_total * 1000:.1f} ms total "
-              f"({batched_per_call_avg * 1000:.1f} ms / call avg)")
+        print(
+            f"  Baseline (commit=True): "
+            f"{baseline_total * 1000:.1f} ms total "
+            f"({baseline_per_call * 1000:.1f} ms / call)"
+        )
+        print(
+            f"  Batched (commit=False): "
+            f"{batched_writes_total * 1000:.1f} ms writes + "
+            f"{flush_total * 1000:.1f} ms flush = "
+            f"{batched_total * 1000:.1f} ms total "
+            f"({batched_per_call_avg * 1000:.1f} ms / call avg)"
+        )
         print(f"  Speed-up              : {speedup:.1f}x")
 
         assert baseline_total > 0
         assert batched_total > 0
 
     async def test_multi_patch_vs_sequential_patches(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """One vault_patch with N patches vs N vault_patch calls."""
         import time
@@ -584,12 +614,16 @@ class TestWriteThroughputBenchmark:
         print("HIVE-104 write throughput — N sequential patches vs 1 multi-patch")
         print(f"{'=' * 72}")
         print(f"  N edits              : {n}")
-        print(f"  Sequential (N calls) : "
-              f"{sequential_total * 1000:.1f} ms total "
-              f"({(sequential_total / n) * 1000:.1f} ms / patch)")
-        print(f"  Multi-patch (1 call) : "
-              f"{multi_total * 1000:.1f} ms total "
-              f"({(multi_total / n) * 1000:.1f} ms / patch avg)")
+        print(
+            f"  Sequential (N calls) : "
+            f"{sequential_total * 1000:.1f} ms total "
+            f"({(sequential_total / n) * 1000:.1f} ms / patch)"
+        )
+        print(
+            f"  Multi-patch (1 call) : "
+            f"{multi_total * 1000:.1f} ms total "
+            f"({(multi_total / n) * 1000:.1f} ms / patch avg)"
+        )
         print(f"  Speed-up             : {speedup:.1f}x")
 
         assert sequential_total > 0
@@ -613,12 +647,14 @@ class TestRealVaultBenchmark:
     @pytest.fixture
     def real_mcp(self) -> FastMCP:
         from pathlib import Path
+
         return create_server(vault_path=Path(REAL_VAULT))
 
     @pytest.fixture
     def real_static_tokens(self) -> int:
         """Count all tokens in the real vault projects directory."""
         from pathlib import Path
+
         total = 0
         for f in Path(REAL_VAULT).rglob("*.md"):
             total += _count_file_tokens(f)
@@ -628,6 +664,7 @@ class TestRealVaultBenchmark:
         """max_lines sweep on a real project."""
         # Find the largest project
         from pathlib import Path
+
         projects_dir = Path(REAL_VAULT) / "10_projects"
         projects = sorted(
             [d for d in projects_dir.iterdir() if d.is_dir()],
@@ -651,10 +688,14 @@ class TestRealVaultBenchmark:
             baseline_tokens = _tokens(baseline_text)
 
             print(f"\nvault_query(project='{project}', section='{section}')")
-            print(f"  Full content: {baseline_tokens:,} tokens, "
-                  f"{len(baseline_text.splitlines())} lines")
-            print(f"  {'max_lines':>10s}  {'tokens':>8s}  {'% of full':>10s}  "
-                  f"{'completeness':>13s}  {'signal/noise':>13s}")
+            print(
+                f"  Full content: {baseline_tokens:,} tokens, "
+                f"{len(baseline_text.splitlines())} lines"
+            )
+            print(
+                f"  {'max_lines':>10s}  {'tokens':>8s}  {'% of full':>10s}  "
+                f"{'completeness':>13s}  {'signal/noise':>13s}"
+            )
             print(f"  {'-' * 64}")
 
             for ml in MAX_LINES_SWEEP:
@@ -668,14 +709,14 @@ class TestRealVaultBenchmark:
                 compl = _completeness(text, baseline_text) * 100
                 snr = _signal_ratio(text) * 100
                 label = "unlimited" if ml == 0 else str(ml)
-                print(f"  {label:>10s}  {tokens:>8d}  {pct:>9.1f}%  "
-                      f"{compl:>12.1f}%  {snr:>12.1f}%")
+                print(f"  {label:>10s}  {tokens:>8d}  {pct:>9.1f}%  {compl:>12.1f}%  {snr:>12.1f}%")
 
     async def test_real_vault_session_comparison(
         self, real_mcp: FastMCP, real_static_tokens: int
     ) -> None:
         """Compare on-demand vs static loading on the real vault."""
         from pathlib import Path
+
         projects_dir = Path(REAL_VAULT) / "10_projects"
         projects = [d.name for d in projects_dir.iterdir() if d.is_dir()][:5]
 

--- a/tests/test_bounded_call.py
+++ b/tests/test_bounded_call.py
@@ -185,7 +185,10 @@ async def test_partial_commit_prevention(git_vault: Path) -> None:
 
     head_before = subprocess.run(  # noqa: S603, S607
         ["git", "rev-parse", "HEAD"],
-        cwd=git_vault, capture_output=True, text=True, check=True,
+        cwd=git_vault,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.strip()
 
     registry: list[subprocess.Popen[bytes]] = []
@@ -193,7 +196,9 @@ async def test_partial_commit_prevention(git_vault: Path) -> None:
     async def two_step_commit() -> None:
         add = subprocess.Popen(  # noqa: S603, S607
             ["git", "add", new_file.name],
-            cwd=git_vault, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            cwd=git_vault,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         registry.append(add)
         await asyncio.to_thread(add.wait)
@@ -204,7 +209,9 @@ async def test_partial_commit_prevention(git_vault: Path) -> None:
         # Should never reach here under a 1s deadline.
         commit = subprocess.Popen(  # noqa: S603, S607
             ["git", "commit", "-m", "should-not-happen"],
-            cwd=git_vault, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            cwd=git_vault,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         registry.append(commit)
         await asyncio.to_thread(commit.wait)
@@ -219,7 +226,10 @@ async def test_partial_commit_prevention(git_vault: Path) -> None:
 
     head_after = subprocess.run(  # noqa: S603, S607
         ["git", "rev-parse", "HEAD"],
-        cwd=git_vault, capture_output=True, text=True, check=True,
+        cwd=git_vault,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.strip()
 
     assert head_before == head_after, "HEAD moved despite mid-commit kill"
@@ -227,7 +237,10 @@ async def test_partial_commit_prevention(git_vault: Path) -> None:
     # Index reflects the staged add even though no commit landed.
     porcelain = subprocess.run(  # noqa: S603, S607
         ["git", "status", "--porcelain"],
-        cwd=git_vault, capture_output=True, text=True, check=True,
+        cwd=git_vault,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout
     assert "audit-pr3-newfile.md" in porcelain, (
         "staged file disappeared from porcelain — recovery path broken"
@@ -290,7 +303,8 @@ async def test_windows_subprocess_terminated_reaches_descendants() -> None:
         proc = subprocess.Popen(  # noqa: S603
             ["cmd", "/c", "timeout", "/t", "60", "/nobreak"],
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         registry.append(proc)
         try:
@@ -349,8 +363,10 @@ async def test_concurrent_bounded_writes_no_deadlock(git_vault: Path) -> None:
                     ["git", "commit", "-m", f"writer-{idx}"],
                 ):
                     proc = subprocess.Popen(  # noqa: S603, S607
-                        argv, cwd=git_vault,
-                        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                        argv,
+                        cwd=git_vault,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
                     )
                     registry.append(proc)
                     try:
@@ -358,14 +374,15 @@ async def test_concurrent_bounded_writes_no_deadlock(git_vault: Path) -> None:
                         if rc != 0:
                             _, err = proc.communicate(timeout=1)
                             raise RuntimeError(
-                                f"git {argv[1]} rc={rc}: "
-                                f"{err.decode('utf-8', 'replace').strip()}",
+                                f"git {argv[1]} rc={rc}: {err.decode('utf-8', 'replace').strip()}",
                             )
                     finally:
                         registry.remove(proc)
 
         await bounded_call(
-            commit_seq, deadline_s=30.0, process_registry=registry,
+            commit_seq,
+            deadline_s=30.0,
+            process_registry=registry,
         )
 
     start = time.monotonic()
@@ -378,7 +395,10 @@ async def test_concurrent_bounded_writes_no_deadlock(git_vault: Path) -> None:
 
     log = subprocess.run(  # noqa: S603, S607
         ["git", "log", "--oneline"],
-        cwd=git_vault, capture_output=True, text=True, check=True,
+        cwd=git_vault,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout
     # All 3 commits landed
     for i in range(3):

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -158,8 +158,11 @@ class TestThreadSafety:
             try:
                 for i in range(n_ops):
                     tracker.record_request(
-                        f"model-{i}", cost_usd=0.01, tokens=10,
-                        latency_ms=10, task_type="test",
+                        f"model-{i}",
+                        cost_usd=0.01,
+                        tokens=10,
+                        latency_ms=10,
+                        task_type="test",
                     )
             except Exception as exc:
                 errors.append(exc)
@@ -184,8 +187,11 @@ class TestThreadSafety:
             try:
                 for _ in range(50):
                     tracker.record_request(
-                        "m", cost_usd=0.01, tokens=10,
-                        latency_ms=10, task_type="test",
+                        "m",
+                        cost_usd=0.01,
+                        tokens=10,
+                        latency_ms=10,
+                        task_type="test",
                     )
             except Exception as exc:
                 errors.append(exc)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,10 +25,12 @@ HOST = "127.0.0.1"
 def _point_state_at(monkeypatch: pytest.MonkeyPatch, state_dir: Path) -> None:
     """Redirect the shim's state-file lookups at *state_dir*."""
     monkeypatch.setattr(
-        "hive._client.port_file_path", lambda: state_dir / "daemon.port",
+        "hive._client.port_file_path",
+        lambda: state_dir / "daemon.port",
     )
     monkeypatch.setattr(
-        "hive._client.token_file_path", lambda: state_dir / "daemon.token",
+        "hive._client.token_file_path",
+        lambda: state_dir / "daemon.token",
     )
 
 
@@ -52,14 +54,16 @@ def _dead_port() -> object:
 
 
 def test_read_state_returns_none_when_files_missing(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     _point_state_at(monkeypatch, tmp_path)
     assert _read_state() is None
 
 
 def test_read_state_parses_valid_files(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     _point_state_at(monkeypatch, tmp_path)
     (tmp_path / "daemon.port").write_text("54321\n", encoding="utf-8")
@@ -68,7 +72,8 @@ def test_read_state_parses_valid_files(
 
 
 def test_read_state_rejects_garbage_port(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     _point_state_at(monkeypatch, tmp_path)
     (tmp_path / "daemon.port").write_text("not-a-number", encoding="utf-8")
@@ -77,7 +82,8 @@ def test_read_state_rejects_garbage_port(
 
 
 def test_read_state_rejects_nonpositive_port(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     _point_state_at(monkeypatch, tmp_path)
     (tmp_path / "daemon.port").write_text("0", encoding="utf-8")
@@ -86,7 +92,8 @@ def test_read_state_rejects_nonpositive_port(
 
 
 def test_read_state_rejects_empty_token(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     _point_state_at(monkeypatch, tmp_path)
     (tmp_path / "daemon.port").write_text("12345", encoding="utf-8")

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -88,8 +88,10 @@ class TestOllamaAvailability:
         client = OllamaClient(endpoint="http://localhost:11434", model="test")
         mock_resp = _mock_response(200)
         with patch.object(
-            client._probe_http, "get",
-            new_callable=AsyncMock, return_value=mock_resp,
+            client._probe_http,
+            "get",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
         ):
             assert await client.is_available() is True
 
@@ -97,8 +99,10 @@ class TestOllamaAvailability:
     async def test_is_available_false_on_error(self) -> None:
         client = OllamaClient(endpoint="http://localhost:11434", model="test")
         with patch.object(
-            client._probe_http, "get",
-            new_callable=AsyncMock, side_effect=httpx.ConnectError("down"),
+            client._probe_http,
+            "get",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("down"),
         ):
             assert await client.is_available() is False
 
@@ -108,8 +112,10 @@ class TestOllamaAvailability:
         client = OllamaClient(endpoint="http://localhost:11434", model="test")
         mock_resp = _mock_response(200)
         with patch.object(
-            client._probe_http, "get",
-            new_callable=AsyncMock, return_value=mock_resp,
+            client._probe_http,
+            "get",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
         ) as mock_get:
             assert await client.is_available() is True
             assert await client.is_available() is True
@@ -294,7 +300,9 @@ class TestOpenRouterListModels:
         client = OpenRouterClient(api_key="sk-test", default_model="m")
         with (
             patch.object(
-                client._http, "get", new_callable=AsyncMock,
+                client._http,
+                "get",
+                new_callable=AsyncMock,
                 side_effect=httpx.ReadTimeout("read timed out"),
             ),
             pytest.raises(ConnectionError, match="timed out"),
@@ -310,7 +318,9 @@ class TestReadTimeoutResilience:
         client = OllamaClient(endpoint="http://localhost:11434", model="test")
         with (
             patch.object(
-                client._http, "post", new_callable=AsyncMock,
+                client._http,
+                "post",
+                new_callable=AsyncMock,
                 side_effect=httpx.ReadTimeout("inference took too long"),
             ),
             pytest.raises(ConnectionError, match="timed out"),
@@ -322,7 +332,9 @@ class TestReadTimeoutResilience:
         client = OpenRouterClient(api_key="sk-test", default_model="m")
         with (
             patch.object(
-                client._http, "post", new_callable=AsyncMock,
+                client._http,
+                "post",
+                new_callable=AsyncMock,
                 side_effect=httpx.ReadTimeout("inference took too long"),
             ),
             pytest.raises(ConnectionError, match="timed out"),
@@ -333,7 +345,9 @@ class TestReadTimeoutResilience:
     async def test_ollama_is_available_read_timeout(self) -> None:
         client = OllamaClient(endpoint="http://localhost:11434", model="test")
         with patch.object(
-            client._probe_http, "get", new_callable=AsyncMock,
+            client._probe_http,
+            "get",
+            new_callable=AsyncMock,
             side_effect=httpx.ReadTimeout("slow"),
         ):
             assert await client.is_available() is False

--- a/tests/test_commit_policy.py
+++ b/tests/test_commit_policy.py
@@ -39,15 +39,23 @@ def _porcelain(vault: Path) -> str:
     """Run git status --porcelain in the vault and return stdout."""
     return subprocess.run(
         ["git", "status", "--porcelain"],
-        cwd=vault, capture_output=True, text=True, check=True,
+        cwd=vault,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout
 
 
 def _commit_count(vault: Path) -> int:
-    return int(subprocess.run(
-        ["git", "rev-list", "--count", "HEAD"],
-        cwd=vault, capture_output=True, text=True, check=True,
-    ).stdout.strip())
+    return int(
+        subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=vault,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    )
 
 
 @pytest.mark.asyncio
@@ -55,20 +63,23 @@ class TestCommitFalseLeavesFileDirty:
     """vault_write(commit=False) / vault_patch(commit=False) skip git commit."""
 
     async def test_vault_write_commit_false_leaves_file_dirty(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         before = _commit_count(git_vault)
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_write",
-            {
-                "project": "testproject",
-                "section": "tasks",
-                "operation": "append",
-                "content": "\n- [ ] uncommitted task\n",
-                "commit": False,
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_write",
+                {
+                    "project": "testproject",
+                    "section": "tasks",
+                    "operation": "append",
+                    "content": "\n- [ ] uncommitted task\n",
+                    "commit": False,
+                },
+            )
+        )
         # No new commit made
         assert _commit_count(git_vault) == before
         # File is dirty in working tree
@@ -77,20 +88,23 @@ class TestCommitFalseLeavesFileDirty:
         assert "uncommitted" in result.lower()
 
     async def test_vault_patch_commit_false_leaves_file_dirty(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         before = _commit_count(git_vault)
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "find": "- [ ] Task one",
-                "replace": "- [x] Task one done",
-                "commit": False,
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "find": "- [ ] Task one",
+                    "replace": "- [x] Task one done",
+                    "commit": False,
+                },
+            )
+        )
         assert _commit_count(git_vault) == before
         assert "11-tasks.md" in _porcelain(git_vault)
         assert "uncommitted" in result.lower()
@@ -117,7 +131,8 @@ class TestVaultCommitTool:
     """vault_commit(message) flushes the working tree into a single commit."""
 
     async def test_vault_commit_returns_sha_and_clears_dirty(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         mcp = create_server(vault_path=git_vault)
         # Dirty the tree without committing
@@ -144,10 +159,12 @@ class TestVaultCommitTool:
         assert _porcelain(git_vault) != ""
         before = _commit_count(git_vault)
 
-        result = _text(await mcp.call_tool(
-            "vault_commit",
-            {"message": "batch update"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_commit",
+                {"message": "batch update"},
+            )
+        )
 
         assert _commit_count(git_vault) == before + 1
         assert _porcelain(git_vault) == ""
@@ -158,14 +175,17 @@ class TestVaultCommitTool:
         ), f"expected 40-char SHA in result, got: {result!r}"
 
     async def test_vault_commit_noop_when_clean(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         mcp = create_server(vault_path=git_vault)
         before = _commit_count(git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_commit",
-            {"message": "noop"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_commit",
+                {"message": "noop"},
+            )
+        )
         assert _commit_count(git_vault) == before
         assert "clean" in result.lower() or "nothing" in result.lower()
 
@@ -174,34 +194,40 @@ class TestObsidianGitDetection:
     """detect_obsidian_git uses pathlib joining (Risk #4 cross-platform)."""
 
     def test_detect_returns_interval_when_data_json_present(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         plugin_dir = tmp_path / ".obsidian" / "plugins" / "obsidian-git"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "data.json").write_text(
-            json.dumps({"commitInterval": 10}), encoding="utf-8",
+            json.dumps({"commitInterval": 10}),
+            encoding="utf-8",
         )
         result = detect_obsidian_git(tmp_path)
         assert result is not None
         assert result["commit_interval"] == 10
 
     def test_detect_returns_none_when_no_obsidian_dir(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         assert detect_obsidian_git(tmp_path) is None
 
     def test_detect_returns_none_when_interval_zero(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         plugin_dir = tmp_path / ".obsidian" / "plugins" / "obsidian-git"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "data.json").write_text(
-            json.dumps({"commitInterval": 0}), encoding="utf-8",
+            json.dumps({"commitInterval": 0}),
+            encoding="utf-8",
         )
         assert detect_obsidian_git(tmp_path) is None
 
     def test_detect_returns_none_when_malformed_json(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         plugin_dir = tmp_path / ".obsidian" / "plugins" / "obsidian-git"
         plugin_dir.mkdir(parents=True)
@@ -214,12 +240,14 @@ class TestVaultHealthExternalCommitter:
     """vault_health surfaces external_committer when obsidian-git is present."""
 
     async def test_health_surfaces_external_committer(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         plugin_dir = git_vault / ".obsidian" / "plugins" / "obsidian-git"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "data.json").write_text(
-            json.dumps({"commitInterval": 5}), encoding="utf-8",
+            json.dumps({"commitInterval": 5}),
+            encoding="utf-8",
         )
         mcp = create_server(vault_path=git_vault)
         result = _text(await mcp.call_tool("vault_health", {}))
@@ -227,7 +255,8 @@ class TestVaultHealthExternalCommitter:
         assert "obsidian-git" in result
 
     async def test_health_omits_external_committer_when_absent(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         mcp = create_server(vault_path=git_vault)
         result = _text(await mcp.call_tool("vault_health", {}))

--- a/tests/test_compat_shim.py
+++ b/tests/test_compat_shim.py
@@ -101,8 +101,12 @@ async def _spawn(vault: Path, db_dir: Path) -> asyncio.subprocess.Process:
     env["HIVE_LESSON_DB_PATH"] = str(db_dir / "lesson_reinforcement.db")
     env["HIVE_LOG_LEVEL"] = "DEBUG"
     proc = await _spawn_subprocess(
-        sys.executable, "-m", "hive.server",
-        stdin=PIPE, stdout=PIPE, stderr=PIPE,
+        sys.executable,
+        "-m",
+        "hive.server",
+        stdin=PIPE,
+        stdout=PIPE,
+        stderr=PIPE,
         env=env,
     )
     await _send(proc, _INIT_MSG)
@@ -173,17 +177,23 @@ async def test_classify_cancellation_race(tmp_path: Path) -> None:
     try:
         for i in range(iterations):
             call_id = 100 + i
-            await _send(proc, {
-                "jsonrpc": "2.0",
-                "id": call_id,
-                "method": "tools/call",
-                "params": {"name": "vault_list", "arguments": {}},
-            })
-            await _send(proc, {
-                "jsonrpc": "2.0",
-                "method": "notifications/cancelled",
-                "params": {"requestId": call_id, "reason": "race-classifier"},
-            })
+            await _send(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "id": call_id,
+                    "method": "tools/call",
+                    "params": {"name": "vault_list", "arguments": {}},
+                },
+            )
+            await _send(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "method": "notifications/cancelled",
+                    "params": {"requestId": call_id, "reason": "race-classifier"},
+                },
+            )
             msgs = await _drain_with_id(proc, call_id, timeout=2.0)
             scenario, detail = _classify(msgs)
             counts[scenario] = counts.get(scenario, 0) + 1
@@ -254,14 +264,12 @@ async def test_ghost_response_counter_records_and_logs(
     assert snap["last_tool"] is None or isinstance(snap["last_tool"], str)
     assert isinstance(snap["last_seen"], str)
     assert any(
-        "mcp.ghost_response.suppressed_after_cancel_ack" in rec.message
-        for rec in caplog.records
+        "mcp.ghost_response.suppressed_after_cancel_ack" in rec.message for rec in caplog.records
     ), [r.message for r in caplog.records]
 
 
 @pytest.mark.asyncio
-async def test_ghost_response_counter_passes_through_when_not_completed(
-) -> None:
+async def test_ghost_response_counter_passes_through_when_not_completed() -> None:
     """Not-yet-completed responder must call original respond — no count bump."""
     from hive import _compat as _hc
 

--- a/tests/test_concurrency_fixes.py
+++ b/tests/test_concurrency_fixes.py
@@ -79,24 +79,36 @@ class TestRespondPatchPreventsKill:
 def _init_git_repo(repo: Path) -> None:
     """Initialize a minimal git repo with an initial commit."""
     subprocess.run(
-        ["git", "init", "-q"], cwd=repo, check=True, capture_output=True,
+        ["git", "init", "-q"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.email", "test@hive.local"],
-        cwd=repo, check=True, capture_output=True,
+        cwd=repo,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.name", "hive-test"],
-        cwd=repo, check=True, capture_output=True,
+        cwd=repo,
+        check=True,
+        capture_output=True,
     )
     seed = repo / "README.md"
     seed.write_text("seed\n", encoding="utf-8")
     subprocess.run(
-        ["git", "add", "README.md"], cwd=repo, check=True, capture_output=True,
+        ["git", "add", "README.md"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "commit", "-q", "-m", "seed"],
-        cwd=repo, check=True, capture_output=True,
+        cwd=repo,
+        check=True,
+        capture_output=True,
     )
 
 
@@ -125,10 +137,7 @@ def _append_to_shared_file_worker(vault: str, shared_file: str, line: str) -> st
     vault_path = _Path(vault)
     file_path = vault_path / shared_file
     with _git_filelock(vault_path).acquire(timeout=30):
-        existing = (
-            file_path.read_text(encoding="utf-8")
-            if file_path.exists() else ""
-        )
+        existing = file_path.read_text(encoding="utf-8") if file_path.exists() else ""
         file_path.write_text(existing + line + "\n", encoding="utf-8")
         _git_commit(vault_path, [_Path(shared_file)], f"append: {line}")
     return line
@@ -138,7 +147,8 @@ class TestInterProcessGitContention:
     """Concurrent ``_git_commit`` from multiple processes must serialize cleanly."""
 
     def test_concurrent_processes_complete_within_budget(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         """8 concurrent processes committing distinct files must all succeed in <60s.
 
@@ -165,18 +175,19 @@ class TestInterProcessGitContention:
         # All files should be committed (not just written) — verify via git log.
         log = subprocess.run(
             ["git", "log", "--pretty=format:%s"],
-            cwd=tmp_path, check=True, capture_output=True, text=True,
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
         ).stdout.splitlines()
-        committed_files = {
-            ln.removeprefix("add ").strip()
-            for ln in log if ln.startswith("add ")
-        }
+        committed_files = {ln.removeprefix("add ").strip() for ln in log if ln.startswith("add ")}
         assert committed_files == set(file_names), (
             f"missing commits: {set(file_names) - committed_files}"
         )
 
     def test_concurrent_appends_to_same_file_lose_no_lines(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         """8 processes appending unique lines to one file must all survive.
 
@@ -196,7 +207,8 @@ class TestInterProcessGitContention:
         ctx = mp.get_context("spawn")
         with ctx.Pool(processes=4) as pool:
             collected = pool.starmap_async(
-                _append_to_shared_file_worker, args,
+                _append_to_shared_file_worker,
+                args,
             ).get(timeout=90)
 
         assert set(collected) == set(lines)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,7 +47,8 @@ class TestEnvOverride:
         assert HiveSettings().lock_timeout_s == 30
 
     def test_hive_lock_timeout_s_validation_low(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Reject HIVE_LOCK_TIMEOUT_S=0 (must be ≥1)."""
         monkeypatch.setenv("HIVE_LOCK_TIMEOUT_S", "0")
@@ -55,7 +56,8 @@ class TestEnvOverride:
             HiveSettings()
 
     def test_hive_lock_timeout_s_validation_high(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Reject HIVE_LOCK_TIMEOUT_S>600 (foot-gun protection)."""
         monkeypatch.setenv("HIVE_LOCK_TIMEOUT_S", "601")
@@ -63,21 +65,24 @@ class TestEnvOverride:
             HiveSettings()
 
     def test_hive_wal_checkpoint_interval_s_env(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """HIVE_WAL_CHECKPOINT_INTERVAL_S env honored (HIVE-115 / ADR-009)."""
         monkeypatch.setenv("HIVE_WAL_CHECKPOINT_INTERVAL_S", "15.5")
         assert HiveSettings().wal_checkpoint_interval_s == 15.5
 
     def test_hive_post_kill_drain_s_env(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """HIVE_POST_KILL_DRAIN_S env honored (HIVE-116 / ADR-012)."""
         monkeypatch.setenv("HIVE_POST_KILL_DRAIN_S", "7.5")
         assert HiveSettings().post_kill_drain_s == 7.5
 
     def test_hive_post_kill_drain_s_default(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Default is 5.0s (HIVE_OUTBOX_TICK_S symmetry, user-locked 2026-05-27)."""
         monkeypatch.delenv("HIVE_POST_KILL_DRAIN_S", raising=False)
@@ -85,7 +90,9 @@ class TestEnvOverride:
 
     @pytest.mark.parametrize("value", ["0.1", "0", "31", "60"])
     def test_hive_post_kill_drain_s_validation_rejects(
-        self, monkeypatch: pytest.MonkeyPatch, value: str,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        value: str,
     ) -> None:
         """Out-of-range values raise ValidationError ([0.5, 30.0])."""
         monkeypatch.setenv("HIVE_POST_KILL_DRAIN_S", value)
@@ -94,7 +101,9 @@ class TestEnvOverride:
 
     @pytest.mark.parametrize("value", ["0.5", "5.0", "30.0"])
     def test_hive_post_kill_drain_s_validation_accepts(
-        self, monkeypatch: pytest.MonkeyPatch, value: str,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        value: str,
     ) -> None:
         """Boundary + default accepted."""
         monkeypatch.setenv("HIVE_POST_KILL_DRAIN_S", value)
@@ -182,7 +191,8 @@ class TestVaultScopesValidation:
     """
 
     def test_accepts_valid_custom_mapping(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv(
             "HIVE_VAULT_SCOPES",
@@ -199,7 +209,8 @@ class TestVaultScopesValidation:
         assert HiveSettings().vault_scopes == {}
 
     def test_rejects_duplicate_directories(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Two scope keys pointing at one directory shadows the second."""
         monkeypatch.setenv(
@@ -214,7 +225,9 @@ class TestVaultScopesValidation:
         ["../escape", "10_projects/../../etc", "sub/../../out"],
     )
     def test_rejects_parent_traversal(
-        self, monkeypatch: pytest.MonkeyPatch, bad_dir: str,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        bad_dir: str,
     ) -> None:
         monkeypatch.setenv("HIVE_VAULT_SCOPES", f'{{"x": "{bad_dir}"}}')
         with pytest.raises(ValidationError, match="relative path inside"):
@@ -222,7 +235,9 @@ class TestVaultScopesValidation:
 
     @pytest.mark.parametrize("bad_dir", ["/etc", "\\\\windows", "C:/data"])
     def test_rejects_absolute_directories(
-        self, monkeypatch: pytest.MonkeyPatch, bad_dir: str,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        bad_dir: str,
     ) -> None:
         monkeypatch.setenv("HIVE_VAULT_SCOPES", f'{{"x": "{bad_dir}"}}')
         with pytest.raises(ValidationError, match="relative path inside"):
@@ -230,7 +245,9 @@ class TestVaultScopesValidation:
 
     @pytest.mark.parametrize("bad_dir", ["", "   "])
     def test_rejects_blank_directories(
-        self, monkeypatch: pytest.MonkeyPatch, bad_dir: str,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        bad_dir: str,
     ) -> None:
         monkeypatch.setenv("HIVE_VAULT_SCOPES", f'{{"x": "{bad_dir}"}}')
         with pytest.raises(ValidationError, match="relative path inside"):

--- a/tests/test_cross_worker_lock.py
+++ b/tests/test_cross_worker_lock.py
@@ -140,13 +140,9 @@ async def test_tool_span_deadline_evicts_filelock(
         assert key not in _GIT_FILELOCKS, (
             "expected _GIT_FILELOCKS to no longer contain the vault key"
         )
-        eviction_logs = [
-            r.message for r in caplog.records
-            if "mcp.lock_eviction" in r.message
-        ]
+        eviction_logs = [r.message for r in caplog.records if "mcp.lock_eviction" in r.message]
         assert eviction_logs, (
-            f"expected mcp.lock_eviction log line; got: "
-            f"{[r.message for r in caplog.records]}"
+            f"expected mcp.lock_eviction log line; got: {[r.message for r in caplog.records]}"
         )
 
         # 5. Tracker recorded the event

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -47,7 +47,8 @@ async def _list_tools(url: str, token: str) -> list[str]:
     from fastmcp.client.transports import StreamableHttpTransport
 
     transport = StreamableHttpTransport(
-        url, headers={"Authorization": f"Bearer {token}"},
+        url,
+        headers={"Authorization": f"Bearer {token}"},
     )
     async with Client(transport) as client:
         return [t.name for t in await client.list_tools()]
@@ -67,7 +68,9 @@ def _seed_demo_project(vault: Path) -> dict[str, str]:
 
 
 async def _drive_shim(
-    env: dict[str, str], tool: str, args: dict[str, str],
+    env: dict[str, str],
+    tool: str,
+    args: dict[str, str],
 ) -> dict[str, object]:
     """Spawn the `hive client` stdio shim and drive it with a fastmcp client.
 
@@ -79,7 +82,9 @@ async def _drive_shim(
     from fastmcp.client.transports import StdioTransport
 
     transport = StdioTransport(
-        command=sys.executable, args=["-m", "hive.server", "client"], env=env,
+        command=sys.executable,
+        args=["-m", "hive.server", "client"],
+        env=env,
     )
     async with Client(transport) as client:
         tools = [t.name for t in await client.list_tools()]
@@ -132,7 +137,9 @@ async def _client_appends(env: dict[str, str], markers: list[str]) -> int:
     from fastmcp.client.transports import StdioTransport
 
     transport = StdioTransport(
-        command=sys.executable, args=["-m", "hive.server", "client"], env=env,
+        command=sys.executable,
+        args=["-m", "hive.server", "client"],
+        env=env,
     )
     done = 0
     async with Client(transport) as client:
@@ -151,7 +158,9 @@ async def _client_appends(env: dict[str, str], markers: list[str]) -> int:
 
 
 async def _two_clients_append(
-    env: dict[str, str], markers_a: list[str], markers_b: list[str],
+    env: dict[str, str],
+    markers_a: list[str],
+    markers_b: list[str],
 ) -> list[int]:
     """Two shim sessions append concurrently against the same daemon."""
     return list(
@@ -184,7 +193,10 @@ def _wait_published(state_dir: Path, port: int, deadline_s: float = 20.0) -> boo
 
 
 async def _reconnect_then_retry(
-    env: dict[str, str], key: str, content: str, restart: Callable[[], None],
+    env: dict[str, str],
+    key: str,
+    content: str,
+    restart: Callable[[], None],
 ) -> None:
     """One shim session straddling a daemon restart.
 
@@ -197,20 +209,27 @@ async def _reconnect_then_retry(
     from fastmcp.client.transports import StdioTransport
 
     args = {
-        "project": "demo", "section": "context", "operation": "append",
-        "content": content, "idempotency_key": key,
+        "project": "demo",
+        "section": "context",
+        "operation": "append",
+        "content": content,
+        "idempotency_key": key,
     }
     transport = StdioTransport(
-        command=sys.executable, args=["-m", "hive.server", "client"], env=env,
+        command=sys.executable,
+        args=["-m", "hive.server", "client"],
+        env=env,
     )
     async with Client(transport) as client:
         await client.call_tool("vault_write", args)  # lands on daemon A
-        await asyncio.to_thread(restart)              # A dies, B takes over
-        await client.call_tool("vault_write", args)   # must follow to daemon B
+        await asyncio.to_thread(restart)  # A dies, B takes over
+        await client.call_tool("vault_write", args)  # must follow to daemon B
 
 
 async def _query_across_kill(
-    env: dict[str, str], args: dict[str, str], kill: Callable[[], None],
+    env: dict[str, str],
+    args: dict[str, str],
+    kill: Callable[[], None],
 ) -> tuple[str, str]:
     """One shim session: vault_query, kill the daemon, vault_query again.
 
@@ -222,7 +241,9 @@ async def _query_across_kill(
     from fastmcp.client.transports import StdioTransport
 
     transport = StdioTransport(
-        command=sys.executable, args=["-m", "hive.server", "client"], env=env,
+        command=sys.executable,
+        args=["-m", "hive.server", "client"],
+        env=env,
     )
     async with Client(transport) as client:
         first = await client.call_tool("vault_query", args)
@@ -237,14 +258,14 @@ async def _query_across_kill(
 # ── observability (slice 4) helpers ───────────────────────────────────────
 
 
-async def _session_calls(url: str, token: str, tool: str, args: dict[str, str],
-                         times: int) -> None:
+async def _session_calls(url: str, token: str, tool: str, args: dict[str, str], times: int) -> None:
     """Open one MCP session, call *tool* *times*, then disconnect."""
     from fastmcp import Client
     from fastmcp.client.transports import StreamableHttpTransport
 
     transport = StreamableHttpTransport(
-        url, headers={"Authorization": f"Bearer {token}"},
+        url,
+        headers={"Authorization": f"Bearer {token}"},
     )
     async with Client(transport) as client:
         for _ in range(times):
@@ -348,9 +369,7 @@ def test_client_forwards_to_daemon(daemon_env: tuple[dict[str, str], Path]) -> N
         assert mode.startswith("daemon"), f"shim did not report daemon mode: {mode!r}"
 
         # The bearer token must never reach disk in any hive log (L4).
-        logs = "".join(
-            f.read_text(errors="replace") for f in state_dir.glob("hive-*.log")
-        )
+        logs = "".join(f.read_text(errors="replace") for f in state_dir.glob("hive-*.log"))
         assert token and token not in logs, "bearer token leaked into a hive log"
     finally:
         daemon.terminate()
@@ -390,15 +409,14 @@ def test_client_falls_back_on_stale_state(
     dead.bind((HOST, 0))
     try:
         (state_dir / "daemon.port").write_text(
-            str(dead.getsockname()[1]), encoding="utf-8",
+            str(dead.getsockname()[1]),
+            encoding="utf-8",
         )
         (state_dir / "daemon.token").write_text("stale-token", encoding="utf-8")
 
         surface = asyncio.run(_drive_shim(env, "vault_query", args))
         assert "vault_query" in surface["tools"]
-        assert _DEMO_MARKER in surface["text"], (
-            f"in-process query failed: {surface['text']!r}"
-        )
+        assert _DEMO_MARKER in surface["text"], f"in-process query failed: {surface['text']!r}"
 
         mode = _client_mode(state_dir)
         assert mode.startswith("fallback"), f"expected fallback mode, got {mode!r}"
@@ -442,12 +460,14 @@ def test_two_clients_share_one_daemon(
         # or coalesced/lost writes — i.e. broken single-owner serialization.
         log = subprocess.run(
             ["git", "log", "--oneline"],
-            cwd=vault, capture_output=True, text=True, check=True,
+            cwd=vault,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout
         commit_count = len(log.splitlines())
         assert commit_count == 1 + 2 * n_each, (
-            f"expected {1 + 2 * n_each} commits (init + per-append), got "
-            f"{commit_count}: {log!r}"
+            f"expected {1 + 2 * n_each} commits (init + per-append), got {commit_count}: {log!r}"
         )
     finally:
         daemon.terminate()
@@ -556,9 +576,7 @@ def test_client_degrades_in_process_when_daemon_dies_mid_session(
         first, second = asyncio.run(_query_across_kill(env, args, kill))
 
         assert _DEMO_MARKER in first, f"daemon-mode query failed: {first!r}"
-        assert _DEMO_MARKER in second, (
-            f"in-process degrade query failed: {second!r}"
-        )
+        assert _DEMO_MARKER in second, f"in-process degrade query failed: {second!r}"
 
         modes = _client_modes(state_dir)
         assert any(m.startswith("daemon") for m in modes), (
@@ -598,9 +616,7 @@ def test_health_probe_is_unauthenticated_and_reports_ready(
 
         # No Authorization header: a supervisor must probe liveness tokenless.
         resp = httpx.get(f"http://{HOST}:{port}/health")
-        assert resp.status_code == 200, (
-            f"/health not served unauthenticated: {resp.status_code}"
-        )
+        assert resp.status_code == 200, f"/health not served unauthenticated: {resp.status_code}"
         payload = resp.json()
         assert payload["status"] == "ok", f"unexpected health status: {payload!r}"
         assert payload["ready"] is True, f"daemon reported not ready: {payload!r}"
@@ -645,15 +661,16 @@ def test_daemon_self_heals_stale_index_lock(
         done = asyncio.run(_client_appends(env, ["HEAL-MARKER"]))
         assert done == 1, "vault_write did not complete"
 
-        assert not stale_lock.exists(), (
-            "startup self-heal did not clear the stale .git/index.lock"
-        )
+        assert not stale_lock.exists(), "startup self-heal did not clear the stale .git/index.lock"
         # The write committed: git log grew past `init`. If the stale lock had
         # survived, the daemon's best-effort commit would have failed silently
         # and the log would still be a single `init` commit.
         log = subprocess.run(
             ["git", "log", "--oneline"],
-            cwd=vault, capture_output=True, text=True, check=True,
+            cwd=vault,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout
         assert len(log.splitlines()) >= 2, f"write did not commit: {log!r}"
         content = (vault / "10_projects" / "demo" / "00-context.md").read_text(
@@ -766,9 +783,9 @@ def test_status_aggregates_across_sessions(
 @pytest.mark.parametrize(
     ("boot", "current", "expected"),
     [
-        ("1.30.0", "1.30.0", False),       # steady state — no restart
-        ("1.30.0", "1.31.0", True),        # in-place upgrade — restart
-        ("1.30.0", "1.29.0", True),        # rollback ships new code too — restart
+        ("1.30.0", "1.30.0", False),  # steady state — no restart
+        ("1.30.0", "1.31.0", True),  # in-place upgrade — restart
+        ("1.30.0", "1.29.0", True),  # rollback ships new code too — restart
         ("1.30.0", "<not-found>", False),  # transient swap window — must NOT bounce
         ("<not-found>", "1.30.0", False),  # never resolved at boot — don't churn
     ],
@@ -825,7 +842,8 @@ def test_watch_for_upgrade_returns_false_on_external_stop() -> None:
 
 
 def test_run_serve_maps_drift_to_restart_exit_code(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """run_serve maps a drift-caused stop to the dedicated restart exit code so a
     ``Restart=on-failure`` supervisor relaunches into the new code, while a clean

--- a/tests/test_detect_and_defer.py
+++ b/tests/test_detect_and_defer.py
@@ -61,11 +61,15 @@ def _install_obsidian_git_config(
     if commit:
         subprocess.run(  # noqa: S603, S607
             ["git", "add", ".obsidian"],
-            cwd=vault, check=True, capture_output=True,
+            cwd=vault,
+            check=True,
+            capture_output=True,
         )
         subprocess.run(  # noqa: S603, S607
             ["git", "commit", "-m", "test: stage obsidian-git config"],
-            cwd=vault, check=True, capture_output=True,
+            cwd=vault,
+            check=True,
+            capture_output=True,
         )
 
 
@@ -74,7 +78,8 @@ def _install_obsidian_git_config(
 
 @_POSIX_ONLY
 def test_defer_when_env_true_and_recent_commit(
-    git_vault: Path, monkeypatch: pytest.MonkeyPatch,
+    git_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """env=true + obsidian-git present + last commit is recent → defer."""
     from hive._vault_write import _should_defer_to_external_committer
@@ -92,7 +97,8 @@ def test_defer_when_env_true_and_recent_commit(
 
 @_POSIX_ONLY
 def test_no_defer_when_env_false(
-    git_vault: Path, monkeypatch: pytest.MonkeyPatch,
+    git_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """env=false (default) + obsidian-git healthy → still commits via hive.
 
@@ -109,7 +115,8 @@ def test_no_defer_when_env_false(
 
 @_POSIX_ONLY
 def test_no_defer_when_env_explicitly_false(
-    git_vault: Path, monkeypatch: pytest.MonkeyPatch,
+    git_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Explicitly setting env to 'false' must also skip deferral."""
     from hive._vault_write import _should_defer_to_external_committer
@@ -125,7 +132,8 @@ def test_no_defer_when_env_explicitly_false(
 
 @_POSIX_ONLY
 def test_fallback_when_obsidian_stale_and_dirty(
-    git_vault: Path, monkeypatch: pytest.MonkeyPatch,
+    git_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """env=true + obsidian present + last commit > 2*interval AND vault is
     dirty → external committer is genuinely broken → fall back.
@@ -141,12 +149,14 @@ def test_fallback_when_obsidian_stale_and_dirty(
     # Make the existing init commit appear ancient (> 2 minutes ago).
     ancient_iso = "2024-01-01T00:00:00Z"
     subprocess.run(  # noqa: S603, S607
-        ["git", "commit", "--amend", "--no-edit",
-         "--date", ancient_iso],
-        cwd=git_vault, env={
+        ["git", "commit", "--amend", "--no-edit", "--date", ancient_iso],
+        cwd=git_vault,
+        env={
             **subprocess.os.environ,
             "GIT_COMMITTER_DATE": ancient_iso,
-        }, check=True, capture_output=True,
+        },
+        check=True,
+        capture_output=True,
     )
 
     # Leave a dirty file.
@@ -160,7 +170,8 @@ def test_fallback_when_obsidian_stale_and_dirty(
 
 @_POSIX_ONLY
 def test_defer_when_obsidian_present_and_vault_idle(
-    git_vault: Path, monkeypatch: pytest.MonkeyPatch,
+    git_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """env=true + obsidian present + last commit > 2*interval BUT vault
     is idle (clean porcelain) → defer is safe; nothing to commit anyway.
@@ -168,24 +179,31 @@ def test_defer_when_obsidian_present_and_vault_idle(
     from hive._vault_write import _should_defer_to_external_committer
 
     _install_obsidian_git_config(
-        git_vault, auto_save_interval_minutes=1, commit=True,
+        git_vault,
+        auto_save_interval_minutes=1,
+        commit=True,
     )
     monkeypatch.setenv("HIVE_AUTO_DEFER_TO_EXTERNAL_COMMITTER", "true")
 
     # Make the commit ancient AND leave the vault clean.
     ancient_iso = "2024-01-01T00:00:00Z"
     subprocess.run(  # noqa: S603, S607
-        ["git", "commit", "--amend", "--no-edit",
-         "--date", ancient_iso],
-        cwd=git_vault, env={
+        ["git", "commit", "--amend", "--no-edit", "--date", ancient_iso],
+        cwd=git_vault,
+        env={
             **subprocess.os.environ,
             "GIT_COMMITTER_DATE": ancient_iso,
-        }, check=True, capture_output=True,
+        },
+        check=True,
+        capture_output=True,
     )
     # Clean porcelain — assert it actually is clean
     porcelain = subprocess.run(  # noqa: S603, S607
         ["git", "status", "--porcelain"],
-        cwd=git_vault, capture_output=True, text=True, check=True,
+        cwd=git_vault,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout
     assert porcelain == "", f"vault not idle: {porcelain!r}"
 
@@ -197,7 +215,8 @@ def test_defer_when_obsidian_present_and_vault_idle(
 
 @_POSIX_ONLY
 def test_no_defer_when_obsidian_absent(
-    git_vault: Path, monkeypatch: pytest.MonkeyPatch,
+    git_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """env=true but obsidian-git absent → fall back to hive's commit."""
     from hive._vault_write import _should_defer_to_external_committer
@@ -213,7 +232,8 @@ def test_no_defer_when_obsidian_absent(
 
 @_POSIX_ONLY
 def test_vault_write_response_announces_deferral(
-    git_vault: Path, monkeypatch: pytest.MonkeyPatch,
+    git_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When a write is deferred, the tool response says so explicitly.
 
@@ -234,7 +254,8 @@ def test_vault_write_response_announces_deferral(
 
 @_POSIX_ONLY
 def test_vault_write_suffix_empty_when_no_defer(
-    git_vault: Path, monkeypatch: pytest.MonkeyPatch,
+    git_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """No defer + commit=True → empty deferral suffix (existing behaviour)."""
     from hive._helpers import _vault_write_deferral_suffix

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -42,7 +42,9 @@ class TestMatchAndReplace:
         # but unique in Pass 2 (body-only)
         content = _FM + "# Title\n\nStatus: active\n"
         ok, new_content = _match_and_replace(
-            content, "Status: active", "Status: done",
+            content,
+            "Status: active",
+            "Status: done",
         )
         assert ok
         assert new_content.startswith("---")
@@ -54,7 +56,9 @@ class TestMatchAndReplace:
         # LLM stripped trailing spaces
         find_text = "| A | B |\n|---|---|\n| 1 | 2 |"
         ok, new_content = _match_and_replace(
-            content, find_text, "| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |",
+            content,
+            find_text,
+            "| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |",
         )
         assert ok
         assert "| C |" in new_content
@@ -70,7 +74,9 @@ class TestMatchAndReplace:
         """Total miss returns diagnostic."""
         content = _FM + "# Title\n\nHello world\n"
         ok, msg = _match_and_replace(
-            content, "completely different text", "replacement",
+            content,
+            "completely different text",
+            "replacement",
         )
         assert not ok
         assert "not found" in msg.lower()
@@ -79,7 +85,9 @@ class TestMatchAndReplace:
         """Files without frontmatter still work (pass 1 or pass 3)."""
         content = "# Plain file\n\nHello world\n"
         ok, new_content = _match_and_replace(
-            content, "Hello world", "Goodbye world",
+            content,
+            "Hello world",
+            "Goodbye world",
         )
         assert ok
         assert "Goodbye world" in new_content
@@ -95,7 +103,9 @@ class TestMatchAndReplace:
         """Frontmatter is byte-identical after body replacement."""
         content = _FM + "# Title\n\nOld content\n"
         ok, new_content = _match_and_replace(
-            content, "Old content", "New content",
+            content,
+            "Old content",
+            "New content",
         )
         assert ok
         assert new_content.startswith(_FM)
@@ -104,7 +114,9 @@ class TestMatchAndReplace:
         """Pass 3 replacement preserves frontmatter."""
         content = _FM + "Hello world  \n"
         ok, new_content = _match_and_replace(
-            content, "Hello world", "Goodbye world",
+            content,
+            "Hello world",
+            "Goodbye world",
         )
         assert ok
         assert new_content.startswith("---")
@@ -180,7 +192,9 @@ class TestResolveProjectDir:
     def test_explicit_scope_flat(self, mock_vault: Path) -> None:
         """Explicit scope:slug resolves for flat scopes."""
         result = _resolve_project_dir(
-            mock_vault, "projects:testproject", _default_scopes(),
+            mock_vault,
+            "projects:testproject",
+            _default_scopes(),
         )
         assert result is not None
         assert result[0] == mock_vault / "10_projects" / "testproject"
@@ -271,7 +285,9 @@ class TestResolveProjectDir:
         assert "agents" in _default_scopes()
         (tmp_path / "80_agents" / "Hermes-NaN").mkdir(parents=True)
         result = _resolve_project_dir(
-            tmp_path, "agents:Hermes-NaN", _default_scopes(),
+            tmp_path,
+            "agents:Hermes-NaN",
+            _default_scopes(),
         )
         assert result is not None
         assert result[0] == tmp_path / "80_agents" / "Hermes-NaN"
@@ -373,21 +389,21 @@ class TestFindLessonHeading:
         """Heading inside ``` ... ``` must NOT be returned."""
         content = (
             "intro\n"
-            "```\n"                    # line 2  fence open
+            "```\n"  # line 2  fence open
             "### [2026-01-01] fake\n"  # line 3  fake heading
-            "```\n"                    # line 4  fence close
-            "body\n"                   # line 5  match line
+            "```\n"  # line 4  fence close
+            "body\n"  # line 5  match line
         )
         assert find_lesson_heading(content, 5) is None
 
     def test_real_heading_wins_when_fake_heading_inside_codeblock(self) -> None:
         content = (
             "### [2026-05-18] real heading\n"  # line 1
-            "intro\n"                            # line 2
-            "```\n"                              # line 3
-            "### [2026-01-01] fake\n"            # line 4
-            "```\n"                              # line 5
-            "body\n"                             # line 6  match line
+            "intro\n"  # line 2
+            "```\n"  # line 3
+            "### [2026-01-01] fake\n"  # line 4
+            "```\n"  # line 5
+            "body\n"  # line 6  match line
         )
         assert find_lesson_heading(content, 6) == "[2026-05-18] real heading"
 
@@ -403,8 +419,8 @@ class TestFindLessonHeading:
 
     def test_ignores_malformed_heading_without_date(self) -> None:
         content = (
-            "### no date here\n"   # line 1  malformed heading
-            "body line\n"           # line 2
+            "### no date here\n"  # line 1  malformed heading
+            "body line\n"  # line 2
         )
         assert find_lesson_heading(content, 2) is None
 
@@ -439,7 +455,9 @@ class TestGitCommitCoalesce:
     """
 
     def test_coalesces_multi_path(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """``_git_commit(vault, [p1, p2, p3], msg)`` → 1 add + 1 commit.
 
@@ -453,7 +471,10 @@ class TestGitCommitCoalesce:
         calls: list[list[str]] = []
 
         def fake_run_git(
-            args: list[str], _vault: Path, *, registry: object = None,  # noqa: ARG001
+            args: list[str],
+            _vault: Path,
+            *,
+            registry: object = None,  # noqa: ARG001
         ) -> tuple[int, str, str]:
             calls.append(["git", *args])
             return 0, "", ""
@@ -469,19 +490,22 @@ class TestGitCommitCoalesce:
         add_calls = [c for c in calls if c[:2] == ["git", "add"]]
         commit_calls = [c for c in calls if c[:2] == ["git", "commit"]]
         assert len(add_calls) == 1, f"expected 1 add, got {len(add_calls)}: {calls}"
-        assert len(commit_calls) == 1, (
-            f"expected 1 commit, got {len(commit_calls)}: {calls}"
-        )
+        assert len(commit_calls) == 1, f"expected 1 commit, got {len(commit_calls)}: {calls}"
         assert add_calls[0] == ["git", "add", "a.md", "b.md", "c.md"]
 
     def test_noop_on_empty_paths(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Empty path list must skip the helper entirely (no git invocation)."""
         calls: list[list[str]] = []
 
         def fake_run_git(
-            args: list[str], _vault: Path, *, registry: object = None,  # noqa: ARG001
+            args: list[str],
+            _vault: Path,
+            *,
+            registry: object = None,  # noqa: ARG001
         ) -> tuple[int, str, str]:
             calls.append(["git", *args])
             return 0, "", ""

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -30,7 +30,8 @@ def _text(result: ToolResult) -> str:
 
 def _server(vault: Path) -> FastMCP:
     return create_server(
-        vault_path=vault, idempotency_store=IdempotencyStore(":memory:"),
+        vault_path=vault,
+        idempotency_store=IdempotencyStore(":memory:"),
     )
 
 
@@ -39,8 +40,10 @@ async def _append(mcp: FastMCP, key: str, content: str) -> str:
         await mcp.call_tool(
             "vault_write",
             {
-                "project": "testproject", "section": "context",
-                "operation": "append", "content": content,
+                "project": "testproject",
+                "section": "context",
+                "operation": "append",
+                "content": content,
                 "idempotency_key": key,
             },
         ),
@@ -50,7 +53,8 @@ async def _append(mcp: FastMCP, key: str, content: str) -> str:
 async def _context_body(mcp: FastMCP) -> str:
     return _text(
         await mcp.call_tool(
-            "vault_query", {"project": "testproject", "section": "context"},
+            "vault_query",
+            {"project": "testproject", "section": "context"},
         ),
     )
 
@@ -94,14 +98,18 @@ async def test_patch_repeated_key_is_noop(git_vault: Path) -> None:
     await mcp.call_tool(
         "vault_write",
         {
-            "project": "testproject", "path": "90-notes.md",
-            "content": "# Notes\n\nstatus: draft\n", "doc_type": "note",
+            "project": "testproject",
+            "path": "90-notes.md",
+            "content": "# Notes\n\nstatus: draft\n",
+            "doc_type": "note",
             "operation": "create",
         },
     )
     args = {
-        "project": "testproject", "path": "90-notes.md",
-        "find": "status: draft", "replace": "status: final",
+        "project": "testproject",
+        "path": "90-notes.md",
+        "find": "status: draft",
+        "replace": "status: final",
         "idempotency_key": "patch-k1",
     }
     first = _text(await mcp.call_tool("vault_patch", args))
@@ -111,7 +119,8 @@ async def test_patch_repeated_key_is_noop(git_vault: Path) -> None:
     assert "already applied" in second.lower(), f"retry was not a no-op: {second!r}"
     body = _text(
         await mcp.call_tool(
-            "vault_query", {"project": "testproject", "path": "90-notes.md"},
+            "vault_query",
+            {"project": "testproject", "path": "90-notes.md"},
         ),
     )
     assert "status: draft" not in body

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -133,37 +133,57 @@ class TestHierarchicalScopeDiscovery:
         projects = _text(await mcp.call_tool("vault_list", {}))
         assert "work/" in projects
 
-        products = _text(await mcp.call_tool(
-            "vault_list", {"project": "work:20-products"},
-        ))
+        products = _text(
+            await mcp.call_tool(
+                "vault_list",
+                {"project": "work:20-products"},
+            )
+        )
         assert "hydra3d-plus" in products
 
-        ctx = _text(await mcp.call_tool(
-            "vault_query", {"project": "work:hydra3d-plus", "section": "context"},
-        ))
+        ctx = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "work:hydra3d-plus", "section": "context"},
+            )
+        )
         assert "Hydra3D Plus" in ctx
 
     async def test_auto_scan_resolves_nested_entity(
-        self, multi_scope_vault: Path,
+        self,
+        multi_scope_vault: Path,
     ) -> None:
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=_HIER_SCOPES)
 
-        ctx = _text(await mcp.call_tool(
-            "vault_query", {"project": "hydra3d-plus", "section": "context"},
-        ))
+        ctx = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "hydra3d-plus", "section": "context"},
+            )
+        )
         assert "Hydra3D Plus" in ctx
 
     async def test_search_with_scope_filter(self, multi_scope_vault: Path) -> None:
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=_HIER_SCOPES)
 
-        result = _text(await mcp.call_tool("vault_search", {
-            "query": "Hydra3D",
-            "scope": "work",
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {
+                    "query": "Hydra3D",
+                    "scope": "work",
+                },
+            )
+        )
         assert "hydra3d" in result.lower()
 
-        result = _text(await mcp.call_tool("vault_search", {
-            "query": "Hydra3D",
-            "scope": "projects",
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {
+                    "query": "Hydra3D",
+                    "scope": "projects",
+                },
+            )
+        )
         assert "no matches" in result.lower()

--- a/tests/test_lesson_reinforcement.py
+++ b/tests/test_lesson_reinforcement.py
@@ -14,8 +14,7 @@ class TestSchemaInit:
     def test_schema_has_lesson_reinforcement_table(self) -> None:
         t = LessonReinforcementTracker()
         rows = t._conn.execute(  # noqa: SLF001
-            "SELECT name FROM sqlite_master "
-            "WHERE type='table' AND name='lesson_reinforcement'",
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='lesson_reinforcement'",
         ).fetchall()
         assert rows, "lesson_reinforcement table missing"
 
@@ -28,8 +27,12 @@ class TestSchemaInit:
             ).fetchall()
         ]
         expected = {
-            "project", "heading", "reinforcements", "confidence",
-            "first_seen", "last_referenced",
+            "project",
+            "heading",
+            "reinforcements",
+            "confidence",
+            "first_seen",
+            "last_referenced",
         }
         assert expected.issubset(set(cols))
 
@@ -169,7 +172,7 @@ class TestTopByReinforcements:
     def test_top_respects_limit(self) -> None:
         t = LessonReinforcementTracker()
         for i in range(5):
-            heading = f"[2026-01-0{i+1}] l{i}"
+            heading = f"[2026-01-0{i + 1}] l{i}"
             t.ensure("hive", heading)
             for _ in range(i):
                 t.increment("hive", heading)
@@ -191,15 +194,13 @@ class TestTopByConfidenceTieBreaker:
         t.increment("hive", "[2026-01-01] old")
         t.flush()
         t._conn.execute(  # noqa: SLF001
-            "UPDATE lesson_reinforcement SET last_referenced='2026-01-01' "
-            "WHERE heading=?",
+            "UPDATE lesson_reinforcement SET last_referenced='2026-01-01' WHERE heading=?",
             ("[2026-01-01] old",),
         )
         t.increment("hive", "[2026-01-02] new")
         t.flush()
         t._conn.execute(  # noqa: SLF001
-            "UPDATE lesson_reinforcement SET last_referenced='2026-05-18' "
-            "WHERE heading=?",
+            "UPDATE lesson_reinforcement SET last_referenced='2026-05-18' WHERE heading=?",
             ("[2026-01-02] new",),
         )
         t._conn.commit()  # noqa: SLF001
@@ -211,8 +212,8 @@ class TestTopByHybridBlend:
     def test_hybrid_blend_favors_high_bm25_when_low_conf_gap(self) -> None:
         """High BM25 wins over moderate confidence gap (alpha=0.7 BM25-leaning)."""
         t = LessonReinforcementTracker()
-        t.ensure("hive", "[2026-01-01] hi_bm25", confidence=0.7)   # low conf
-        t.ensure("hive", "[2026-01-02] hi_conf", confidence=1.0)   # high conf
+        t.ensure("hive", "[2026-01-01] hi_bm25", confidence=0.7)  # low conf
+        t.ensure("hive", "[2026-01-02] hi_conf", confidence=1.0)  # high conf
 
         bm25 = {
             "[2026-01-01] hi_bm25": 1.0,  # max BM25
@@ -221,7 +222,10 @@ class TestTopByHybridBlend:
         # hybrid_score(hi_bm25) = 0.7*1.0 + 0.3*0.7 = 0.91
         # hybrid_score(hi_conf) = 0.7*0.0 + 0.3*1.0 = 0.30
         top = t.top(
-            "hive", by="hybrid", limit=2, bm25_scores=bm25,
+            "hive",
+            by="hybrid",
+            limit=2,
+            bm25_scores=bm25,
         )
         assert top[0] == "[2026-01-01] hi_bm25"
 

--- a/tests/test_lesson_reinforcement_e2e.py
+++ b/tests/test_lesson_reinforcement_e2e.py
@@ -33,12 +33,7 @@ def _text(result: ToolResult) -> str:
 
 
 _LESSONS_HEADER = (
-    "---\n"
-    "id: testproject-lessons\n"
-    "type: lesson\n"
-    "status: active\n"
-    "---\n\n"
-    "# Test: Lessons\n\n"
+    "---\nid: testproject-lessons\ntype: lesson\nstatus: active\n---\n\n# Test: Lessons\n\n"
 )
 
 
@@ -56,8 +51,7 @@ def _git_init_commit(vault: Path, msg: str = "init") -> None:
 def _seed_three_lessons(project_dir: Path) -> None:
     project_dir.mkdir(parents=True)
     (project_dir / "00-context.md").write_text(
-        "---\nid: testproject\ntype: project\nstatus: active\n---\n\n"
-        "# Test\n\nOverview.\n",
+        "---\nid: testproject\ntype: project\nstatus: active\n---\n\n# Test\n\nOverview.\n",
     )
     (project_dir / "90-lessons.md").write_text(
         _LESSONS_HEADER
@@ -93,7 +87,8 @@ def e2e_mcp(
     lesson_tracker: LessonReinforcementTracker,
 ) -> Generator[FastMCP, None, None]:
     mcp = create_server(
-        vault_path=e2e_vault, lesson_tracker=lesson_tracker,
+        vault_path=e2e_vault,
+        lesson_tracker=lesson_tracker,
     )
     yield mcp
     ctx = getattr(mcp, "_hive_ctx", None)
@@ -130,13 +125,16 @@ class TestE2ECaptureThenSearchRanked:
         )
         # Direct verification on tracker state.
         alpha = lesson_tracker.get(
-            "testproject", "[2026-01-01] alpha bug fix",
+            "testproject",
+            "[2026-01-01] alpha bug fix",
         )
         beta = lesson_tracker.get(
-            "testproject", "[2026-01-02] beta refactor",
+            "testproject",
+            "[2026-01-02] beta refactor",
         )
         gamma = lesson_tracker.get(
-            "testproject", "[2026-01-03] gamma docs",
+            "testproject",
+            "[2026-01-03] gamma docs",
         )
         assert alpha is not None
         assert beta is not None
@@ -148,10 +146,12 @@ class TestE2ECaptureThenSearchRanked:
         assert gamma["reinforcements"] == 1
 
         # Now verify the ranked search response surfaces alpha first.
-        result = _text(await e2e_mcp.call_tool(
-            "vault_search",
-            {"query": "Context", "rank_by": "reinforcements"},
-        ))
+        result = _text(
+            await e2e_mcp.call_tool(
+                "vault_search",
+                {"query": "Context", "rank_by": "reinforcements"},
+            )
+        )
         alpha_pos = result.find("alpha bug fix")
         beta_pos = result.find("beta refactor")
         gamma_pos = result.find("gamma docs")
@@ -171,31 +171,38 @@ class TestE2ECaptureLessonFindMode:
         e2e_mcp: FastMCP,
         lesson_tracker: LessonReinforcementTracker,
     ) -> None:
-        result = _text(await e2e_mcp.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "find": "alpha"},
-        ))
+        result = _text(
+            await e2e_mcp.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "find": "alpha"},
+            )
+        )
         # Response surfaces the matching lesson.
         assert "alpha bug fix" in result
         # The matching lesson got incremented.
         alpha = lesson_tracker.get(
-            "testproject", "[2026-01-01] alpha bug fix",
+            "testproject",
+            "[2026-01-01] alpha bug fix",
         )
         assert alpha is not None
         assert alpha["reinforcements"] == 1
         # Non-matching lessons untouched.
         beta = lesson_tracker.get(
-            "testproject", "[2026-01-02] beta refactor",
+            "testproject",
+            "[2026-01-02] beta refactor",
         )
         assert beta is None
 
     async def test_find_mode_no_matches_returns_clear_message(
-        self, e2e_mcp: FastMCP,
+        self,
+        e2e_mcp: FastMCP,
     ) -> None:
-        result = _text(await e2e_mcp.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "find": "nonexistent-xyz"},
-        ))
+        result = _text(
+            await e2e_mcp.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "find": "nonexistent-xyz"},
+            )
+        )
         lower = result.lower()
         assert "no" in lower and "lesson" in lower
 
@@ -226,10 +233,12 @@ class TestE2EReadThenRank:
             assert row is not None
             assert row["reinforcements"] == 1
         # Now rank_by search finds them (body content lookup).
-        result = _text(await e2e_mcp.call_tool(
-            "vault_search",
-            {"query": "Context", "rank_by": "reinforcements"},
-        ))
+        result = _text(
+            await e2e_mcp.call_tool(
+                "vault_search",
+                {"query": "Context", "rank_by": "reinforcements"},
+            )
+        )
         assert "alpha" in result or "beta" in result or "gamma" in result
 
 
@@ -246,7 +255,8 @@ class TestE2EBackCompat:
         identical regardless of tracker state. Stronger than T2.5 — checks
         every search variant (filter, regex, plain)."""
         mcp1 = create_server(
-            vault_path=e2e_vault, lesson_tracker=lesson_tracker,
+            vault_path=e2e_vault,
+            lesson_tracker=lesson_tracker,
         )
         try:
             queries = [
@@ -254,10 +264,7 @@ class TestE2EBackCompat:
                 {"query": "alpha"},
                 {"query": "context", "type_filter": "project"},
             ]
-            golden = [
-                _text(await mcp1.call_tool("vault_search", q))
-                for q in queries
-            ]
+            golden = [_text(await mcp1.call_tool("vault_search", q)) for q in queries]
         finally:
             ctx = getattr(mcp1, "_hive_ctx", None)
             if ctx is not None:
@@ -269,20 +276,20 @@ class TestE2EBackCompat:
         lesson_tracker.ensure("testproject", "[2026-01-01] alpha bug fix")
         for _ in range(10):
             lesson_tracker.increment(
-                "testproject", "[2026-01-01] alpha bug fix",
+                "testproject",
+                "[2026-01-01] alpha bug fix",
             )
 
         # Re-run with the SAME tracker and a fresh server. Default outputs
         # must match byte-for-byte.
         mcp2 = create_server(
-            vault_path=e2e_vault, lesson_tracker=lesson_tracker,
+            vault_path=e2e_vault,
+            lesson_tracker=lesson_tracker,
         )
         try:
             for i, q in enumerate(queries):
                 replay = _text(await mcp2.call_tool("vault_search", q))
-                assert replay == golden[i], (
-                    f"default vault_search query {q} drifted between runs"
-                )
+                assert replay == golden[i], f"default vault_search query {q} drifted between runs"
         finally:
             ctx = getattr(mcp2, "_hive_ctx", None)
             if ctx is not None:
@@ -295,7 +302,10 @@ class TestE2EBackCompat:
 
 
 def _subprocess_increment_target(
-    db_path: str, project: str, heading: str, n: int,
+    db_path: str,
+    project: str,
+    heading: str,
+    n: int,
 ) -> None:
     """Target for multiprocessing.Process — opens its OWN tracker over
     the same on-disk SQLite file and increments N times. Validates the
@@ -346,8 +356,7 @@ class TestE2ECrossProcessIncrement:
             row = verifier.get(project, heading)
             assert row is not None
             assert row["reinforcements"] == 10, (
-                f"expected 10 cumulative increments across 2 processes, "
-                f"got {row['reinforcements']}"
+                f"expected 10 cumulative increments across 2 processes, got {row['reinforcements']}"
             )
         finally:
             verifier.close()
@@ -359,7 +368,8 @@ class TestE2EConcurrentLazyEnsureRace:
     count == 2 (INSERT OR IGNORE wins the race)."""
 
     def test_concurrent_first_touch_no_duplicate_key(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         db_path = str(tmp_path / "lesson.db")
         project = "p"
@@ -384,10 +394,7 @@ class TestE2EConcurrentLazyEnsureRace:
             row = verifier.get(project, heading)
             assert row is not None, "lazy-create lost the race entirely"
             assert row["reinforcements"] == 2, (
-                f"expected exactly 2 increments under lazy-create race, "
-                f"got {row['reinforcements']}"
+                f"expected exactly 2 increments under lazy-create race, got {row['reinforcements']}"
             )
         finally:
             verifier.close()
-
-

--- a/tests/test_lesson_reinforcement_hooks.py
+++ b/tests/test_lesson_reinforcement_hooks.py
@@ -30,12 +30,7 @@ def _text(result: ToolResult) -> str:
 
 
 _LESSONS_HEADER = (
-    "---\n"
-    "id: testproject-lessons\n"
-    "type: lesson\n"
-    "status: active\n"
-    "---\n\n"
-    "# Test: Lessons\n\n"
+    "---\nid: testproject-lessons\ntype: lesson\nstatus: active\n---\n\n# Test: Lessons\n\n"
 )
 
 
@@ -53,32 +48,49 @@ def _three_lessons_body() -> str:
 
 def _git_init_commit(vault: Path, msg: str = "init") -> None:
     subprocess.run(
-        ["git", "init"], cwd=vault, check=True, capture_output=True,
+        ["git", "init"],
+        cwd=vault,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.email", "t@t.com"],
-        cwd=vault, check=True, capture_output=True,
+        cwd=vault,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.name", "T"],
-        cwd=vault, check=True, capture_output=True,
+        cwd=vault,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
-        ["git", "add", "."], cwd=vault, check=True, capture_output=True,
+        ["git", "add", "."],
+        cwd=vault,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "commit", "-m", msg],
-        cwd=vault, check=True, capture_output=True,
+        cwd=vault,
+        check=True,
+        capture_output=True,
     )
 
 
 def _git_recommit(vault: Path, msg: str = "update") -> None:
     subprocess.run(
-        ["git", "add", "."], cwd=vault, check=True, capture_output=True,
+        ["git", "add", "."],
+        cwd=vault,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "commit", "-m", msg],
-        cwd=vault, check=True, capture_output=True,
+        cwd=vault,
+        check=True,
+        capture_output=True,
     )
 
 
@@ -159,7 +171,9 @@ class TestCaptureLessonInsertsBaseline:
                 {
                     "project": "testproject",
                     "title": title,
-                    "context": "c", "problem": "p", "solution": "s",
+                    "context": "c",
+                    "problem": "p",
+                    "solution": "s",
                 },
             )
         for title in ("L1", "L2", "L3"):
@@ -189,8 +203,7 @@ class TestVaultQueryIncrementsLessons:
             row = lesson_tracker.get("testproject", heading)
             assert row is not None, f"no increment for {heading}"
             assert row["reinforcements"] == 1, (
-                f"{heading}: expected single dedup increment, got "
-                f"{row['reinforcements']}"
+                f"{heading}: expected single dedup increment, got {row['reinforcements']}"
             )
 
     async def test_vault_query_non_lesson_file_is_noop_on_db(
@@ -223,16 +236,22 @@ class TestVaultSearchRankBy:
         """Back-compat: default vault_search output is byte-identical
         regardless of tracker state. The hook must NOT mutate the
         rank_by='bm25' code path."""
-        before = _text(await lesson_mcp.call_tool(
-            "vault_search", {"query": "lesson"},
-        ))
+        before = _text(
+            await lesson_mcp.call_tool(
+                "vault_search",
+                {"query": "lesson"},
+            )
+        )
         # Mutate the tracker — this must NOT change subsequent default output.
         lesson_tracker.ensure("testproject", "[2026-01-01] alpha lesson")
         lesson_tracker.increment("testproject", "[2026-01-01] alpha lesson")
         lesson_tracker.increment("testproject", "[2026-01-01] alpha lesson")
-        after = _text(await lesson_mcp.call_tool(
-            "vault_search", {"query": "lesson"},
-        ))
+        after = _text(
+            await lesson_mcp.call_tool(
+                "vault_search",
+                {"query": "lesson"},
+            )
+        )
         assert before == after, "default vault_search output drifted with tracker state"
 
     async def test_rank_by_reinforcements_filters_to_lessons_file_only(
@@ -244,28 +263,32 @@ class TestVaultSearchRankBy:
         rank_by=reinforcements only the lesson hit must appear."""
         lesson_tracker.ensure("testproject", "[2026-01-01] alpha lesson")
         lesson_tracker.increment("testproject", "[2026-01-01] alpha lesson")
-        result = _text(await lesson_mcp.call_tool(
-            "vault_search",
-            {"query": "alpha", "rank_by": "reinforcements"},
-        ))
+        result = _text(
+            await lesson_mcp.call_tool(
+                "vault_search",
+                {"query": "alpha", "rank_by": "reinforcements"},
+            )
+        )
         assert "90-lessons.md" in result
         assert "00-context.md" not in result
 
     async def test_rank_by_invalid_returns_clear_error(
-        self, lesson_mcp: FastMCP,
+        self,
+        lesson_mcp: FastMCP,
     ) -> None:
         """`rank_by='bogus'` MUST NOT silently fall back to bm25 — it
         must surface a clear error mentioning both the field and the bad
         value so typos are caught immediately."""
-        result = _text(await lesson_mcp.call_tool(
-            "vault_search",
-            {"query": "alpha", "rank_by": "bogus"},
-        ))
+        result = _text(
+            await lesson_mcp.call_tool(
+                "vault_search",
+                {"query": "alpha", "rank_by": "bogus"},
+            )
+        )
         lower = result.lower()
         assert "rank_by" in lower
         assert "bogus" in result, (
-            "Error message must include the bad value 'bogus' so the "
-            "user sees what to fix"
+            "Error message must include the bad value 'bogus' so the user sees what to fix"
         )
 
 
@@ -279,15 +302,20 @@ class TestLazyEnsureForPreExistingLessons:
         lesson_tracker: LessonReinforcementTracker,
     ) -> None:
         # Tracker is empty before the call.
-        assert lesson_tracker.get(
-            "testproject", "[2026-01-01] alpha lesson",
-        ) is None
+        assert (
+            lesson_tracker.get(
+                "testproject",
+                "[2026-01-01] alpha lesson",
+            )
+            is None
+        )
         await lesson_mcp.call_tool(
             "vault_query",
             {"project": "testproject", "section": "lessons"},
         )
         row = lesson_tracker.get(
-            "testproject", "[2026-01-01] alpha lesson",
+            "testproject",
+            "[2026-01-01] alpha lesson",
         )
         assert row is not None, "first read should lazy-create the DB row"
         # First read counts as the lazy-create + the increment.
@@ -320,7 +348,8 @@ class TestHeadingParserEdgeCases:
         _git_recommit(lesson_vault)
 
         mcp = create_server(
-            vault_path=lesson_vault, lesson_tracker=lesson_tracker,
+            vault_path=lesson_vault,
+            lesson_tracker=lesson_tracker,
         )
         try:
             await mcp.call_tool(
@@ -335,12 +364,14 @@ class TestHeadingParserEdgeCases:
                 ctx.relevance.close()
 
         real = lesson_tracker.get(
-            "testproject", "[2026-01-01] real heading",
+            "testproject",
+            "[2026-01-01] real heading",
         )
         assert real is not None
         assert real["reinforcements"] == 1
         fake = lesson_tracker.get(
-            "testproject", "[2026-12-31] fake heading inside code",
+            "testproject",
+            "[2026-12-31] fake heading inside code",
         )
         assert fake is None, "heading inside code block must NOT be counted"
 
@@ -362,7 +393,8 @@ class TestHeadingParserEdgeCases:
         _git_recommit(lesson_vault)
 
         mcp = create_server(
-            vault_path=lesson_vault, lesson_tracker=lesson_tracker,
+            vault_path=lesson_vault,
+            lesson_tracker=lesson_tracker,
         )
         try:
             # The call must not raise.
@@ -378,6 +410,10 @@ class TestHeadingParserEdgeCases:
                 ctx.relevance.close()
 
         assert lesson_tracker.get("testproject", "no date here") is None
-        assert lesson_tracker.get(
-            "testproject", "[not-a-date] also broken",
-        ) is None
+        assert (
+            lesson_tracker.get(
+                "testproject",
+                "[not-a-date] also broken",
+            )
+            is None
+        )

--- a/tests/test_lock_eviction.py
+++ b/tests/test_lock_eviction.py
@@ -23,13 +23,16 @@ def tracker(tmp_path: Path) -> LockEvictionTracker:
 
 class TestLockEvictionTracker:
     def test_empty_tracker_returns_zero(
-        self, tracker: LockEvictionTracker,
+        self,
+        tracker: LockEvictionTracker,
     ) -> None:
         assert tracker.count_last_30d() == 0
         assert tracker.last_iso() is None
 
     def test_record_then_count(
-        self, tracker: LockEvictionTracker, tmp_path: Path,
+        self,
+        tracker: LockEvictionTracker,
+        tmp_path: Path,
     ) -> None:
         tracker.record(tmp_path, killed_pids=[111, 222])
         assert tracker.count_last_30d() == 1
@@ -39,22 +42,25 @@ class TestLockEvictionTracker:
         assert last.endswith("+00:00") or last.endswith("Z")
 
     def test_multiple_records_ordered(
-        self, tracker: LockEvictionTracker, tmp_path: Path,
+        self,
+        tracker: LockEvictionTracker,
+        tmp_path: Path,
     ) -> None:
         for i in range(5):
             tracker.record(tmp_path, killed_pids=[1000 + i])
         assert tracker.count_last_30d() == 5
 
     def test_old_events_excluded_from_30d_count(
-        self, tracker: LockEvictionTracker, tmp_path: Path,
+        self,
+        tracker: LockEvictionTracker,
+        tmp_path: Path,
     ) -> None:
         """Manually insert a row dated 40 days ago; not in 30d window."""
-        old_ts = (
-            _dt.datetime.now(_dt.UTC) - _dt.timedelta(days=40)
-        ).isoformat(timespec="microseconds")
+        old_ts = (_dt.datetime.now(_dt.UTC) - _dt.timedelta(days=40)).isoformat(
+            timespec="microseconds"
+        )
         tracker._conn.execute(
-            "INSERT INTO lock_evictions "
-            "(iso_ts, vault_path, killed_pids_json) VALUES (?, ?, ?)",
+            "INSERT INTO lock_evictions (iso_ts, vault_path, killed_pids_json) VALUES (?, ?, ?)",
             (old_ts, str(tmp_path), "[]"),
         )
         tracker._conn.commit()

--- a/tests/test_outbox.py
+++ b/tests/test_outbox.py
@@ -80,9 +80,7 @@ def test_same_process_top_does_not_double_count(tmp_path: Path) -> None:
         row = tracker.get("proj", "[2026-05-22] a")
         assert row is not None
         # Counter should be 2 (one flushed + one buffered), not 1 or 3.
-        assert row["reinforcements"] == 2, (
-            f"expected reinforcements=2; got {row!r}"
-        )
+        assert row["reinforcements"] == 2, f"expected reinforcements=2; got {row!r}"
     finally:
         tracker.close()
 
@@ -104,7 +102,8 @@ def test_cross_process_eventual_consistency(tmp_path: Path) -> None:
     tick = 0.5  # fast tick to keep test runtime sane
 
     proc_a = LessonReinforcementTracker(
-        db_path=str(db), outbox_tick_s=tick,
+        db_path=str(db),
+        outbox_tick_s=tick,
     )
     try:
         proc_a.increment("proj", "[2026-05-22] cross-proc")
@@ -116,7 +115,8 @@ def test_cross_process_eventual_consistency(tmp_path: Path) -> None:
     # Open a fresh tracker (mimics "process B" with its own connection
     # and outbox); reads must see the DB row written by proc_a.
     proc_b = LessonReinforcementTracker(
-        db_path=str(db), outbox_tick_s=tick,
+        db_path=str(db),
+        outbox_tick_s=tick,
     )
     try:
         row = proc_b.get("proj", "[2026-05-22] cross-proc")
@@ -146,7 +146,8 @@ def test_reconciler_busy_timeout_guard_does_not_hang(tmp_path: Path) -> None:
     db = tmp_path / "lesson.db"
 
     tracker = LessonReinforcementTracker(
-        db_path=str(db), outbox_tick_s=0.2,
+        db_path=str(db),
+        outbox_tick_s=0.2,
     )
     try:
         tracker.increment("proj", "[2026-05-22] busy-test")
@@ -170,10 +171,9 @@ def test_reconciler_busy_timeout_guard_does_not_hang(tmp_path: Path) -> None:
 
         # Reconciler is still running (no thread crash). Sanity check
         # — the daemon thread is alive on the tracker.
-        assert (
-            tracker._reconciler_thread is None
-            or tracker._reconciler_thread.is_alive()
-        ), "reconciler thread crashed"
+        assert tracker._reconciler_thread is None or tracker._reconciler_thread.is_alive(), (
+            "reconciler thread crashed"
+        )
         # Outbox preserved (counter not yet visible from sibling's view —
         # we'll release and verify the recovery path).
         sibling.execute("ROLLBACK")
@@ -238,9 +238,7 @@ def test_outbox_drain_is_atomic_under_concurrent_appends() -> None:
     # No entries lost: drained + remaining + already-drained-pre-thread = 200
     remaining = box.drain()
     total = sum(len(d) for d in drained) + len(remaining)
-    assert total == 200, (
-        f"entries lost: drained={drained!r}, remaining={remaining!r}"
-    )
+    assert total == 200, f"entries lost: drained={drained!r}, remaining={remaining!r}"
 
 
 def test_outbox_crash_loss_contract_is_documented() -> None:

--- a/tests/test_relevance.py
+++ b/tests/test_relevance.py
@@ -130,7 +130,10 @@ class TestExploration:
         t.record_access("hive", "tasks")
         recent_sections = ["lessons", "roadmap"]
         result = t.top_sections_with_exploration(
-            "hive", n=3, recent_sections=recent_sections, epsilon=1.0,
+            "hive",
+            n=3,
+            recent_sections=recent_sections,
+            epsilon=1.0,
         )
         assert any(s in result for s in recent_sections)
 
@@ -139,7 +142,10 @@ class TestExploration:
         t.record_access("hive", "tasks")
         recent_sections = ["lessons", "roadmap"]
         result = t.top_sections_with_exploration(
-            "hive", n=1, recent_sections=recent_sections, epsilon=0.0,
+            "hive",
+            n=1,
+            recent_sections=recent_sections,
+            epsilon=0.0,
         )
         assert result == ["tasks"]
 
@@ -148,7 +154,10 @@ class TestExploration:
         t.record_access("hive", "tasks")
         # "tasks" is already in top — should not be added again as exploration
         result = t.top_sections_with_exploration(
-            "hive", n=3, recent_sections=["tasks"], epsilon=1.0,
+            "hive",
+            n=3,
+            recent_sections=["tasks"],
+            epsilon=1.0,
         )
         assert result.count("tasks") == 1
 
@@ -206,10 +215,7 @@ class TestThreadSafety:
             except Exception as exc:
                 errors.append(exc)
 
-        threads = [
-            threading.Thread(target=worker, args=(i,))
-            for i in range(n_threads)
-        ]
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
         for th in threads:
             th.start()
         for th in threads:

--- a/tests/test_run_git.py
+++ b/tests/test_run_git.py
@@ -107,7 +107,8 @@ def test_git_commit_warning_carries_cause_git_error(
     _git_commit(git_vault, [bogus.relative_to(git_vault)], "test")
 
     git_warnings = [
-        rec.message for rec in caplog.records
+        rec.message
+        for rec in caplog.records
         if rec.levelno >= logging.WARNING
         and ("git add" in rec.message or "git commit" in rec.message)
     ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -69,33 +69,40 @@ class TestVaultNotFound:
 
     async def test_vault_query(self, missing_vault_mcp: FastMCP) -> None:
         result = await missing_vault_mcp.call_tool(
-            "vault_query", {"project": "test"},
+            "vault_query",
+            {"project": "test"},
         )
         assert "Vault not found" in _text(result)
 
     async def test_vault_search(self, missing_vault_mcp: FastMCP) -> None:
         result = await missing_vault_mcp.call_tool(
-            "vault_search", {"query": "hello"},
+            "vault_search",
+            {"query": "hello"},
         )
         assert "Vault not found" in _text(result)
 
     async def test_session_briefing(self, missing_vault_mcp: FastMCP) -> None:
         result = await missing_vault_mcp.call_tool(
-            "session_briefing", {"project": "test"},
+            "session_briefing",
+            {"project": "test"},
         )
         assert "Vault not found" in _text(result)
 
     async def test_vault_write(self, missing_vault_mcp: FastMCP) -> None:
         result = await missing_vault_mcp.call_tool(
-            "vault_write", {"project": "test", "content": "hello"},
+            "vault_write",
+            {"project": "test", "content": "hello"},
         )
         assert "Vault not found" in _text(result)
 
     async def test_vault_patch(self, missing_vault_mcp: FastMCP) -> None:
         result = await missing_vault_mcp.call_tool(
-            "vault_patch", {
-                "project": "test", "path": "f.md",
-                "find": "a", "replace": "b",
+            "vault_patch",
+            {
+                "project": "test",
+                "path": "f.md",
+                "find": "a",
+                "replace": "b",
             },
         )
         assert "Vault not found" in _text(result)
@@ -106,9 +113,13 @@ class TestVaultNotFound:
 
     async def test_capture_lesson(self, missing_vault_mcp: FastMCP) -> None:
         result = await missing_vault_mcp.call_tool(
-            "capture_lesson", {
-                "project": "test", "title": "t",
-                "context": "c", "problem": "p", "solution": "s",
+            "capture_lesson",
+            {
+                "project": "test",
+                "title": "t",
+                "context": "c",
+                "problem": "p",
+                "solution": "s",
             },
         )
         assert "Vault not found" in _text(result)
@@ -171,7 +182,8 @@ class TestUnicodeDecodeErrors:
         bad.write_bytes(b"\xff\xfe invalid utf-8")
         mcp = create_server(vault_path=mock_vault)
         result = await mcp.call_tool(
-            "vault_query", {"project": "testproject", "path": "bad.md"},
+            "vault_query",
+            {"project": "testproject", "path": "bad.md"},
         )
         text = _text(result)
         assert "utf-8" in text.lower() or "error" in text.lower()
@@ -181,22 +193,27 @@ class TestUnicodeDecodeErrors:
         bad.write_bytes(b"\xff\xfe invalid utf-8")
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_patch", {
-                "project": "testproject", "path": "bad.md",
-                "find": "a", "replace": "b",
+            "vault_patch",
+            {
+                "project": "testproject",
+                "path": "bad.md",
+                "find": "a",
+                "replace": "b",
             },
         )
         text = _text(result)
         assert "utf-8" in text.lower() or "error" in text.lower()
 
     async def test_vault_write_append_non_utf8(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         bad = git_vault / "10_projects" / "testproject" / "90-lessons.md"
         bad.write_bytes(b"\xff\xfe invalid utf-8")
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_write", {
+            "vault_write",
+            {
                 "project": "testproject",
                 "content": "\nnew content\n",
                 "section": "lessons",
@@ -368,13 +385,15 @@ class TestVaultSearch:
 
     async def test_invalid_regex_rejected(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_search", {"query": "[invalid", "use_regex": True},
+            "vault_search",
+            {"query": "[invalid", "use_regex": True},
         )
         assert "invalid regex" in _text(result).lower()
 
     async def test_negative_since_days_rejected(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_search", {"query": "test", "since_days": -5},
+            "vault_search",
+            {"query": "test", "since_days": -5},
         )
         assert "positive" in _text(result).lower()
 
@@ -413,9 +432,7 @@ class TestVaultSearch:
         assert "adr-001-test" in text
 
     async def test_type_filter_excludes_non_matching(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "Test", "type_filter": "adr"}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "Test", "type_filter": "adr"})
         text = _text(result)
         assert "00-context.md" not in text
 
@@ -455,15 +472,11 @@ class TestVaultSearch:
         assert "extra-lesson" in text
 
     async def test_regex_too_long_rejected(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "a" * 201, "use_regex": True}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "a" * 201, "use_regex": True})
         assert "too long" in _text(result).lower()
 
     async def test_regex_at_max_length_accepted(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "a" * 200, "use_regex": True}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "a" * 200, "use_regex": True})
         text = _text(result)
         # Should not be rejected — either finds matches or returns "no matches"
         assert "too long" not in text.lower()
@@ -472,9 +485,7 @@ class TestVaultSearch:
         bare = mock_vault / "10_projects" / "testproject" / "bare.md"
         bare.write_text("# No frontmatter\nSome active content.\n")
         mcp = create_server(vault_path=mock_vault)
-        result = await mcp.call_tool(
-            "vault_search", {"query": "active", "type_filter": "project"}
-        )
+        result = await mcp.call_tool("vault_search", {"query": "active", "type_filter": "project"})
         text = _text(result)
         assert "bare.md" not in text
 
@@ -560,7 +571,8 @@ class TestVaultHealth:
     # -- ghost-response counter surface (HIVE-104 Fase C) --
 
     async def test_ghost_responses_block_when_counter_nonzero(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """When _compat.GHOST_RESPONSES has entries, vault_health surfaces them."""
         from hive import _compat as _hc
@@ -576,7 +588,8 @@ class TestVaultHealth:
             _hc.GHOST_RESPONSES.reset()
 
     async def test_ghost_responses_block_omitted_when_zero(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """When no ghost responses recorded, the block is omitted."""
         from hive import _compat as _hc
@@ -595,7 +608,8 @@ class TestVaultHealthIdentity:
     """Identity block is always present at the top of vault_health output."""
 
     async def test_identity_block_present_no_args(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """Default vault_health() includes the ## server identity block."""
         result = _text(await vault_mcp.call_tool("vault_health", {}))
@@ -607,7 +621,8 @@ class TestVaultHealthIdentity:
         assert "- started_at:" in result
 
     async def test_identity_appears_before_project_stats(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """Identity block is prepended — appears before per-project blocks."""
         result = _text(await vault_mcp.call_tool("vault_health", {}))
@@ -618,12 +633,14 @@ class TestVaultHealthIdentity:
         assert idx_server < idx_project
 
     async def test_identity_with_validation_mode(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """Identity block also appears when checks=[...] is passed."""
         result = _text(
             await vault_mcp.call_tool(
-                "vault_health", {"checks": ["frontmatter"]},
+                "vault_health",
+                {"checks": ["frontmatter"]},
             ),
         )
         assert "## server" in result
@@ -641,14 +658,16 @@ class TestVaultHealthIdentity:
             _close_server(mcp)
 
     async def test_identity_backends_no_api_keys(
-        self, mock_vault: Path,
+        self,
+        mock_vault: Path,
     ) -> None:
         """The identity block never embeds API key material."""
         secret = "sk-DO-NOT-LEAK-CANARY-12345"
         mcp = create_server(
             vault_path=mock_vault,
             openrouter_client=OpenRouterClient(
-                api_key=secret, default_model="qwen/qwen3-coder:free",
+                api_key=secret,
+                default_model="qwen/qwen3-coder:free",
             ),
         )
         try:
@@ -661,7 +680,8 @@ class TestVaultHealthIdentity:
             _close_server(mcp)
 
     async def test_identity_total_length_bounded(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """Acceptance: identity block adds <10 lines to the report."""
         result = _text(await vault_mcp.call_tool("vault_health", {}))
@@ -673,10 +693,7 @@ class TestVaultHealthIdentity:
         )
         assert start is not None
         end = next(
-            (
-                i for i, line in enumerate(lines[start + 1 :], start + 1)
-                if line.startswith("## ")
-            ),
+            (i for i, line in enumerate(lines[start + 1 :], start + 1) if line.startswith("## ")),
             len(lines),
         )
         assert (end - start) < 10
@@ -686,18 +703,21 @@ class TestVaultHealthRuntime:
     """include_runtime=True activates the optional ## runtime block."""
 
     async def test_runtime_block_omitted_by_default(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         result = _text(await vault_mcp.call_tool("vault_health", {}))
         assert "## runtime" not in result
         assert "uptime_s" not in result
 
     async def test_runtime_block_present_when_opted_in(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         result = _text(
             await vault_mcp.call_tool(
-                "vault_health", {"include_runtime": True},
+                "vault_health",
+                {"include_runtime": True},
             ),
         )
         assert "## runtime" in result
@@ -706,21 +726,27 @@ class TestVaultHealthRuntime:
         assert "openrouter_budget" in result
 
     async def test_runtime_lists_registered_tool_names(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """tools_registered must include the known hive tools."""
         result = _text(
             await vault_mcp.call_tool(
-                "vault_health", {"include_runtime": True},
+                "vault_health",
+                {"include_runtime": True},
             ),
         )
         for expected in (
-            "vault_query", "vault_search", "vault_health", "vault_list",
+            "vault_query",
+            "vault_search",
+            "vault_health",
+            "vault_list",
         ):
             assert expected in result
 
     async def test_runtime_orthogonal_to_include_usage(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """include_runtime is independent from include_usage — both can stack."""
         result = _text(
@@ -731,20 +757,19 @@ class TestVaultHealthRuntime:
         )
         assert "## runtime" in result
         # usage block surfaces 'No vault tool calls' or 'Total calls:'
-        assert (
-            "no vault tool calls" in result.lower()
-            or "Total calls:" in result
-        )
+        assert "no vault tool calls" in result.lower() or "Total calls:" in result
 
     async def test_runtime_block_includes_wal_size_bytes(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """HIVE-115 / ADR-009: wal_size_bytes field present as non-negative int."""
         import re
 
         result = _text(
             await vault_mcp.call_tool(
-                "vault_health", {"include_runtime": True},
+                "vault_health",
+                {"include_runtime": True},
             ),
         )
         m = re.search(r"wal_size_bytes:\s*(\d+)", result)
@@ -752,14 +777,16 @@ class TestVaultHealthRuntime:
         assert int(m.group(1)) >= 0
 
     async def test_runtime_block_includes_competing_pid_count(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """HIVE-115 / ADR-009: competing_pid_count field present (non-negative int)."""
         import re
 
         result = _text(
             await vault_mcp.call_tool(
-                "vault_health", {"include_runtime": True},
+                "vault_health",
+                {"include_runtime": True},
             ),
         )
         m = re.search(r"competing_pid_count:\s*(\d+)", result)
@@ -767,12 +794,14 @@ class TestVaultHealthRuntime:
         assert int(m.group(1)) >= 0
 
     async def test_runtime_block_includes_last_git_lock_wait_ms(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """HIVE-115 / ADR-010: last_git_lock_wait_ms surfaces mean + p99 + samples."""
         result = _text(
             await vault_mcp.call_tool(
-                "vault_health", {"include_runtime": True},
+                "vault_health",
+                {"include_runtime": True},
             ),
         )
         assert "last_git_lock_wait_ms:" in result
@@ -781,21 +810,24 @@ class TestVaultHealthRuntime:
         assert "samples:" in result
 
     async def test_runtime_block_includes_obsidian_git_present(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """HIVE-115 / ADR-010: obsidian_git_present field is true/false."""
         import re
 
         result = _text(
             await vault_mcp.call_tool(
-                "vault_health", {"include_runtime": True},
+                "vault_health",
+                {"include_runtime": True},
             ),
         )
         m = re.search(r"obsidian_git_present:\s*(true|false)", result)
         assert m is not None, f"obsidian_git_present field missing in:\n{result}"
 
     async def test_runtime_block_obsidian_git_present_when_plugin_active(
-        self, mock_vault: Path,
+        self,
+        mock_vault: Path,
     ) -> None:
         """When the obsidian-git plugin config exists, presence flips to true."""
         import json
@@ -803,13 +835,15 @@ class TestVaultHealthRuntime:
         plugin_dir = mock_vault / ".obsidian" / "plugins" / "obsidian-git"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "data.json").write_text(
-            json.dumps({"commitInterval": 10}), encoding="utf-8",
+            json.dumps({"commitInterval": 10}),
+            encoding="utf-8",
         )
         mcp = create_server(vault_path=mock_vault)
         try:
             result = _text(
                 await mcp.call_tool(
-                    "vault_health", {"include_runtime": True},
+                    "vault_health",
+                    {"include_runtime": True},
                 ),
             )
             assert "obsidian_git_present: true" in result
@@ -817,14 +851,16 @@ class TestVaultHealthRuntime:
             _close_server(mcp)
 
     async def test_runtime_block_includes_lock_eviction(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """HIVE-116 PR-2 / AC-8: lock_eviction.count_30d + last_iso fields."""
         import re
 
         result = _text(
             await vault_mcp.call_tool(
-                "vault_health", {"include_runtime": True},
+                "vault_health",
+                {"include_runtime": True},
             ),
         )
         assert "lock_eviction:" in result
@@ -836,19 +872,22 @@ class TestVaultHealthRuntime:
         assert "last_iso: null" in result
 
     async def test_runtime_budget_does_not_leak_api_key(
-        self, mock_vault: Path,
+        self,
+        mock_vault: Path,
     ) -> None:
         secret = "sk-RUNTIME-NEVER-LEAK-ABCDEF"
         mcp = create_server(
             vault_path=mock_vault,
             openrouter_client=OpenRouterClient(
-                api_key=secret, default_model="qwen/qwen3-coder:free",
+                api_key=secret,
+                default_model="qwen/qwen3-coder:free",
             ),
         )
         try:
             result = _text(
                 await mcp.call_tool(
-                    "vault_health", {"include_runtime": True},
+                    "vault_health",
+                    {"include_runtime": True},
                 ),
             )
             assert secret not in result
@@ -875,8 +914,10 @@ class TestVaultWrite:
         result = await mcp.call_tool(
             "vault_write",
             {
-                "project": "testproject", "section": "nonexistent",
-                "operation": "append", "content": "x",
+                "project": "testproject",
+                "section": "nonexistent",
+                "operation": "append",
+                "content": "x",
             },
         )
         text = _text(result)
@@ -1118,7 +1159,9 @@ class TestCaptureLesson:
         subprocess.run(["git", "add", "."], cwd=git_vault, capture_output=True, check=True)
         subprocess.run(
             ["git", "commit", "-m", "remove lessons"],
-            cwd=git_vault, capture_output=True, check=True,
+            cwd=git_vault,
+            capture_output=True,
+            check=True,
         )
 
         mcp = create_server(vault_path=git_vault)
@@ -1170,7 +1213,10 @@ class TestCaptureLesson:
 
         log = subprocess.run(
             ["git", "log", "--oneline", "-1"],
-            cwd=git_vault, capture_output=True, text=True, check=True,
+            cwd=git_vault,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         assert "capture_lesson" in log.stdout or "lesson" in log.stdout.lower()
 
@@ -1228,16 +1274,15 @@ class TestCaptureLessonXmlDefense:
         )
 
         # The lesson WAS written (warn-don't-reject contract).
-        lessons = (
-            git_vault / "10_projects" / "testproject" / "90-lessons.md"
-        ).read_text()
+        lessons = (git_vault / "10_projects" / "testproject" / "90-lessons.md").read_text()
         # HTML comment marker visible during manual review.
         assert "POSSIBLE_CORRUPTION" in lessons, (
             "expected POSSIBLE_CORRUPTION marker in lessons file"
         )
 
     async def test_clean_lesson_has_no_warning_or_marker(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """Normal lesson body without suspect patterns → no warning, no marker."""
         mcp = create_server(vault_path=git_vault)
@@ -1256,9 +1301,7 @@ class TestCaptureLessonXmlDefense:
         assert "WARNING" not in text
         assert "POSSIBLE_CORRUPTION" not in text
 
-        lessons = (
-            git_vault / "10_projects" / "testproject" / "90-lessons.md"
-        ).read_text()
+        lessons = (git_vault / "10_projects" / "testproject" / "90-lessons.md").read_text()
         assert "POSSIBLE_CORRUPTION" not in lessons
 
 
@@ -1429,7 +1472,8 @@ class TestDelegateTaskSummarize:
         assert "type=project" in text
 
     async def test_large_file_returns_summary_or_content(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """Files >50 lines: worker summary if available, raw content otherwise."""
         result = await vault_mcp.call_tool(
@@ -1467,16 +1511,13 @@ class TestDelegateTaskSummarize:
         """max_summary_lines is a valid parameter (used when workers are online)."""
         result = await vault_mcp.call_tool(
             "delegate_task",
-            {"project": "testproject", "path": "92-large-doc.md",
-             "max_summary_lines": 10},
+            {"project": "testproject", "path": "92-large-doc.md", "max_summary_lines": 10},
         )
         text = _text(result)
         assert "Large Document" in text
 
     async def test_missing_project(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "delegate_task", {"project": "nonexistent"}
-        )
+        result = await vault_mcp.call_tool("delegate_task", {"project": "nonexistent"})
         assert "not found" in _text(result).lower()
 
     async def test_missing_file(self, vault_mcp: FastMCP) -> None:
@@ -1497,9 +1538,7 @@ class TestDelegateTaskSummarize:
         bare = mock_vault / "10_projects" / "testproject" / "bare.md"
         bare.write_text("# Bare\nJust text.\n")
         mcp = create_server(vault_path=mock_vault)
-        result = await mcp.call_tool(
-            "delegate_task", {"project": "testproject", "path": "bare.md"}
-        )
+        result = await mcp.call_tool("delegate_task", {"project": "testproject", "path": "bare.md"})
         text = _text(result)
         assert "# Bare" in text
         assert "**Metadata:**" not in text
@@ -1511,14 +1550,13 @@ class TestDelegateTaskSummarize:
 class TestVaultSearchRanked:
     async def test_empty_query_rejected(self, vault_mcp: FastMCP) -> None:
         result = await vault_mcp.call_tool(
-            "vault_search", {"ranked": True},
+            "vault_search",
+            {"ranked": True},
         )
         assert "Query is required" in _text(result)
 
     async def test_finds_matching_files(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "Task one", "ranked": True}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "Task one", "ranked": True})
         text = _text(result)
         assert "11-tasks.md" in text
         assert "score:" in text
@@ -1531,9 +1569,7 @@ class TestVaultSearchRanked:
 
     async def test_active_ranks_above_terminal(self, vault_mcp: FastMCP) -> None:
         """Active files should score higher than completed/accepted files."""
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "Lesson", "ranked": True}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "Lesson", "ranked": True})
         text = _text(result)
         lines = text.splitlines()
         score_lines = [ln for ln in lines if "score:" in ln]
@@ -1551,10 +1587,7 @@ class TestVaultSearchRanked:
             "alpha alpha alpha\nalpha again\nalpha more\n"
         )
         few = mock_vault / "10_projects" / "testproject" / "few-matches.md"
-        few.write_text(
-            "---\nid: few\ntype: lesson\nstatus: active\n---\n\n"
-            "alpha once\n"
-        )
+        few.write_text("---\nid: few\ntype: lesson\nstatus: active\n---\n\nalpha once\n")
         mcp = create_server(vault_path=mock_vault)
         result = await mcp.call_tool("vault_search", {"query": "alpha", "ranked": True})
         text = _text(result)
@@ -1587,18 +1620,14 @@ class TestVaultSearchRanked:
         assert "truncated" in text.lower()
 
     async def test_case_insensitive(self, vault_mcp: FastMCP) -> None:
-        result = await vault_mcp.call_tool(
-            "vault_search", {"query": "task ONE", "ranked": True}
-        )
+        result = await vault_mcp.call_tool("vault_search", {"query": "task ONE", "ranked": True})
         assert "11-tasks.md" in _text(result)
 
     async def test_files_without_frontmatter_searchable(self, mock_vault: Path) -> None:
         bare = mock_vault / "10_projects" / "testproject" / "bare.md"
         bare.write_text("# Bare\nSearchable bare content.\n")
         mcp = create_server(vault_path=mock_vault)
-        result = await mcp.call_tool(
-            "vault_search", {"query": "Searchable bare", "ranked": True}
-        )
+        result = await mcp.call_tool("vault_search", {"query": "Searchable bare", "ranked": True})
         text = _text(result)
         assert "bare.md" in text
         assert "score:" in text
@@ -1790,12 +1819,15 @@ class TestRelevanceTracking:
 
         relevance = RelevanceTracker()
         mcp = create_server(vault_path=git_vault, relevance_tracker=relevance)
-        await mcp.call_tool("vault_write", {
-            "project": "testproject",
-            "section": "lessons",
-            "operation": "append",
-            "content": "\n## New Lesson\nTest.",
-        })
+        await mcp.call_tool(
+            "vault_write",
+            {
+                "project": "testproject",
+                "section": "lessons",
+                "operation": "append",
+                "content": "\n## New Lesson\nTest.",
+            },
+        )
         scores = relevance.get_scores("testproject")
         assert "lessons" in scores
 
@@ -1824,7 +1856,8 @@ class TestAdaptiveBriefing:
         assert "Lessons" in text
 
     async def test_briefing_prioritizes_high_score_sections(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """After repeated task queries, briefing should show tasks first."""
         from hive.relevance import RelevanceTracker
@@ -1841,7 +1874,8 @@ class TestAdaptiveBriefing:
         assert tasks_pos < lessons_pos
 
     async def test_briefing_reorders_when_lessons_dominate(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """When lessons are accessed more, they should appear before tasks."""
         from hive.relevance import RelevanceTracker
@@ -1882,13 +1916,13 @@ class TestVaultSearchRecent:
         import subprocess
 
         new_file = git_vault / "10_projects" / "testproject" / "new-note.md"
-        new_file.write_text(
-            "---\nid: new-note\ntype: lesson\nstatus: active\n---\n\n# New\n"
-        )
+        new_file.write_text("---\nid: new-note\ntype: lesson\nstatus: active\n---\n\n# New\n")
         subprocess.run(["git", "add", "."], cwd=git_vault, capture_output=True, check=True)
         subprocess.run(
             ["git", "commit", "-m", "add note"],
-            cwd=git_vault, capture_output=True, check=True,
+            cwd=git_vault,
+            capture_output=True,
+            check=True,
         )
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool("vault_search", {"since_days": 1})
@@ -1906,12 +1940,12 @@ class TestVaultSearchRecent:
         subprocess.run(["git", "add", "."], cwd=git_vault, capture_output=True, check=True)
         subprocess.run(
             ["git", "commit", "-m", "add other"],
-            cwd=git_vault, capture_output=True, check=True,
+            cwd=git_vault,
+            capture_output=True,
+            check=True,
         )
         mcp = create_server(vault_path=git_vault)
-        result = await mcp.call_tool(
-            "vault_search", {"since_days": 1, "project": "testproject"}
-        )
+        result = await mcp.call_tool("vault_search", {"since_days": 1, "project": "testproject"})
         text = _text(result)
         assert "other" not in text.lower() or "testproject" in text
 
@@ -1947,11 +1981,14 @@ class TestVaultSearchRecent:
         subprocess.run(["git", "add", "."], cwd=git_vault, capture_output=True, check=True)
         subprocess.run(
             ["git", "commit", "-m", "bulk add"],
-            cwd=git_vault, capture_output=True, check=True,
+            cwd=git_vault,
+            capture_output=True,
+            check=True,
         )
         mcp = create_server(vault_path=git_vault)
         result = await mcp.call_tool(
-            "vault_search", {"since_days": 1, "max_lines": 100},
+            "vault_search",
+            {"since_days": 1, "max_lines": 100},
         )
         assert "truncated" in _text(result).lower()
 
@@ -1965,7 +2002,8 @@ class TestVaultUsage:
         await vault_mcp.call_tool("vault_list", {})
         await vault_mcp.call_tool("vault_query", {"project": "testproject"})
         result = await vault_mcp.call_tool(
-            "vault_health", {"include_usage": True, "usage_days": 1},
+            "vault_health",
+            {"include_usage": True, "usage_days": 1},
         )
         text = _text(result)
         assert "vault_list" in text
@@ -1975,21 +2013,24 @@ class TestVaultUsage:
     async def test_tracks_project(self, vault_mcp: FastMCP) -> None:
         await vault_mcp.call_tool("vault_query", {"project": "testproject"})
         result = await vault_mcp.call_tool(
-            "vault_health", {"include_usage": True, "usage_days": 1},
+            "vault_health",
+            {"include_usage": True, "usage_days": 1},
         )
         assert "testproject" in _text(result)
 
     async def test_empty_usage(self, tmp_path: Path) -> None:
         mcp = create_server(vault_path=tmp_path)
         result = await mcp.call_tool(
-            "vault_health", {"include_usage": True, "usage_days": 1},
+            "vault_health",
+            {"include_usage": True, "usage_days": 1},
         )
         assert "no vault tool calls" in _text(result).lower()
 
     async def test_estimates_tokens(self, vault_mcp: FastMCP) -> None:
         await vault_mcp.call_tool("vault_query", {"project": "testproject"})
         result = await vault_mcp.call_tool(
-            "vault_health", {"include_usage": True, "usage_days": 1},
+            "vault_health",
+            {"include_usage": True, "usage_days": 1},
         )
         assert "tokens served" in _text(result).lower()
 
@@ -2020,9 +2061,7 @@ class TestDelegateTaskAutoRouting:
     """Auto routing: Ollama first, then OpenRouter free, then paid."""
 
     @pytest.mark.asyncio
-    async def test_ollama_first_when_available(
-        self, worker: FastMCP, ollama: OllamaClient
-    ) -> None:
+    async def test_ollama_first_when_available(self, worker: FastMCP, ollama: OllamaClient) -> None:
         ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=ClientResponse(
@@ -2198,7 +2237,9 @@ class TestDelegateTaskExplicitModel:
 
     @pytest.mark.asyncio
     async def test_explicit_openrouter_paid(
-        self, worker: FastMCP, openrouter: OpenRouterClient,
+        self,
+        worker: FastMCP,
+        openrouter: OpenRouterClient,
     ) -> None:
         openrouter.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=ClientResponse(
@@ -2216,7 +2257,9 @@ class TestDelegateTaskExplicitModel:
 
     @pytest.mark.asyncio
     async def test_explicit_custom_model(
-        self, worker: FastMCP, openrouter: OpenRouterClient,
+        self,
+        worker: FastMCP,
+        openrouter: OpenRouterClient,
     ) -> None:
         openrouter.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=ClientResponse(
@@ -2229,7 +2272,8 @@ class TestDelegateTaskExplicitModel:
         )
         result = _text(
             await worker.call_tool(
-                "delegate_task", {"prompt": "test", "model": "deepseek/deepseek-v3"},
+                "delegate_task",
+                {"prompt": "test", "model": "deepseek/deepseek-v3"},
             )
         )
         assert "custom model output" in result
@@ -2347,23 +2391,32 @@ class TestMultiScopeListProjects:
 class TestMultiScopeQuery:
     async def test_auto_scan_finds_work_project(self, multi_scope_vault: Path) -> None:
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool(
-            "vault_query", {"project": "my-company", "section": "context"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "my-company", "section": "context"},
+            )
+        )
         assert "My Company" in result
 
     async def test_explicit_scope(self, multi_scope_vault: Path) -> None:
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool(
-            "vault_query", {"project": "work:my-company", "section": "context"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "work:my-company", "section": "context"},
+            )
+        )
         assert "My Company" in result
 
     async def test_explicit_wrong_scope(self, multi_scope_vault: Path) -> None:
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool(
-            "vault_query", {"project": "projects:my-company", "section": "context"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "projects:my-company", "section": "context"},
+            )
+        )
         assert "not found" in result.lower()
 
     async def test_first_match_wins(self, multi_scope_vault: Path) -> None:
@@ -2371,21 +2424,26 @@ class TestMultiScopeQuery:
         dup = multi_scope_vault / "50_work" / "testproject"
         dup.mkdir(parents=True)
         (dup / "00-context.md").write_text(
-            "---\nid: testproject-work\ntype: project\nstatus: active\n---\n\n"
-            "# Work Copy\n"
+            "---\nid: testproject-work\ntype: project\nstatus: active\n---\n\n# Work Copy\n"
         )
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool(
-            "vault_query", {"project": "testproject", "section": "context"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "testproject", "section": "context"},
+            )
+        )
         # projects scope comes first → should find the original, not "Work Copy"
         assert "Test Project" in result
 
     async def test_meta_still_works(self, multi_scope_vault: Path) -> None:
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool(
-            "vault_query", {"project": "_meta", "path": "patterns/pattern-tdd.md"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "_meta", "path": "patterns/pattern-tdd.md"},
+            )
+        )
         assert "Test-Driven Development" in result
 
 
@@ -2400,31 +2458,40 @@ class TestMultiScopeHealth:
 class TestMultiScopeUpdate:
     async def test_update_work_project(self, git_multi_scope_vault: Path) -> None:
         mcp = create_server(
-            vault_path=git_multi_scope_vault, vault_scopes=MULTI_SCOPES,
+            vault_path=git_multi_scope_vault,
+            vault_scopes=MULTI_SCOPES,
         )
-        result = _text(await mcp.call_tool("vault_write", {
-            "project": "my-company",
-            "section": "lessons",
-            "operation": "append",
-            "content": "\n## New Lesson\nAlways test.\n",
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_write",
+                {
+                    "project": "my-company",
+                    "section": "lessons",
+                    "operation": "append",
+                    "content": "\n## New Lesson\nAlways test.\n",
+                },
+            )
+        )
         assert "Updated" in result
-        content = (
-            git_multi_scope_vault / "50_work" / "my-company" / "90-lessons.md"
-        ).read_text()
+        content = (git_multi_scope_vault / "50_work" / "my-company" / "90-lessons.md").read_text()
         assert "Always test" in content
 
 
 class TestMultiScopeSearchRecent:
     async def test_project_filter_in_work_scope(
-        self, git_multi_scope_vault: Path,
+        self,
+        git_multi_scope_vault: Path,
     ) -> None:
         mcp = create_server(
-            vault_path=git_multi_scope_vault, vault_scopes=MULTI_SCOPES,
+            vault_path=git_multi_scope_vault,
+            vault_scopes=MULTI_SCOPES,
         )
-        result = _text(await mcp.call_tool(
-            "vault_search", {"project": "my-company", "since_days": 30},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {"project": "my-company", "since_days": 30},
+            )
+        )
         # Should find files in 50_work/my-company, not return "No changes"
         assert "my-company" in result or "50_work" in result
 
@@ -2440,52 +2507,74 @@ class TestHierarchicalScopeWriteGuard:
             "---\nid: hydra3d\ntype: project\nstatus: active\n---\n\n# Hydra3D\n"
         )
         import subprocess
+
         subprocess.run(
-            ["git", "add", "."], cwd=git_multi_scope_vault,
-            capture_output=True, check=True,
+            ["git", "add", "."],
+            cwd=git_multi_scope_vault,
+            capture_output=True,
+            check=True,
         )
         subprocess.run(
-            ["git", "commit", "-m", "add hydra3d"], cwd=git_multi_scope_vault,
-            capture_output=True, check=True,
+            ["git", "commit", "-m", "add hydra3d"],
+            cwd=git_multi_scope_vault,
+            capture_output=True,
+            check=True,
         )
 
         mcp = create_server(vault_path=git_multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool("vault_write", {
-            "project": "work:hydra3d",
-            "path": "notes.md",
-            "content": "# Notes\n",
-            "doc_type": "note",
-            "operation": "create",
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_write",
+                {
+                    "project": "work:hydra3d",
+                    "path": "notes.md",
+                    "content": "# Notes\n",
+                    "doc_type": "note",
+                    "operation": "create",
+                },
+            )
+        )
         assert "created" in result.lower()
 
     async def test_write_to_nonexistent_slug_without_path_fails(
-        self, git_multi_scope_vault: Path,
+        self,
+        git_multi_scope_vault: Path,
     ) -> None:
         """Creating a file in a non-existent slug without category path returns error."""
         mcp = create_server(vault_path=git_multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool("vault_write", {
-            "project": "work:new-thing",
-            "path": "notes.md",
-            "content": "# Notes\n",
-            "doc_type": "note",
-            "operation": "create",
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_write",
+                {
+                    "project": "work:new-thing",
+                    "path": "notes.md",
+                    "content": "# Notes\n",
+                    "doc_type": "note",
+                    "operation": "create",
+                },
+            )
+        )
         assert "not found" in result.lower()
 
     async def test_write_with_explicit_category_path_works(
-        self, git_multi_scope_vault: Path,
+        self,
+        git_multi_scope_vault: Path,
     ) -> None:
         """Creating with explicit category/entity path works (vault_write resolves it)."""
         # my-company is a direct child of 50_work — use it as the target
         mcp = create_server(vault_path=git_multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool("vault_write", {
-            "project": "work:my-company",
-            "path": "40-runbooks/deploy.md",
-            "content": "# Deploy Guide\n",
-            "doc_type": "runbook",
-            "operation": "create",
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_write",
+                {
+                    "project": "work:my-company",
+                    "path": "40-runbooks/deploy.md",
+                    "content": "# Deploy Guide\n",
+                    "doc_type": "runbook",
+                    "operation": "create",
+                },
+            )
+        )
         assert "created" in result.lower()
 
 
@@ -2504,7 +2593,8 @@ class TestDuplicateNameDetection:
         assert "agents" in result
 
     async def test_no_false_positive_without_duplicates(
-        self, multi_scope_vault: Path,
+        self,
+        multi_scope_vault: Path,
     ) -> None:
         """No duplicate warning when all names are unique."""
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
@@ -2518,58 +2608,88 @@ class TestVaultSearchScopeFilter:
     async def test_scope_filter_limits_to_work(self, multi_scope_vault: Path) -> None:
         """Search with scope='work' only finds files in 50_work."""
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool("vault_search", {
-            "query": "Project",
-            "scope": "work",
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {
+                    "query": "Project",
+                    "scope": "work",
+                },
+            )
+        )
         assert "50_work" in result or "my-company" in result
         assert "10_projects" not in result
 
     async def test_scope_filter_limits_to_projects(self, multi_scope_vault: Path) -> None:
         """Search with scope='projects' only finds files in 10_projects."""
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool("vault_search", {
-            "query": "Project",
-            "scope": "projects",
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {
+                    "query": "Project",
+                    "scope": "projects",
+                },
+            )
+        )
         assert "10_projects" in result or "testproject" in result
         assert "50_work" not in result
 
     async def test_scope_filter_invalid_scope(self, multi_scope_vault: Path) -> None:
         """Search with an invalid scope name returns error."""
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool("vault_search", {
-            "query": "anything",
-            "scope": "nonexistent",
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {
+                    "query": "anything",
+                    "scope": "nonexistent",
+                },
+            )
+        )
         assert "unknown scope" in result.lower()
 
     async def test_no_scope_searches_everything(self, multi_scope_vault: Path) -> None:
         """Without scope, searches the entire vault (backward compat)."""
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool("vault_search", {
-            "query": "Project",
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {
+                    "query": "Project",
+                },
+            )
+        )
         assert "testproject" in result.lower() or "10_projects" in result
         assert "my-company" in result.lower() or "50_work" in result
 
     async def test_scope_filter_ranked_mode(self, multi_scope_vault: Path) -> None:
         """Scope filter works in ranked mode too."""
         mcp = create_server(vault_path=multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool("vault_search", {
-            "query": "Project",
-            "scope": "work",
-            "ranked": True,
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {
+                    "query": "Project",
+                    "scope": "work",
+                    "ranked": True,
+                },
+            )
+        )
         assert "10_projects" not in result
 
     async def test_scope_filter_recent_mode(self, git_multi_scope_vault: Path) -> None:
         """Scope filter works in recent mode too."""
         mcp = create_server(vault_path=git_multi_scope_vault, vault_scopes=MULTI_SCOPES)
-        result = _text(await mcp.call_tool("vault_search", {
-            "scope": "work",
-            "since_days": 30,
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {
+                    "scope": "work",
+                    "since_days": 30,
+                },
+            )
+        )
         assert "10_projects" not in result
 
 
@@ -2579,63 +2699,75 @@ class TestVaultSearchScopeFilter:
 class TestPathTraversal:
     async def test_query_path_escape_blocked(self, vault_mcp: FastMCP) -> None:
         # Needs enough ../.. to escape tmp_path (vault root)
-        result = _text(await vault_mcp.call_tool(
-            "vault_query",
-            {"project": "testproject", "path": "../../../../etc/passwd"},
-        ))
+        result = _text(
+            await vault_mcp.call_tool(
+                "vault_query",
+                {"project": "testproject", "path": "../../../../etc/passwd"},
+            )
+        )
         assert "escapes vault boundary" in result.lower()
 
     async def test_create_path_escape_blocked(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_write",
-            {
-                "project": "testproject",
-                "path": "../../../../tmp/evil.md",
-                "content": "pwned",
-                "doc_type": "test",
-                "operation": "create",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_write",
+                {
+                    "project": "testproject",
+                    "path": "../../../../tmp/evil.md",
+                    "content": "pwned",
+                    "doc_type": "test",
+                    "operation": "create",
+                },
+            )
+        )
         assert "escapes vault boundary" in result.lower()
 
     async def test_delegate_summarize_path_escape_blocked(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
-        result = _text(await vault_mcp.call_tool(
-            "delegate_task",
-            {"project": "testproject", "path": "../../../../etc/shadow"},
-        ))
+        result = _text(
+            await vault_mcp.call_tool(
+                "delegate_task",
+                {"project": "testproject", "path": "../../../../etc/shadow"},
+            )
+        )
         assert "escapes vault boundary" in result.lower()
 
     async def test_project_param_traversal_blocked(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         """H1: crafted project name must not escape vault boundary."""
-        result = _text(await vault_mcp.call_tool(
-            "vault_write",
-            {
-                "project": "projects:../../etc",
-                "section": "context",
-                "operation": "append",
-                "content": "pwned",
-            },
-        ))
+        result = _text(
+            await vault_mcp.call_tool(
+                "vault_write",
+                {
+                    "project": "projects:../../etc",
+                    "section": "context",
+                    "operation": "append",
+                    "content": "pwned",
+                },
+            )
+        )
         assert "not found" in result.lower()
 
     async def test_yaml_injection_sanitized(self, git_vault: Path) -> None:
         """H2: newlines in doc_type must not inject YAML fields."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_write",
-            {
-                "project": "testproject",
-                "path": "injected.md",
-                "content": "body",
-                "doc_type": "adr\nevil_field: true",
-                "operation": "create",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_write",
+                {
+                    "project": "testproject",
+                    "path": "injected.md",
+                    "content": "body",
+                    "doc_type": "adr\nevil_field: true",
+                    "operation": "create",
+                },
+            )
+        )
         assert "created" in result.lower()
         content = (git_vault / "10_projects" / "testproject" / "injected.md").read_text()
         # Newline was stripped — no separate YAML key injected
@@ -2645,26 +2777,30 @@ class TestPathTraversal:
 
     async def test_patch_path_escape_blocked(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "../../../../etc/passwd",
-                "find": "root",
-                "replace": "pwned",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "../../../../etc/passwd",
+                    "find": "root",
+                    "replace": "pwned",
+                },
+            )
+        )
         assert "escapes vault boundary" in result.lower()
 
     async def test_list_files_path_escape_blocked(self, git_vault: Path) -> None:
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_list",
-            {
-                "project": "testproject",
-                "path": "../../../../etc",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_list",
+                {
+                    "project": "testproject",
+                    "path": "../../../../etc",
+                },
+            )
+        )
         assert "escapes vault boundary" in result.lower()
 
     async def test_list_files_glob_capped(self, mock_vault: Path) -> None:
@@ -2674,10 +2810,12 @@ class TestPathTraversal:
         for i in range(510):
             (project / f"file_{i:04d}.md").write_text(f"# File {i}\n")
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_list",
-            {"project": "testproject", "path": "bulk", "pattern": "*.md"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_list",
+                {"project": "testproject", "path": "bulk", "pattern": "*.md"},
+            )
+        )
         # Should contain at most 500 file entries
         file_lines = [ln for ln in result.splitlines() if ln.startswith("- ")]
         assert len(file_lines) <= 500
@@ -2685,14 +2823,16 @@ class TestPathTraversal:
     async def test_patch_invalid_keys_returns_error(self, git_vault: Path) -> None:
         """Patches with wrong dict keys return error, not KeyError crash."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "patches": [{"old": "wrong", "new": "keys"}],
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "patches": [{"old": "wrong", "new": "keys"}],
+                },
+            )
+        )
         assert "find" in result.lower() and "replace" in result.lower()
 
 
@@ -2705,15 +2845,17 @@ class TestVaultPatch:
     async def test_single_patch(self, git_vault: Path) -> None:
         """Single find/replace works."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "find": "- [ ] Task one",
-                "replace": "- [x] Task one",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "find": "- [ ] Task one",
+                    "replace": "- [x] Task one",
+                },
+            )
+        )
         assert "1 patch" in result.lower()
         content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
         assert "- [x] Task one" in content
@@ -2721,17 +2863,19 @@ class TestVaultPatch:
     async def test_multi_patch_applies_all(self, git_vault: Path) -> None:
         """Multiple patches applied in sequence to the same file."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "patches": [
-                    {"find": "- [ ] Task one", "replace": "- [x] Task one"},
-                    {"find": "- [x] Task two", "replace": "- [ ] Task two reopened"},
-                ],
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "patches": [
+                        {"find": "- [ ] Task one", "replace": "- [x] Task one"},
+                        {"find": "- [x] Task two", "replace": "- [ ] Task two reopened"},
+                    ],
+                },
+            )
+        )
         assert "2 patches" in result.lower()
         content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
         assert "- [x] Task one" in content
@@ -2740,33 +2884,37 @@ class TestVaultPatch:
     async def test_multi_patch_single_item(self, git_vault: Path) -> None:
         """A patches list with one item works fine."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "patches": [
-                    {"find": "- [ ] Task one", "replace": "- [x] Task one"},
-                ],
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "patches": [
+                        {"find": "- [ ] Task one", "replace": "- [x] Task one"},
+                    ],
+                },
+            )
+        )
         assert "1 patch" in result.lower()
 
     async def test_multi_patch_rejects_mixed_params(self, git_vault: Path) -> None:
         """Providing both patches AND find/replace is an error."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "find": "- [ ] Task one",
-                "replace": "- [x] Task one",
-                "patches": [
-                    {"find": "- [x] Task two", "replace": "- [ ] Task two"},
-                ],
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "find": "- [ ] Task one",
+                    "replace": "- [x] Task one",
+                    "patches": [
+                        {"find": "- [x] Task two", "replace": "- [ ] Task two"},
+                    ],
+                },
+            )
+        )
         assert "error" in result.lower() or "cannot" in result.lower() or "mix" in result.lower()
         # File must remain unchanged
         content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
@@ -2775,30 +2923,34 @@ class TestVaultPatch:
     async def test_multi_patch_empty_list(self, git_vault: Path) -> None:
         """An empty patches list is an error."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "patches": [],
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "patches": [],
+                },
+            )
+        )
         assert "provide" in result.lower() or "error" in result.lower()
 
     async def test_multi_patch_ambiguous_aborts_all(self, git_vault: Path) -> None:
         """If any patch in the list is ambiguous, no patches are applied."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "patches": [
-                    {"find": "- [ ] Task one", "replace": "- [x] Task one"},
-                    {"find": "Task", "replace": "Item"},  # ambiguous
-                ],
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "patches": [
+                        {"find": "- [ ] Task one", "replace": "- [x] Task one"},
+                        {"find": "Task", "replace": "Item"},  # ambiguous
+                    ],
+                },
+            )
+        )
         assert "ambiguous" in result.lower()
         # File must remain unchanged — first patch NOT applied
         content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
@@ -2807,17 +2959,19 @@ class TestVaultPatch:
     async def test_multi_patch_not_found_aborts_all(self, git_vault: Path) -> None:
         """If any patch find text is not found, no patches are applied."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "patches": [
-                    {"find": "- [ ] Task one", "replace": "- [x] Task one"},
-                    {"find": "nonexistent text", "replace": "something"},
-                ],
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "patches": [
+                        {"find": "- [ ] Task one", "replace": "- [x] Task one"},
+                        {"find": "nonexistent text", "replace": "something"},
+                    ],
+                },
+            )
+        )
         assert "not found" in result.lower()
         # File must remain unchanged
         content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
@@ -2827,17 +2981,19 @@ class TestVaultPatch:
         """Later patches see the result of earlier patches."""
         mcp = create_server(vault_path=git_vault)
         # First patch changes text, second patch modifies the result of the first
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "patches": [
-                    {"find": "- [ ] Task one", "replace": "- [x] Task alpha"},
-                    {"find": "- [x] Task alpha", "replace": "- [x] Task alpha (done)"},
-                ],
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "patches": [
+                        {"find": "- [ ] Task one", "replace": "- [x] Task alpha"},
+                        {"find": "- [x] Task alpha", "replace": "- [x] Task alpha (done)"},
+                    ],
+                },
+            )
+        )
         assert "2 patches" in result.lower()
         content = (git_vault / "10_projects" / "testproject" / "11-tasks.md").read_text()
         assert "- [x] Task alpha (done)" in content
@@ -2845,69 +3001,79 @@ class TestVaultPatch:
     async def test_single_patch_project_not_found(self, git_vault: Path) -> None:
         """Single patch with unknown project returns error."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "nonexistent",
-                "path": "11-tasks.md",
-                "find": "foo",
-                "replace": "bar",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "nonexistent",
+                    "path": "11-tasks.md",
+                    "find": "foo",
+                    "replace": "bar",
+                },
+            )
+        )
         assert "not found" in result.lower()
 
     async def test_single_patch_file_not_found(self, git_vault: Path) -> None:
         """Single patch with unknown file returns error."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "nonexistent.md",
-                "find": "foo",
-                "replace": "bar",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "nonexistent.md",
+                    "find": "foo",
+                    "replace": "bar",
+                },
+            )
+        )
         assert "not found" in result.lower()
 
     async def test_single_patch_ambiguous(self, git_vault: Path) -> None:
         """Single patch with ambiguous match returns error."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "find": "Task",
-                "replace": "Item",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "find": "Task",
+                    "replace": "Item",
+                },
+            )
+        )
         assert "ambiguous" in result.lower()
 
     async def test_single_patch_not_found_in_file(self, git_vault: Path) -> None:
         """Single patch with text not in file returns error."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "find": "nonexistent text here",
-                "replace": "replacement",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "find": "nonexistent text here",
+                    "replace": "replacement",
+                },
+            )
+        )
         assert "not found" in result.lower()
 
     async def test_no_params_error(self, git_vault: Path) -> None:
         """Neither find/replace nor patches provided is an error."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                },
+            )
+        )
         assert "error" in result.lower() or "provide" in result.lower()
 
     async def test_multi_patch_single_git_commit(self, git_vault: Path) -> None:
@@ -2918,7 +3084,10 @@ class TestVaultPatch:
         # Count commits before
         before = subprocess.run(
             ["git", "rev-list", "--count", "HEAD"],
-            cwd=git_vault, capture_output=True, text=True, check=True,
+            cwd=git_vault,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         count_before = int(before.stdout.strip())
 
@@ -2936,7 +3105,10 @@ class TestVaultPatch:
 
         after = subprocess.run(
             ["git", "rev-list", "--count", "HEAD"],
-            cwd=git_vault, capture_output=True, text=True, check=True,
+            cwd=git_vault,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         count_after = int(after.stdout.strip())
         assert count_after == count_before + 1
@@ -2946,7 +3118,8 @@ class TestVaultPatchTolerantMatching:
     """Tests for tolerant matching in vault_patch (Issue #52)."""
 
     async def test_patch_tolerates_trailing_whitespace(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """Multi-line find text with trailing whitespace differences."""
         tasks = git_vault / "10_projects" / "testproject" / "11-tasks.md"
@@ -2958,66 +3131,82 @@ class TestVaultPatchTolerantMatching:
         )
         tasks.write_text(raw)
         import subprocess
+
         subprocess.run(
-            ["git", "add", "."], cwd=git_vault, capture_output=True,
+            ["git", "add", "."],
+            cwd=git_vault,
+            capture_output=True,
         )
         subprocess.run(
-            ["git", "commit", "-m", "ws"], cwd=git_vault, capture_output=True,
+            ["git", "commit", "-m", "ws"],
+            cwd=git_vault,
+            capture_output=True,
         )
 
         mcp = create_server(vault_path=git_vault)
         # LLM stripped trailing spaces from multi-line text
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "find": "| A | B |\n|---|---|\n| 1 | 2 |",
-                "replace": "| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "find": "| A | B |\n|---|---|\n| 1 | 2 |",
+                    "replace": "| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |",
+                },
+            )
+        )
         assert "1 patch" in result.lower()
 
     async def test_patch_not_found_shows_similarity(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """Close miss includes similarity % in error."""
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "find": "- [ ] Task ones",
-                "replace": "- [x] Task one",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "find": "- [ ] Task ones",
+                    "replace": "- [x] Task one",
+                },
+            )
+        )
         assert "not found" in result.lower()
         assert "%" in result
 
     async def test_patch_roundtrip_query_then_patch(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """Real workflow: vault_query output used as vault_patch find text."""
         mcp = create_server(vault_path=git_vault)
-        query_result = _text(await mcp.call_tool(
-            "vault_query",
-            {"project": "testproject", "section": "tasks"},
-        ))
+        query_result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "testproject", "section": "tasks"},
+            )
+        )
         assert "- [ ] Task one" in query_result
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "find": "- [ ] Task one",
-                "replace": "- [x] Task one (completed)",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "find": "- [ ] Task one",
+                    "replace": "- [x] Task one (completed)",
+                },
+            )
+        )
         assert "1 patch" in result.lower()
 
     async def test_patch_body_only_match_when_frontmatter_overlaps(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """find text matches body uniquely even if ambiguous in full file."""
         tasks = git_vault / "10_projects" / "testproject" / "11-tasks.md"
@@ -3026,23 +3215,30 @@ class TestVaultPatchTolerantMatching:
         raw = raw.replace("- [ ] Task one", "- [ ] active task")
         tasks.write_text(raw)
         import subprocess
+
         subprocess.run(
-            ["git", "add", "."], cwd=git_vault, capture_output=True,
+            ["git", "add", "."],
+            cwd=git_vault,
+            capture_output=True,
         )
         subprocess.run(
-            ["git", "commit", "-m", "ov"], cwd=git_vault, capture_output=True,
+            ["git", "commit", "-m", "ov"],
+            cwd=git_vault,
+            capture_output=True,
         )
 
         mcp = create_server(vault_path=git_vault)
-        result = _text(await mcp.call_tool(
-            "vault_patch",
-            {
-                "project": "testproject",
-                "path": "11-tasks.md",
-                "find": "- [ ] active task",
-                "replace": "- [x] active task (done)",
-            },
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_patch",
+                {
+                    "project": "testproject",
+                    "path": "11-tasks.md",
+                    "find": "- [ ] active task",
+                    "replace": "- [x] active task (done)",
+                },
+            )
+        )
         assert "1 patch" in result.lower()
         content = tasks.read_text()
         assert content.startswith("---")
@@ -3059,15 +3255,17 @@ class TestGitCommitResilience:
         mcp = create_server(vault_path=git_vault)
 
         with patch("hive._helpers.subprocess.run", side_effect=OSError("git not found")):
-            result = _text(await mcp.call_tool(
-                "vault_patch",
-                {
-                    "project": "testproject",
-                    "path": "11-tasks.md",
-                    "find": "- [ ] Task one",
-                    "replace": "- [x] Task one done",
-                },
-            ))
+            result = _text(
+                await mcp.call_tool(
+                    "vault_patch",
+                    {
+                        "project": "testproject",
+                        "path": "11-tasks.md",
+                        "find": "- [ ] Task one",
+                        "replace": "- [x] Task one done",
+                    },
+                )
+            )
 
         assert "applied" in result.lower()
         # Data was written to disk despite git failure
@@ -3081,15 +3279,17 @@ class TestGitCommitResilience:
         mcp = create_server(vault_path=git_vault)
 
         with patch("hive._helpers.subprocess.run", side_effect=RuntimeError("unexpected")):
-            result = _text(await mcp.call_tool(
-                "vault_write",
-                {
-                    "project": "testproject",
-                    "section": "tasks",
-                    "operation": "append",
-                    "content": "\n- [ ] New task from test\n",
-                },
-            ))
+            result = _text(
+                await mcp.call_tool(
+                    "vault_write",
+                    {
+                        "project": "testproject",
+                        "section": "tasks",
+                        "operation": "append",
+                        "content": "\n- [ ] New task from test\n",
+                    },
+                )
+            )
 
         assert "updated" in result.lower()
 
@@ -3112,9 +3312,12 @@ class TestGitCommitResilience:
             )
 
         # Second call: read-only, must succeed (no mock — real subprocess)
-        result = _text(await mcp.call_tool(
-            "vault_query", {"project": "testproject", "section": "tasks"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "testproject", "section": "tasks"},
+            )
+        )
         assert "task one done" in result.lower()
 
 
@@ -3128,9 +3331,12 @@ class TestGitReadResilience:
         mcp = create_server(vault_path=git_vault)
 
         with patch("hive._helpers.subprocess.run", side_effect=OSError("git not found")):
-            result = _text(await mcp.call_tool(
-                "session_briefing", {"project": "testproject"},
-            ))
+            result = _text(
+                await mcp.call_tool(
+                    "session_briefing",
+                    {"project": "testproject"},
+                )
+            )
 
         assert "session briefing" in result.lower()
 
@@ -3141,9 +3347,12 @@ class TestGitReadResilience:
         mcp = create_server(vault_path=git_vault)
 
         with patch("hive._helpers.subprocess.run", side_effect=OSError("git not found")):
-            result = _text(await mcp.call_tool(
-                "vault_search", {"since_days": 7},
-            ))
+            result = _text(
+                await mcp.call_tool(
+                    "vault_search",
+                    {"since_days": 7},
+                )
+            )
 
         # Should return gracefully (no changes or empty result)
         assert result  # non-empty response
@@ -3162,15 +3371,17 @@ class TestFileIOResilience:
         tasks = git_vault / "10_projects" / "testproject" / "11-tasks.md"
         tasks.chmod(0o000)
         try:
-            result = _text(await mcp.call_tool(
-                "vault_patch",
-                {
-                    "project": "testproject",
-                    "path": "11-tasks.md",
-                    "find": "foo",
-                    "replace": "bar",
-                },
-            ))
+            result = _text(
+                await mcp.call_tool(
+                    "vault_patch",
+                    {
+                        "project": "testproject",
+                        "path": "11-tasks.md",
+                        "find": "foo",
+                        "replace": "bar",
+                    },
+                )
+            )
             # format_io_error wording: "Cannot read 'X': permission denied. ..."
             lower = result.lower()
             assert "permission" in lower or "error" in lower
@@ -3183,15 +3394,17 @@ class TestFileIOResilience:
         tasks = git_vault / "10_projects" / "testproject" / "11-tasks.md"
         tasks.chmod(0o444)
         try:
-            result = _text(await mcp.call_tool(
-                "vault_write",
-                {
-                    "project": "testproject",
-                    "section": "tasks",
-                    "operation": "append",
-                    "content": "\n- [ ] New task\n",
-                },
-            ))
+            result = _text(
+                await mcp.call_tool(
+                    "vault_write",
+                    {
+                        "project": "testproject",
+                        "section": "tasks",
+                        "operation": "append",
+                        "content": "\n- [ ] New task\n",
+                    },
+                )
+            )
             lower = result.lower()
             assert "permission" in lower or "error" in lower
         finally:
@@ -3203,20 +3416,25 @@ class TestSectionFallback:
         # Create a bare context.md alongside the legacy 00-context.md
         project = mock_vault / "10_projects" / "testproject"
         (project / "context.md").write_text(
-            "---\nid: bare-context\ntype: project\nstatus: active\n---\n\n"
-            "# Bare Context\n"
+            "---\nid: bare-context\ntype: project\nstatus: active\n---\n\n# Bare Context\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_query", {"project": "testproject", "section": "context"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "testproject", "section": "context"},
+            )
+        )
         assert "Bare Context" in result
 
     async def test_legacy_fallback(self, mock_vault: Path) -> None:
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_query", {"project": "testproject", "section": "context"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "testproject", "section": "context"},
+            )
+        )
         assert "Test Project" in result
 
 
@@ -3241,28 +3459,34 @@ def worker_vault(
 
 def _worker_response(text: str) -> ClientResponse:
     return ClientResponse(
-        text=text, model="qwen2.5-coder:7b", tokens=100, cost_usd=0.0, latency_ms=500,
+        text=text,
+        model="qwen2.5-coder:7b",
+        tokens=100,
+        cost_usd=0.0,
+        latency_ms=500,
     )
 
 
-_VALID_LESSONS_JSON = json.dumps([
-    {
-        "title": "Always check return values",
-        "context": "Debugging a crash in the parser",
-        "problem": "Function returned None, caller didn't check",
-        "solution": "Added explicit None guard before use",
-        "tags": ["python", "debugging"],
-        "confidence": 0.9,
-    },
-    {
-        "title": "Use parameterized queries",
-        "context": "Writing database layer",
-        "problem": "String interpolation in SQL is injection risk",
-        "solution": "Switched to ? placeholders",
-        "tags": ["sql", "security"],
-        "confidence": 0.8,
-    },
-])
+_VALID_LESSONS_JSON = json.dumps(
+    [
+        {
+            "title": "Always check return values",
+            "context": "Debugging a crash in the parser",
+            "problem": "Function returned None, caller didn't check",
+            "solution": "Added explicit None guard before use",
+            "tags": ["python", "debugging"],
+            "confidence": 0.9,
+        },
+        {
+            "title": "Use parameterized queries",
+            "context": "Writing database layer",
+            "problem": "String interpolation in SQL is injection risk",
+            "solution": "Switched to ? placeholders",
+            "tags": ["sql", "security"],
+            "confidence": 0.8,
+        },
+    ]
+)
 
 
 class TestExtractLessons:
@@ -3270,16 +3494,21 @@ class TestExtractLessons:
 
     @pytest.mark.asyncio
     async def test_extracts_and_writes_lessons(
-        self, git_vault: Path, worker_vault: FastMCP, ollama: OllamaClient,
+        self,
+        git_vault: Path,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
     ) -> None:
         ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(_VALID_LESSONS_JSON),
         )
-        result = _text(await worker_vault.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "text": "We found a crash..."},
-        ))
+        result = _text(
+            await worker_vault.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "text": "We found a crash..."},
+            )
+        )
         assert "2" in result  # 2 lessons extracted
         assert "Always check return values" in result
 
@@ -3289,7 +3518,10 @@ class TestExtractLessons:
 
     @pytest.mark.asyncio
     async def test_deduplicates_existing(
-        self, git_vault: Path, worker_vault: FastMCP, ollama: OllamaClient,
+        self,
+        git_vault: Path,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
     ) -> None:
         # Pre-write a lesson with same title
         lessons_file = git_vault / "10_projects" / "testproject" / "90-lessons.md"
@@ -3301,106 +3533,157 @@ class TestExtractLessons:
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(_VALID_LESSONS_JSON),
         )
-        result = _text(await worker_vault.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "text": "session text"},
-        ))
+        result = _text(
+            await worker_vault.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "text": "session text"},
+            )
+        )
         # First lesson skipped (duplicate), second written
         assert "skipped" in result.lower() or "duplicate" in result.lower()
         assert "Use parameterized queries" in result
 
     @pytest.mark.asyncio
     async def test_filters_low_confidence(
-        self, worker_vault: FastMCP, ollama: OllamaClient,
+        self,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
     ) -> None:
-        low_conf = json.dumps([
-            {
-                "title": "Maybe this matters",
-                "context": "ctx", "problem": "prob", "solution": "sol",
-                "tags": [], "confidence": 0.3,
-            },
-        ])
+        low_conf = json.dumps(
+            [
+                {
+                    "title": "Maybe this matters",
+                    "context": "ctx",
+                    "problem": "prob",
+                    "solution": "sol",
+                    "tags": [],
+                    "confidence": 0.3,
+                },
+            ]
+        )
         ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(low_conf),
         )
-        result = _text(await worker_vault.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "text": "some text", "min_confidence": 0.7},
-        ))
+        result = _text(
+            await worker_vault.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "text": "some text", "min_confidence": 0.7},
+            )
+        )
         assert "0" in result or "no lessons" in result.lower()
 
     @pytest.mark.asyncio
     async def test_worker_unavailable(
-        self, worker_vault: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient,
+        self,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
+        openrouter: OpenRouterClient,
     ) -> None:
         ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
         openrouter.generate = AsyncMock(  # type: ignore[method-assign]
             side_effect=ConnectionError("no workers"),
         )
-        result = _text(await worker_vault.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "text": "some text"},
-        ))
+        result = _text(
+            await worker_vault.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "text": "some text"},
+            )
+        )
         assert "unavailable" in result.lower() or "worker" in result.lower()
 
     @pytest.mark.asyncio
     async def test_worker_invalid_json(
-        self, worker_vault: FastMCP, ollama: OllamaClient,
+        self,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
     ) -> None:
         ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response("This is not JSON at all, just text."),
         )
-        result = _text(await worker_vault.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "text": "some text"},
-        ))
+        result = _text(
+            await worker_vault.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "text": "some text"},
+            )
+        )
         assert "parse" in result.lower() or "invalid" in result.lower()
 
     @pytest.mark.asyncio
     async def test_worker_empty_array(
-        self, worker_vault: FastMCP, ollama: OllamaClient,
+        self,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
     ) -> None:
         ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response("[]"),
         )
-        result = _text(await worker_vault.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "text": "nothing interesting"},
-        ))
+        result = _text(
+            await worker_vault.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "text": "nothing interesting"},
+            )
+        )
         assert "no lessons" in result.lower()
 
     @pytest.mark.asyncio
     async def test_markdown_wrapped_json(
-        self, git_vault: Path, worker_vault: FastMCP, ollama: OllamaClient,
+        self,
+        git_vault: Path,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
     ) -> None:
         """Worker wraps JSON in markdown fences — still parsed correctly."""
-        wrapped = '```json\n' + json.dumps([{
-            "title": "Fence test",
-            "context": "ctx", "problem": "prob", "solution": "sol",
-            "tags": [], "confidence": 0.9,
-        }]) + '\n```'
+        wrapped = (
+            "```json\n"
+            + json.dumps(
+                [
+                    {
+                        "title": "Fence test",
+                        "context": "ctx",
+                        "problem": "prob",
+                        "solution": "sol",
+                        "tags": [],
+                        "confidence": 0.9,
+                    }
+                ]
+            )
+            + "\n```"
+        )
         ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(wrapped),
         )
-        result = _text(await worker_vault.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "text": "session notes"},
-        ))
+        result = _text(
+            await worker_vault.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "text": "session notes"},
+            )
+        )
         assert "Fence test" in result
 
     @pytest.mark.asyncio
     async def test_respects_max_lessons(
-        self, git_vault: Path, worker_vault: FastMCP, ollama: OllamaClient,
+        self,
+        git_vault: Path,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
     ) -> None:
-        many = json.dumps([
-            {"title": f"Lesson {i}", "context": "c", "problem": "p",
-             "solution": "s", "tags": [], "confidence": 0.9}
-            for i in range(10)
-        ])
+        many = json.dumps(
+            [
+                {
+                    "title": f"Lesson {i}",
+                    "context": "c",
+                    "problem": "p",
+                    "solution": "s",
+                    "tags": [],
+                    "confidence": 0.9,
+                }
+                for i in range(10)
+            ]
+        )
         ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(many),
@@ -3416,25 +3699,34 @@ class TestExtractLessons:
 
     @pytest.mark.asyncio
     async def test_sanitizes_newlines_in_worker_output(
-        self, git_vault: Path, worker_vault: FastMCP, ollama: OllamaClient,
+        self,
+        git_vault: Path,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
     ) -> None:
         """Worker output with newlines in fields is sanitized."""
-        injected = json.dumps([{
-            "title": "Good title\nevil_field: true",
-            "context": "ctx\ninjection",
-            "problem": "prob",
-            "solution": "sol",
-            "tags": [],
-            "confidence": 0.9,
-        }])
+        injected = json.dumps(
+            [
+                {
+                    "title": "Good title\nevil_field: true",
+                    "context": "ctx\ninjection",
+                    "problem": "prob",
+                    "solution": "sol",
+                    "tags": [],
+                    "confidence": 0.9,
+                }
+            ]
+        )
         ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(injected),
         )
-        result = _text(await worker_vault.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "text": "session"},
-        ))
+        result = _text(
+            await worker_vault.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "text": "session"},
+            )
+        )
         assert "Good title" in result
         lessons = (git_vault / "10_projects" / "testproject" / "90-lessons.md").read_text()
         # Newlines stripped — no injection
@@ -3443,7 +3735,10 @@ class TestExtractLessons:
 
     @pytest.mark.asyncio
     async def test_write_error_surfaces_in_summary(
-        self, git_vault: Path, worker_vault: FastMCP, ollama: OllamaClient,
+        self,
+        git_vault: Path,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
     ) -> None:
         """Filesystem errors during lesson write are reported, not silently dropped."""
         lessons_file = git_vault / "10_projects" / "testproject" / "90-lessons.md"
@@ -3454,22 +3749,23 @@ class TestExtractLessons:
             ollama.generate = AsyncMock(  # type: ignore[method-assign]
                 return_value=_worker_response(_VALID_LESSONS_JSON),
             )
-            result = _text(await worker_vault.call_tool(
-                "capture_lesson",
-                {"project": "testproject", "text": "session notes"},
-            ))
-            lower = result.lower()
-            assert (
-                "permission" in lower
-                or "write error" in lower
-                or "error" in lower
+            result = _text(
+                await worker_vault.call_tool(
+                    "capture_lesson",
+                    {"project": "testproject", "text": "session notes"},
+                )
             )
+            lower = result.lower()
+            assert "permission" in lower or "write error" in lower or "error" in lower
         finally:
             lessons_file.chmod(0o644)
 
     @pytest.mark.asyncio
     async def test_curly_braces_in_user_text(
-        self, git_vault: Path, worker_vault: FastMCP, ollama: OllamaClient,
+        self,
+        git_vault: Path,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
     ) -> None:
         """User text with curly braces (code, JSON) doesn't crash str.format()."""
         ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
@@ -3477,31 +3773,44 @@ class TestExtractLessons:
             return_value=_worker_response(_VALID_LESSONS_JSON),
         )
         # Text containing curly braces — would crash without escaping
-        result = _text(await worker_vault.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "text": 'def foo(): return {"key": value}'},
-        ))
+        result = _text(
+            await worker_vault.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "text": 'def foo(): return {"key": value}'},
+            )
+        )
         assert "Always check return values" in result
 
     @pytest.mark.asyncio
     async def test_sanitizes_newlines_in_tags(
-        self, git_vault: Path, worker_vault: FastMCP, ollama: OllamaClient,
+        self,
+        git_vault: Path,
+        worker_vault: FastMCP,
+        ollama: OllamaClient,
     ) -> None:
         """Tags with newlines are sanitized to prevent markdown injection."""
-        injected_tags = json.dumps([{
-            "title": "Tag injection test",
-            "context": "ctx", "problem": "prob", "solution": "sol",
-            "tags": ["python\n### Fake Lesson"],
-            "confidence": 0.9,
-        }])
+        injected_tags = json.dumps(
+            [
+                {
+                    "title": "Tag injection test",
+                    "context": "ctx",
+                    "problem": "prob",
+                    "solution": "sol",
+                    "tags": ["python\n### Fake Lesson"],
+                    "confidence": 0.9,
+                }
+            ]
+        )
         ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
         ollama.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(injected_tags),
         )
-        result = _text(await worker_vault.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "text": "session"},
-        ))
+        result = _text(
+            await worker_vault.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "text": "session"},
+            )
+        )
         assert "Tag injection test" in result
         lessons = (git_vault / "10_projects" / "testproject" / "90-lessons.md").read_text()
         # Newline sanitized: "### Fake Lesson" must NOT appear as a standalone heading
@@ -3518,9 +3827,12 @@ class TestVaultValidate:
     async def test_unknown_check_names_rejected(self, mock_vault: Path) -> None:
         """Typo in check name returns error instead of false positive."""
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_health", {"checks": ["frontmater"]},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmater"]},
+            )
+        )
         assert "Unknown check" in result
         assert "frontmatter" in result
 
@@ -3529,18 +3841,23 @@ class TestVaultValidate:
         scope = tmp_path / "10_projects"
         scope.mkdir()
         mcp = create_server(vault_path=tmp_path)
-        result = _text(await mcp.call_tool(
-            "vault_health", {"checks": ["frontmatter"]},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmatter"]},
+            )
+        )
         assert "no projects" in result.lower() or "0 issues" in result.lower()
 
     async def test_healthy_vault_no_errors(self, mock_vault: Path) -> None:
         """Well-formed vault produces no error-level issues."""
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
+        result = _text(
+            await mcp.call_tool(
                 "vault_health",
                 {"checks": ["frontmatter", "stale", "links"]},
-            ))
+            )
+        )
         # Anchor on the `[error]` issue marker (and the "Vault clean"
         # all-green message) rather than the bare substring — the
         # identity block now exposes ``vault_path`` which may contain
@@ -3552,10 +3869,12 @@ class TestVaultValidate:
         bad = mock_vault / "10_projects" / "testproject" / "no-frontmatter.md"
         bad.write_text("# Just a heading\n\nNo frontmatter here.\n")
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
+        result = _text(
+            await mcp.call_tool(
                 "vault_health",
                 {"checks": ["frontmatter", "stale", "links"]},
-            ))
+            )
+        )
         assert "no-frontmatter.md" in result
         assert "frontmatter" in result.lower()
 
@@ -3564,10 +3883,12 @@ class TestVaultValidate:
         bad = mock_vault / "10_projects" / "testproject" / "incomplete.md"
         bad.write_text("---\nid: incomplete\n---\n\n# Missing type and status\n")
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
+        result = _text(
+            await mcp.call_tool(
                 "vault_health",
                 {"checks": ["frontmatter", "stale", "links"]},
-            ))
+            )
+        )
         assert "incomplete.md" in result
         assert "type" in result.lower() or "status" in result.lower()
 
@@ -3579,10 +3900,12 @@ class TestVaultValidate:
             "---\n\n# Bad date\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
+        result = _text(
+            await mcp.call_tool(
                 "vault_health",
                 {"checks": ["frontmatter", "stale", "links"]},
-            ))
+            )
+        )
         assert "bad-date.md" in result
         assert "date" in result.lower()
 
@@ -3594,10 +3917,12 @@ class TestVaultValidate:
             "---\n\n# Very old file\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
+        result = _text(
+            await mcp.call_tool(
                 "vault_health",
                 {"checks": ["frontmatter", "stale", "links"]},
-            ))
+            )
+        )
         assert "ancient.md" in result
         assert "stale" in result.lower()
 
@@ -3609,10 +3934,12 @@ class TestVaultValidate:
             "---\n\n# Old but done\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
+        result = _text(
+            await mcp.call_tool(
                 "vault_health",
                 {"checks": ["frontmatter", "stale", "links"]},
-            ))
+            )
+        )
         assert "old-done.md" not in result
 
     async def test_broken_wikilink_detected(self, mock_vault: Path) -> None:
@@ -3623,10 +3950,12 @@ class TestVaultValidate:
             "See [[nonexistent-doc]] for details.\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
+        result = _text(
+            await mcp.call_tool(
                 "vault_health",
                 {"checks": ["frontmatter", "stale", "links"]},
-            ))
+            )
+        )
         assert "nonexistent-doc" in result
         assert "link" in result.lower() or "broken" in result.lower()
 
@@ -3638,10 +3967,12 @@ class TestVaultValidate:
             "See [[adr-001-test]] for details.\n"
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
+        result = _text(
+            await mcp.call_tool(
                 "vault_health",
                 {"checks": ["frontmatter", "stale", "links"]},
-            ))
+            )
+        )
         assert "adr-001-test" not in result
 
     async def test_project_filter(self, mock_vault: Path) -> None:
@@ -3651,9 +3982,12 @@ class TestVaultValidate:
         other.mkdir(parents=True)
         (other / "broken.md").write_text("No frontmatter here.\n")
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_health", {"project": "testproject"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"project": "testproject"},
+            )
+        )
         assert "broken.md" not in result
 
     async def test_checks_filter(self, mock_vault: Path) -> None:
@@ -3667,9 +4001,12 @@ class TestVaultValidate:
         bad.write_text("No frontmatter.\n")
         mcp = create_server(vault_path=mock_vault)
         # Only run frontmatter check — stale should not appear
-        result = _text(await mcp.call_tool(
-            "vault_health", {"checks": ["frontmatter"]},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmatter"]},
+            )
+        )
         assert "no-fm.md" in result
         assert "ancient2.md" not in result
 
@@ -3679,23 +4016,28 @@ class TestVaultValidate:
         for i in range(20):
             (project / f"bad-{i}.md").write_text("No frontmatter.\n")
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_health",
-            {"checks": ["frontmatter"], "max_issues": 5},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"checks": ["frontmatter"], "max_issues": 5},
+            )
+        )
         assert "truncated" in result.lower() or "more" in result.lower()
 
     async def test_project_not_found(self, mock_vault: Path) -> None:
         """Unknown project returns error."""
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_health",
-            {"project": "nonexistent", "checks": ["frontmatter"]},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"project": "nonexistent", "checks": ["frontmatter"]},
+            )
+        )
         assert "not found" in result.lower()
 
     async def test_wikilink_inside_fenced_code_block_not_flagged(
-        self, mock_vault: Path,
+        self,
+        mock_vault: Path,
     ) -> None:
         """Bash regex classes (e.g. [[:space:]], [[ -z "$1" ]]) inside fenced
         code blocks must NOT be parsed as wikilinks. Currently false-positives.
@@ -3714,17 +4056,20 @@ class TestVaultValidate:
             "~~~\n",
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_health",
-            {"project": "testproject", "checks": ["links"]},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"project": "testproject", "checks": ["links"]},
+            )
+        )
         assert "shell-snippets.md" not in result, (
             f"Bash regex inside fenced blocks should not produce broken-link "
             f"warnings; got: {result}"
         )
 
     async def test_escaped_pipe_in_wikilink_resolves_target(
-        self, mock_vault: Path,
+        self,
+        mock_vault: Path,
     ) -> None:
         """`[[target\\|alias]]` is Obsidian's escape for pipes inside table cells.
         The parser must treat `\\|` as an alias separator, not part of the target.
@@ -3737,19 +4082,21 @@ class TestVaultValidate:
             "| ADR | [[adr-001-test\\|the ADR]] |\n",
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_health",
-            {"project": "testproject", "checks": ["links"]},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"project": "testproject", "checks": ["links"]},
+            )
+        )
         # The target adr-001-test exists; the escaped pipe must be parsed as
         # an alias separator, so no broken-link warning should appear.
         assert "with-escaped-pipe.md" not in result, (
-            f"Escaped-pipe wikilink should resolve to existing target; "
-            f"got: {result}"
+            f"Escaped-pipe wikilink should resolve to existing target; got: {result}"
         )
 
     async def test_subdir_path_wikilink_to_existing_file_not_flagged(
-        self, mock_vault: Path,
+        self,
+        mock_vault: Path,
     ) -> None:
         """`[[30-architecture/adr-001-test|alias]]` should resolve to the
         existing file `30-architecture/adr-001-test.md`, not be flagged broken.
@@ -3760,17 +4107,19 @@ class TestVaultValidate:
             "See [[30-architecture/adr-001-test|the ADR]] for the rationale.\n",
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_health",
-            {"project": "testproject", "checks": ["links"]},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"project": "testproject", "checks": ["links"]},
+            )
+        )
         assert "with-subdir-link.md" not in result, (
-            f"Subdir-path wikilink to existing file should not be flagged; "
-            f"got: {result}"
+            f"Subdir-path wikilink to existing file should not be flagged; got: {result}"
         )
 
     async def test_memory_file_skipped_by_frontmatter_check(
-        self, mock_vault: Path,
+        self,
+        mock_vault: Path,
     ) -> None:
         """Files under */memory/ use Claude auto-memory schema
         (`name`/`description`/`metadata.type`), not the standard vault schema.
@@ -3789,19 +4138,20 @@ class TestVaultValidate:
             "# Project Memory\n\nIndex content with no frontmatter.\n",
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_health",
-            {"project": "testproject", "checks": ["frontmatter"]},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"project": "testproject", "checks": ["frontmatter"]},
+            )
+        )
         assert "memory/feedback_example.md" not in result, (
             f"Auto-memory schema must be accepted; got: {result}"
         )
-        assert "memory/MEMORY.md" not in result, (
-            f"MEMORY.md must be skipped; got: {result}"
-        )
+        assert "memory/MEMORY.md" not in result, f"MEMORY.md must be skipped; got: {result}"
 
     async def test_meta_scope_wikilink_resolves(
-        self, mock_vault: Path,
+        self,
+        mock_vault: Path,
     ) -> None:
         """`[[pattern-X]]` targeting `00_meta/patterns/pattern-X.md` must
         resolve. The meta scope is the canonical home for cross-project
@@ -3816,17 +4166,19 @@ class TestVaultValidate:
             "Also [[_meta/patterns/pattern-tdd]] (scope-rooted form).\n",
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_health",
-            {"project": "testproject", "checks": ["links"]},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"project": "testproject", "checks": ["links"]},
+            )
+        )
         assert "with-meta-link.md" not in result, (
-            f"Wikilink to existing meta-scope target must resolve; "
-            f"got: {result}"
+            f"Wikilink to existing meta-scope target must resolve; got: {result}"
         )
 
     async def test_cross_project_vault_rooted_wikilink_resolves(
-        self, mock_vault: Path,
+        self,
+        mock_vault: Path,
     ) -> None:
         """`[[other-project/30-architecture/adr-X]]` must resolve to the
         existing file under another project in the same scope. This is the
@@ -3837,14 +4189,12 @@ class TestVaultValidate:
         kubelab = mock_vault / "10_projects" / "kubelab"
         kubelab.mkdir()
         (kubelab / "00-context.md").write_text(
-            "---\nid: kubelab\ntype: project\nstatus: active\n---\n\n"
-            "# Kubelab\n",
+            "---\nid: kubelab\ntype: project\nstatus: active\n---\n\n# Kubelab\n",
         )
         adrs = kubelab / "30-architecture" / "adrs"
         adrs.mkdir(parents=True)
         (adrs / "adr-038-orchestrator-architecture.md").write_text(
-            "---\nid: adr-038\ntype: adr\nstatus: accepted\n---\n\n"
-            "# ADR-038\n",
+            "---\nid: adr-038\ntype: adr\nstatus: accepted\n---\n\n# ADR-038\n",
         )
 
         doc = mock_vault / "10_projects" / "testproject" / "with-xproj-link.md"
@@ -3855,15 +4205,19 @@ class TestVaultValidate:
             "|ADR-038]].\n",
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_health", {"checks": ["links"]},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"checks": ["links"]},
+            )
+        )
         assert "with-xproj-link.md" not in result, (
             f"Cross-project vault-rooted wikilink must resolve; got: {result}"
         )
 
     async def test_posix_class_in_heading_not_flagged(
-        self, mock_vault: Path,
+        self,
+        mock_vault: Path,
     ) -> None:
         """POSIX character classes (`[[:space:]]`, `[[:digit:]]`, etc.) that
         appear in markdown headings or prose (outside fenced/inline code) must
@@ -3884,13 +4238,14 @@ class TestVaultValidate:
             encoding="utf-8",
         )
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_health",
-            {"project": "testproject", "checks": ["links"]},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_health",
+                {"project": "testproject", "checks": ["links"]},
+            )
+        )
         assert "posix-heading.md" not in result, (
-            f"POSIX character classes outside code must not be flagged; "
-            f"got: {result}"
+            f"POSIX character classes outside code must not be flagged; got: {result}"
         )
 
 
@@ -3899,7 +4254,9 @@ class TestVaultValidate:
 
 class TestSetupFileLogging:
     def test_creates_log_file_and_handler(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         import logging
         import os
@@ -3916,7 +4273,8 @@ class TestSetupFileLogging:
 
         logger = logging.getLogger("hive")
         file_handlers = [
-            h for h in logger.handlers
+            h
+            for h in logger.handlers
             if isinstance(h, logging.handlers.RotatingFileHandler)
             and str(expected) in str(getattr(h, "baseFilename", ""))
         ]
@@ -3944,6 +4302,7 @@ class TestToolTimeouts:
         ollama: OllamaClient,
     ) -> None:
         """delegate_task returns timeout message when worker hangs."""
+
         async def slow_generate(*a: object, **kw: object) -> ClientResponse:
             await asyncio.sleep(999)
             raise AssertionError("unreachable")
@@ -3964,6 +4323,7 @@ class TestToolTimeouts:
         ollama: OllamaClient,
     ) -> None:
         """worker_status returns timeout message when connectivity check hangs."""
+
         async def slow_check() -> bool:
             await asyncio.sleep(999)
             return True
@@ -4002,10 +4362,12 @@ class TestToolTimeouts:
         ctx = mcp._hive_ctx  # type: ignore[attr-defined]
         ctx.tool_timeout = 0.1
 
-        result = _text(await mcp.call_tool(
-            "capture_lesson",
-            {"project": "testproject", "text": "some text to extract"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "capture_lesson",
+                {"project": "testproject", "text": "some text to extract"},
+            )
+        )
         assert "timed out" in result.lower()
         _close_server(mcp)
 
@@ -4015,7 +4377,8 @@ class TestWriteLockTimeout:
 
     @pytest.mark.asyncio
     async def test_write_lock_timeout_returns_error(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """vault_write returns friendly error when write lock cannot be acquired."""
         from unittest.mock import patch
@@ -4024,21 +4387,24 @@ class TestWriteLockTimeout:
 
         with patch("hive._helpers._WRITE_LOCK") as mock_lock:
             mock_lock.acquire.return_value = False
-            result = _text(await mcp.call_tool(
-                "vault_write",
-                {
-                    "project": "testproject",
-                    "section": "lessons",
-                    "operation": "append",
-                    "content": "\nNew content\n",
-                },
-            ))
+            result = _text(
+                await mcp.call_tool(
+                    "vault_write",
+                    {
+                        "project": "testproject",
+                        "section": "lessons",
+                        "operation": "append",
+                        "content": "\nNew content\n",
+                    },
+                )
+            )
         assert "busy" in result.lower() or "timeout" in result.lower()
         _close_server(mcp)
 
     @pytest.mark.asyncio
     async def test_patch_lock_timeout_returns_error(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """vault_patch returns friendly error when write lock cannot be acquired."""
         from unittest.mock import patch
@@ -4047,21 +4413,24 @@ class TestWriteLockTimeout:
 
         with patch("hive._helpers._WRITE_LOCK") as mock_lock:
             mock_lock.acquire.return_value = False
-            result = _text(await mcp.call_tool(
-                "vault_patch",
-                {
-                    "project": "testproject",
-                    "path": "11-tasks.md",
-                    "find": "- [ ] Task one",
-                    "replace": "- [x] Task one done",
-                },
-            ))
+            result = _text(
+                await mcp.call_tool(
+                    "vault_patch",
+                    {
+                        "project": "testproject",
+                        "path": "11-tasks.md",
+                        "find": "- [ ] Task one",
+                        "replace": "- [x] Task one done",
+                    },
+                )
+            )
         assert "busy" in result.lower() or "timeout" in result.lower()
         _close_server(mcp)
 
     @pytest.mark.asyncio
     async def test_create_lock_timeout_returns_error(
-        self, git_vault: Path,
+        self,
+        git_vault: Path,
     ) -> None:
         """vault_write create mode returns error when write lock cannot be acquired."""
         from unittest.mock import patch
@@ -4070,16 +4439,18 @@ class TestWriteLockTimeout:
 
         with patch("hive._helpers._WRITE_LOCK") as mock_lock:
             mock_lock.acquire.return_value = False
-            result = _text(await mcp.call_tool(
-                "vault_write",
-                {
-                    "project": "testproject",
-                    "operation": "create",
-                    "path": "new-doc.md",
-                    "doc_type": "note",
-                    "content": "# New Doc\n",
-                },
-            ))
+            result = _text(
+                await mcp.call_tool(
+                    "vault_write",
+                    {
+                        "project": "testproject",
+                        "operation": "create",
+                        "path": "new-doc.md",
+                        "doc_type": "note",
+                        "content": "# New Doc\n",
+                    },
+                )
+            )
         assert "busy" in result.lower() or "timeout" in result.lower()
         _close_server(mcp)
 
@@ -4114,18 +4485,24 @@ class TestAgentsScope:
     async def test_query_explicit_agents_scope(self, mock_vault: Path) -> None:
         _seed_agent(mock_vault)
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_query", {"project": "agents:Hermes-NaN", "section": "context"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "agents:Hermes-NaN", "section": "context"},
+            )
+        )
         assert "Remote ops agent" in result
         _close_server(mcp)
 
     async def test_query_auto_scan_agents(self, mock_vault: Path) -> None:
         _seed_agent(mock_vault)
         mcp = create_server(vault_path=mock_vault)
-        result = _text(await mcp.call_tool(
-            "vault_query", {"project": "Hermes-NaN", "section": "context"},
-        ))
+        result = _text(
+            await mcp.call_tool(
+                "vault_query",
+                {"project": "Hermes-NaN", "section": "context"},
+            )
+        )
         assert "Remote ops agent" in result
         _close_server(mcp)
 
@@ -4141,20 +4518,29 @@ class TestAgentsScope:
 
         agent = _seed_agent(git_multi_scope_vault)
         subprocess.run(
-            ["git", "add", "."], cwd=git_multi_scope_vault,
-            capture_output=True, check=True,
+            ["git", "add", "."],
+            cwd=git_multi_scope_vault,
+            capture_output=True,
+            check=True,
         )
         subprocess.run(
-            ["git", "commit", "-m", "add agent"], cwd=git_multi_scope_vault,
-            capture_output=True, check=True,
+            ["git", "commit", "-m", "add agent"],
+            cwd=git_multi_scope_vault,
+            capture_output=True,
+            check=True,
         )
         mcp = create_server(vault_path=git_multi_scope_vault)
-        result = _text(await mcp.call_tool("vault_write", {
-            "project": "agents:Hermes-NaN",
-            "section": "tasks",
-            "operation": "append",
-            "content": "\n## Inbox\nFirst task for the agent.\n",
-        }))
+        result = _text(
+            await mcp.call_tool(
+                "vault_write",
+                {
+                    "project": "agents:Hermes-NaN",
+                    "section": "tasks",
+                    "operation": "append",
+                    "content": "\n## Inbox\nFirst task for the agent.\n",
+                },
+            )
+        )
         assert "Updated" in result
         assert "First task for the agent" in (agent / "11-tasks.md").read_text()
         _close_server(mcp)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -59,7 +59,8 @@ def test_render_windows_task_xml_has_logon_trigger_and_restart_on_failure() -> N
 
 
 def test_install_writes_systemd_unit_and_enables(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     import hive._service as svc
 
@@ -80,7 +81,8 @@ def test_install_writes_systemd_unit_and_enables(
 
 
 def test_install_no_enable_writes_unit_but_skips_systemctl(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     import hive._service as svc
 
@@ -133,7 +135,8 @@ def test_install_macos_is_a_clear_stub(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_uninstall_linux_removes_unit_and_disables(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     import hive._service as svc
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -56,9 +56,7 @@ def _ollama_reachable() -> bool:
 
 
 skip_no_ollama = pytest.mark.skipif(not _ollama_reachable(), reason="Ollama not reachable")
-skip_no_openrouter = pytest.mark.skipif(
-    not OPENROUTER_API_KEY, reason="OPENROUTER_API_KEY not set"
-)
+skip_no_openrouter = pytest.mark.skipif(not OPENROUTER_API_KEY, reason="OPENROUTER_API_KEY not set")
 
 
 # ── Fixtures ────────────────────────────────────────────────────────
@@ -69,15 +67,22 @@ def _init_git(path: Path) -> None:
     subprocess.run(["git", "init"], cwd=path, capture_output=True, check=True)
     subprocess.run(
         ["git", "config", "user.email", "test@test.com"],
-        cwd=path, capture_output=True, check=True,
+        cwd=path,
+        capture_output=True,
+        check=True,
     )
     subprocess.run(
         ["git", "config", "user.name", "Test"],
-        cwd=path, capture_output=True, check=True,
+        cwd=path,
+        capture_output=True,
+        check=True,
     )
     subprocess.run(["git", "add", "."], cwd=path, capture_output=True, check=True)
     subprocess.run(
-        ["git", "commit", "-m", "init"], cwd=path, capture_output=True, check=True,
+        ["git", "commit", "-m", "init"],
+        cwd=path,
+        capture_output=True,
+        check=True,
     )
 
 
@@ -130,8 +135,15 @@ def smoke_vault(tmp_path: Path) -> Path:
 
     # Large file for truncation tests
     large_lines = [
-        "---", "id: large-doc", "type: lesson", "status: active",
-        'created: "2026-01-15"', "---", "", "# Large Document", "",
+        "---",
+        "id: large-doc",
+        "type: lesson",
+        "status: active",
+        'created: "2026-01-15"',
+        "---",
+        "",
+        "# Large Document",
+        "",
     ]
     for i in range(1, 101):
         large_lines.append(f"Line {i}: content.")
@@ -171,57 +183,80 @@ class TestVaultSmoke:
 
     # B2
     async def test_query_context(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_query", {"project": "smoketest", "section": "context"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_query",
+                {"project": "smoketest", "section": "context"},
+            )
+        )
         assert "Smoke Test Project" in result
 
     async def test_query_tasks(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_query", {"project": "smoketest", "section": "tasks"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_query",
+                {"project": "smoketest", "section": "tasks"},
+            )
+        )
         assert "Task alpha" in result
 
     async def test_query_lessons(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_query", {"project": "smoketest", "section": "lessons"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_query",
+                {"project": "smoketest", "section": "lessons"},
+            )
+        )
         assert "Lesson One" in result
 
     # B3
     async def test_query_arbitrary_path(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_query", {"project": "smoketest", "path": "30-architecture/adr-001.md"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_query",
+                {"project": "smoketest", "path": "30-architecture/adr-001.md"},
+            )
+        )
         assert "ADR-001" in result
 
     # B4
     async def test_query_meta(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_query", {"project": "_meta", "path": "patterns/pattern-tdd.md"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_query",
+                {"project": "_meta", "path": "patterns/pattern-tdd.md"},
+            )
+        )
         assert "TDD" in result
 
     # B5
     async def test_query_max_lines(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_query", {"project": "smoketest", "path": "92-large-doc.md", "max_lines": 5},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_query",
+                {"project": "smoketest", "path": "92-large-doc.md", "max_lines": 5},
+            )
+        )
         assert "truncated" in result.lower()
 
     # B6
     async def test_query_include_metadata(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_query",
-            {"project": "smoketest", "section": "context", "include_metadata": True},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_query",
+                {"project": "smoketest", "section": "context", "include_metadata": True},
+            )
+        )
         assert "type=project" in result
 
     # B7
     async def test_query_project_not_found(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_query", {"project": "nonexistent"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_query",
+                {"project": "nonexistent"},
+            )
+        )
         assert "not found" in result.lower()
 
     # B8
@@ -231,23 +266,32 @@ class TestVaultSmoke:
 
     # B9
     async def test_search_with_filter(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_search", {"query": "Decision", "type_filter": "adr"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_search",
+                {"query": "Decision", "type_filter": "adr"},
+            )
+        )
         assert "adr-001" in result
 
     # B10
     async def test_search_regex(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_search", {"query": r"Line\s+\d+:", "use_regex": True},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_search",
+                {"query": r"Line\s+\d+:", "use_regex": True},
+            )
+        )
         assert "92-large-doc.md" in result
 
     # B11
     async def test_search_no_results(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_search", {"query": "xyznonexistent999"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_search",
+                {"query": "xyznonexistent999"},
+            )
+        )
         assert "no matches" in result.lower()
 
     # B12
@@ -257,118 +301,138 @@ class TestVaultSmoke:
 
     # B13
     async def test_update_append(self, server: FastMCP, smoke_vault: Path) -> None:
-        result = _text(await server.call_tool(
-            "vault_write",
-            {
-                "project": "smoketest",
-                "section": "lessons",
-                "operation": "append",
-                "content": "\n## Lesson Two\nNew lesson.\n",
-            },
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_write",
+                {
+                    "project": "smoketest",
+                    "section": "lessons",
+                    "operation": "append",
+                    "content": "\n## Lesson Two\nNew lesson.\n",
+                },
+            )
+        )
         assert "updated" in result.lower()
         content = (smoke_vault / "10_projects" / "smoketest" / "90-lessons.md").read_text()
         assert "Lesson Two" in content
 
     # B14
     async def test_update_invalid_frontmatter(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_write",
-            {
-                "project": "smoketest",
-                "section": "tasks",
-                "operation": "replace",
-                "content": "# No frontmatter\n",
-            },
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_write",
+                {
+                    "project": "smoketest",
+                    "section": "tasks",
+                    "operation": "replace",
+                    "content": "# No frontmatter\n",
+                },
+            )
+        )
         assert "frontmatter" in result.lower()
 
     # B15
     async def test_create(self, server: FastMCP, smoke_vault: Path) -> None:
-        result = _text(await server.call_tool(
-            "vault_write",
-            {
-                "project": "smoketest",
-                "path": "30-architecture/adr-test.md",
-                "content": "# Test ADR\n",
-                "doc_type": "adr",
-                "operation": "create",
-            },
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_write",
+                {
+                    "project": "smoketest",
+                    "path": "30-architecture/adr-test.md",
+                    "content": "# Test ADR\n",
+                    "doc_type": "adr",
+                    "operation": "create",
+                },
+            )
+        )
         assert "created" in result.lower()
         adr = smoke_vault / "10_projects" / "smoketest" / "30-architecture" / "adr-test.md"
         assert adr.exists()
 
     # B16
     async def test_create_duplicate(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_write",
-            {
-                "project": "smoketest",
-                "path": "30-architecture/adr-001.md",
-                "content": "dup",
-                "doc_type": "adr",
-                "operation": "create",
-            },
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_write",
+                {
+                    "project": "smoketest",
+                    "path": "30-architecture/adr-001.md",
+                    "content": "dup",
+                    "doc_type": "adr",
+                    "operation": "create",
+                },
+            )
+        )
         assert "already exists" in result.lower()
 
     # B17
     async def test_list_files(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_list", {"project": "smoketest"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_list",
+                {"project": "smoketest"},
+            )
+        )
         assert "00-context.md" in result
         assert "30-architecture/" in result
 
     # B18
     async def test_list_files_pattern(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_list", {"project": "smoketest", "pattern": "adr-*"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_list",
+                {"project": "smoketest", "pattern": "adr-*"},
+            )
+        )
         assert "adr-001.md" in result
 
     # B19
     async def test_patch(self, server: FastMCP, smoke_vault: Path) -> None:
-        result = _text(await server.call_tool(
-            "vault_patch",
-            {
-                "project": "smoketest",
-                "path": "11-tasks.md",
-                "find": "- [ ] Task alpha",
-                "replace": "- [x] Task alpha",
-            },
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_patch",
+                {
+                    "project": "smoketest",
+                    "path": "11-tasks.md",
+                    "find": "- [ ] Task alpha",
+                    "replace": "- [x] Task alpha",
+                },
+            )
+        )
         assert "patch" in result.lower()
         content = (smoke_vault / "10_projects" / "smoketest" / "11-tasks.md").read_text()
         assert "- [x] Task alpha" in content
 
     # B20
     async def test_patch_ambiguous(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_patch",
-            {
-                "project": "smoketest",
-                "path": "11-tasks.md",
-                "find": "Task",
-                "replace": "Item",
-            },
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_patch",
+                {
+                    "project": "smoketest",
+                    "path": "11-tasks.md",
+                    "find": "Task",
+                    "replace": "Item",
+                },
+            )
+        )
         assert "ambiguous" in result.lower()
 
     # B21
     async def test_capture_lesson(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "capture_lesson",
-            {
-                "project": "smoketest",
-                "title": "Smoke Lesson",
-                "context": "E2E test",
-                "problem": "Need to verify capture works",
-                "solution": "Call the tool",
-                "tags": ["smoke", "test"],
-            },
-        ))
+        result = _text(
+            await server.call_tool(
+                "capture_lesson",
+                {
+                    "project": "smoketest",
+                    "title": "Smoke Lesson",
+                    "context": "E2E test",
+                    "problem": "Need to verify capture works",
+                    "solution": "Call the tool",
+                    "tags": ["smoke", "test"],
+                },
+            )
+        )
         assert "captured" in result.lower()
 
     # B22
@@ -379,46 +443,64 @@ class TestVaultSmoke:
             {
                 "project": "smoketest",
                 "title": "Dedup Lesson",
-                "context": "test", "problem": "test", "solution": "test",
+                "context": "test",
+                "problem": "test",
+                "solution": "test",
             },
         )
         # Second with same title
-        result = _text(await server.call_tool(
-            "capture_lesson",
-            {
-                "project": "smoketest",
-                "title": "Dedup Lesson",
-                "context": "test2", "problem": "test2", "solution": "test2",
-            },
-        ))
+        result = _text(
+            await server.call_tool(
+                "capture_lesson",
+                {
+                    "project": "smoketest",
+                    "title": "Dedup Lesson",
+                    "context": "test2",
+                    "problem": "test2",
+                    "solution": "test2",
+                },
+            )
+        )
         assert "already exists" in result.lower()
 
     # B23
     async def test_summarize_small_file(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "delegate_task", {"project": "smoketest", "section": "context"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "delegate_task",
+                {"project": "smoketest", "section": "context"},
+            )
+        )
         assert "Smoke Test Project" in result
 
     # B24
     async def test_ranked_search(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_search", {"query": "Decision", "ranked": True},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_search",
+                {"query": "Decision", "ranked": True},
+            )
+        )
         assert "adr-001" in result
 
     # B25
     async def test_session_briefing(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "session_briefing", {"project": "smoketest"},
-        ))
+        result = _text(
+            await server.call_tool(
+                "session_briefing",
+                {"project": "smoketest"},
+            )
+        )
         assert "Session Briefing" in result
 
     # B26
     async def test_vault_search_recent(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_search", {"project": "smoketest", "since_days": 30},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_search",
+                {"project": "smoketest", "since_days": 30},
+            )
+        )
         # Should return something (at least the recently created files)
         assert "smoketest" in result.lower() or "recent" in result.lower()
 
@@ -426,9 +508,12 @@ class TestVaultSmoke:
     async def test_vault_health_usage(self, server: FastMCP) -> None:
         # Call a tool first to generate usage data
         await server.call_tool("vault_list", {})
-        result = _text(await server.call_tool(
-            "vault_health", {"include_usage": True},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_health",
+                {"include_usage": True},
+            )
+        )
         assert "vault_list" in result
 
 
@@ -501,22 +586,29 @@ class TestEdgeCasesSmoke:
 
     # G3
     async def test_large_file_truncation(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool(
-            "vault_query", {"project": "smoketest", "path": "92-large-doc.md", "max_lines": 10},
-        ))
+        result = _text(
+            await server.call_tool(
+                "vault_query",
+                {"project": "smoketest", "path": "92-large-doc.md", "max_lines": 10},
+            )
+        )
         assert "truncated" in result.lower()
         lines_before_truncation = result.split("[...")[0].strip().splitlines()
         assert len(lines_before_truncation) == 10
 
     # G4
     async def test_budget_exhausted(
-        self, server: FastMCP, smoke_budget: BudgetTracker,
+        self,
+        server: FastMCP,
+        smoke_budget: BudgetTracker,
     ) -> None:
         smoke_budget.record_request(model="test", cost_usd=5.0, tokens=0, latency_ms=0)
-        result = _text(await server.call_tool(
-            "delegate_task",
-            {"prompt": PING_PROMPT, "model": "openrouter", "max_cost_per_request": 0.01},
-        ))
+        result = _text(
+            await server.call_tool(
+                "delegate_task",
+                {"prompt": PING_PROMPT, "model": "openrouter", "max_cost_per_request": 0.01},
+            )
+        )
         assert "budget" in result.lower()
 
 
@@ -567,9 +659,7 @@ class TestOpenRouterFreeDirect:
     async def test_openrouter_free_records_budget(
         self, server: FastMCP, smoke_budget: BudgetTracker
     ) -> None:
-        await server.call_tool(
-            "delegate_task", {"prompt": PING_PROMPT, "model": "openrouter-free"}
-        )
+        await server.call_tool("delegate_task", {"prompt": PING_PROMPT, "model": "openrouter-free"})
         stats = smoke_budget.month_stats(5.0)
         assert stats["request_count"] == 1
 
@@ -617,15 +707,11 @@ class TestAutoRouting:
     """Auto routing with real backends."""
 
     async def test_auto_picks_ollama_first(self, server: FastMCP) -> None:
-        result = _text(
-            await server.call_tool("delegate_task", {"prompt": PING_PROMPT})
-        )
+        result = _text(await server.call_tool("delegate_task", {"prompt": PING_PROMPT}))
         assert "Worker Response" in result
         assert "qwen2.5-coder" in result
 
-    async def test_auto_records_budget(
-        self, server: FastMCP, smoke_budget: BudgetTracker
-    ) -> None:
+    async def test_auto_records_budget(self, server: FastMCP, smoke_budget: BudgetTracker) -> None:
         await server.call_tool("delegate_task", {"prompt": PING_PROMPT})
         stats = smoke_budget.month_stats(5.0)
         assert stats["request_count"] == 1

--- a/tests/test_sqlite_checkpoint.py
+++ b/tests/test_sqlite_checkpoint.py
@@ -26,7 +26,9 @@ class _ExampleTracker(_SqliteTracker):
 
 
 def _wait_for_count(
-    tracker: _SqliteTracker, minimum: int, deadline_s: float = 2.0,
+    tracker: _SqliteTracker,
+    minimum: int,
+    deadline_s: float = 2.0,
 ) -> int:
     """Poll ``tracker._checkpoint_count`` until it reaches ``minimum`` or
     ``deadline_s`` elapses. Returns the count seen at exit.
@@ -64,10 +66,7 @@ def test_passive_checkpoint_runs_on_interval(tmp_path: Path) -> None:
     try:
         _seed_wal(tracker)
         count = _wait_for_count(tracker, minimum=3, deadline_s=2.0)
-        assert count >= 3, (
-            f"expected ≥3 checkpoint ticks within 2s at 0.1s interval, "
-            f"got {count}"
-        )
+        assert count >= 3, f"expected ≥3 checkpoint ticks within 2s at 0.1s interval, got {count}"
     finally:
         tracker.close()
 
@@ -128,9 +127,7 @@ def test_close_runs_truncate_checkpoint(tmp_path: Path) -> None:
     tracker.close()
 
     post_size = wal_path.stat().st_size if wal_path.exists() else 0
-    assert post_size <= pre_size, (
-        f"WAL not drained on close: pre={pre_size}, post={post_size}"
-    )
+    assert post_size <= pre_size, f"WAL not drained on close: pre={pre_size}, post={post_size}"
 
 
 def test_close_completes_within_guard_under_sibling_reader(tmp_path: Path) -> None:
@@ -202,9 +199,7 @@ def test_checkpoint_loop_survives_sqlite_errors(tmp_path: Path) -> None:
     try:
         _seed_wal(tracker)
         early_count = _wait_for_count(tracker, minimum=2, deadline_s=2.0)
-        assert early_count >= 2, (
-            f"expected ≥2 checkpoint ticks within 2s, got {early_count}"
-        )
+        assert early_count >= 2, f"expected ≥2 checkpoint ticks within 2s, got {early_count}"
 
         # Forcefully simulate a transient error by closing & reopening the
         # connection out from under the loop. The next tick should encounter
@@ -242,6 +237,7 @@ def test_default_interval_from_settings(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     # Reload settings to pick up the env override.
     from hive import config as hive_config
+
     monkeypatch.setattr(hive_config, "settings", hive_config.HiveSettings())
 
     db_path = str(tmp_path / "test.db")

--- a/tests/test_tool_param_aliases.py
+++ b/tests/test_tool_param_aliases.py
@@ -36,12 +36,14 @@ class TestRealAliases:
         mcp = create_server(vault_path=mock_vault)
         canonical = _text(
             await mcp.call_tool(
-                "vault_list", {"project": "testproject", "path": "30-architecture"},
+                "vault_list",
+                {"project": "testproject", "path": "30-architecture"},
             )
         )
         alias = _text(
             await mcp.call_tool(
-                "vault_list", {"project": "testproject", "subpath": "30-architecture"},
+                "vault_list",
+                {"project": "testproject", "subpath": "30-architecture"},
             )
         )
         assert "adr-001-test.md" in alias
@@ -55,7 +57,8 @@ class TestRealAliases:
         )
         alias = _text(
             await mcp.call_tool(
-                "vault_query", {"project": "testproject", "identifier": target},
+                "vault_query",
+                {"project": "testproject", "identifier": target},
             )
         )
         assert "Test Decision" in alias
@@ -65,12 +68,8 @@ class TestRealAliases:
         mcp = create_server(vault_path=mock_vault)
         # A pattern that only matches as a regex, never as a literal substring.
         query = r"Task\s+one"
-        canonical = _text(
-            await mcp.call_tool("vault_search", {"query": query, "use_regex": True})
-        )
-        alias = _text(
-            await mcp.call_tool("vault_search", {"query": query, "regex": True})
-        )
+        canonical = _text(await mcp.call_tool("vault_search", {"query": query, "use_regex": True}))
+        alias = _text(await mcp.call_tool("vault_search", {"query": query, "regex": True}))
         assert alias == canonical
 
     async def test_vault_patch_old_new_string_alias(self, git_vault: Path) -> None:
@@ -89,7 +88,8 @@ class TestRealAliases:
         assert "error" not in resp.lower()
         readback = _text(
             await mcp.call_tool(
-                "vault_query", {"project": "testproject", "path": "11-tasks.md"},
+                "vault_query",
+                {"project": "testproject", "path": "11-tasks.md"},
             )
         )
         assert "- [x] Task one DONE" in readback

--- a/tests/test_transport_recovery.py
+++ b/tests/test_transport_recovery.py
@@ -51,7 +51,8 @@ class TestInMemoryCancellation:
     """Cancellation at the in-process FastMCP boundary must not poison the server."""
 
     async def test_cancelled_call_does_not_break_subsequent_calls(
-        self, vault_mcp: FastMCP,
+        self,
+        vault_mcp: FastMCP,
     ) -> None:
         task = asyncio.create_task(vault_mcp.call_tool("vault_list", {}))
         await asyncio.sleep(0)
@@ -131,7 +132,9 @@ class TestSubprocessTransportRecovery:
         env["HIVE_DB_PATH"] = str(vault / "worker.db")
         env["HIVE_RELEVANCE_DB_PATH"] = str(vault / "relevance.db")
         proc = await asyncio.create_subprocess_exec(
-            sys.executable, "-m", "hive.server",
+            sys.executable,
+            "-m",
+            "hive.server",
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -153,36 +156,45 @@ class TestSubprocessTransportRecovery:
             await proc.wait()
 
     async def test_server_survives_cancellation_notification(
-        self, mock_vault: Path,
+        self,
+        mock_vault: Path,
     ) -> None:
         """A notifications/cancelled mid-call must not kill the transport."""
         proc = await self._spawn(mock_vault)
         try:
             call_id = 2
-            await _send(proc, {
-                "jsonrpc": "2.0",
-                "id": call_id,
-                "method": "tools/call",
-                "params": {"name": "vault_list", "arguments": {}},
-            })
-            await _send(proc, {
-                "jsonrpc": "2.0",
-                "method": "notifications/cancelled",
-                "params": {"requestId": call_id, "reason": "user rejected"},
-            })
+            await _send(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "id": call_id,
+                    "method": "tools/call",
+                    "params": {"name": "vault_list", "arguments": {}},
+                },
+            )
+            await _send(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "method": "notifications/cancelled",
+                    "params": {"requestId": call_id, "reason": "user rejected"},
+                },
+            )
 
             first = await _recv(proc, timeout=15.0)
             assert first.get("id") == call_id, f"unexpected first response: {first!r}"
 
-            await _send(proc, {
-                "jsonrpc": "2.0",
-                "id": 3,
-                "method": "tools/call",
-                "params": {"name": "vault_list", "arguments": {}},
-            })
+            await _send(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {"name": "vault_list", "arguments": {}},
+                },
+            )
             second = await _recv(proc, timeout=15.0)
             assert second.get("id") == 3, f"transport poisoned: {second!r}"
             assert "result" in second or "error" in second
         finally:
             await self._shutdown(proc)
-

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -88,10 +88,7 @@ class TestThreadSafety:
             except Exception as exc:
                 errors.append(exc)
 
-        threads = [
-            threading.Thread(target=worker, args=(i,))
-            for i in range(n_threads)
-        ]
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
         for th in threads:
             th.start()
         for th in threads:

--- a/tests/test_vault_write.py
+++ b/tests/test_vault_write.py
@@ -71,6 +71,4 @@ def test_commit_status_suffix_routes_deadline_killed(
     if expected_substring == "":
         assert result == "", f"expected empty suffix, got {result!r}"
     else:
-        assert expected_substring in result, (
-            f"expected {expected_substring!r} in {result!r}"
-        )
+        assert expected_substring in result, f"expected {expected_substring!r} in {result!r}"


### PR DESCRIPTION
Adopts ruff's formatter as the canonical style and gates it, so `ruff check` and `ruff format` can no longer silently diverge (#157).

## Changes
- One-time `uv run ruff format src/ tests/` — 47 files reformatted (whitespace-only, no behavior change).
- `make lint` + CI gain a `ruff format --check src/ tests/` step alongside `ruff check`.

## Validation
- `make lint` (ruff check + format --check) clean; `mypy --strict` clean.
- Full suite: 685 passed, 2 skipped.

The large diff is purely mechanical reformatting; the only non-format changes are `Makefile` (+3/-1) and `.github/workflows/ci.yml` (+3).

Closes #157