### PR TITLE
fix: surface obsidian-git commit race in vault_health + ADR-014 (#174)

### DIFF
--- a/docs/adr/adr-014-vault-commit-coordination.md
+++ b/docs/adr/adr-014-vault-commit-coordination.md
@@ -1,0 +1,52 @@
+---
+id: adr-014-vault-commit-coordination
+type: adr
+status: active
+created: "2026-06-02"
+---
+
+# ADR-014: Vault Commit Coordination — Single Deliberate Committer
+
+## Status
+
+Accepted — 2026-06-02. Resolves [#174](https://github.com/mlorentedev/hive/issues/174). Extends ADR-010 (external-committer coexistence).
+
+## Context
+
+The knowledge vault is committed **directly to `master`** (no PR flow). Two writers were acting on `master` concurrently and uncoordinated:
+
+1. **Hive** — auto-commits a semantic patch on every `vault_write` / `vault_patch` (`vault: patch …`, `vault: capture_lesson …`). Hive **commits but does not push** (no `git push` / `pull` anywhere in `src/`).
+2. **obsidian-git plugin** — auto-commits on a timer (`autoSaveInterval`, message `vault backup: …`) and reconciles with `pullBeforePush` using **merge**, then pushes.
+
+Observed 3× in one session: semantic commits swept into `vault backup:` blobs, merge commits, and rejected (non-fast-forward) pushes. Root cause: two concurrent committers to one branch with no coordination, made worse by `autoCommitOnlyStaged: false` (the timer sweeps in-progress, unstaged work — including an agent's half-written change) and `pullBeforePush: merge` (merge commits + push contention).
+
+Options weighed (issue #174):
+
+- **A — event-driven, single deliberate committer (chosen).** Eliminate the second writer rather than orchestrate two: turn the obsidian-git timer off and let Hive be the single committer; the plugin (or the operator) pushes deliberately with `rebase`, not on a merge timer. *Boring tech: remove the race, don't manage it.*
+- **D — lock-file coordination.** Teach obsidian-git to respect Hive's ADR-012 cooperative filelock. More robust but requires wrapping a third-party plugin whose timer we do not control; the failure mode (a swept unstaged change) is a *config* problem, not a locking one.
+
+A key constraint shaped the decision: **Hive does not push.** So Hive cannot, by itself, produce a merge commit or a rejected push — those come from the external committer's timer + merge reconciliation. The fix is therefore primarily the external committer's **configuration**, which Hive cannot enforce, only surface.
+
+## Decision
+
+**Adopt A: Hive is the single deliberate committer; the obsidian-git auto-commit timer must be OFF, with `rebase` reconciliation, as a precondition.**
+
+Split by who owns what:
+
+- **Vault configuration (operator-applied, no code).** `autoSaveInterval: 0` (kill the timer → commits become event-driven, Hive-only) and `syncMethod: merge → rebase` (no reconciliation merge commits). This removes the second writer and the merge noise; it is the behavioural fix for the issue's acceptance criteria (no merge commits, no rejected pushes).
+- **Hive-side (this change).** Hive cannot enforce the vault config, so it **makes the racy config visible**: `vault_health` emits a `warning` in its `## external_committer` block whenever `detect_obsidian_git` reports a non-zero `commitInterval` (the block only renders in that case), naming the concrete fix (`autoSaveInterval=0` + `syncMethod=rebase`). A racy config is surfaced, never silently tolerated.
+
+Hive deliberately stays **commit-only** (no push): pushing remains the external committer's / operator's job. Introducing a Hive pusher (pull-rebase-push) was rejected — it adds network I/O and failure handling to the write path to solve a problem the vault config already removes.
+
+## Consequences
+
+- **Positive.** No merge commits and no rejected pushes once the timer is off + rebase is set (the config the warning prescribes). The single-committer invariant is simple and matches the daemon model's single-owner direction (ADR-011). `vault_health` now flags the misconfiguration proactively, so drift back into the racy state is caught.
+- **Negative.** The behavioural guarantee depends on operator-applied vault config that Hive cannot enforce — Hive can only warn. If the operator re-enables the timer, the race returns (the warning will fire again).
+- **Neutral.** No change to Hive's commit path; the only code change is the additive `vault_health` warning line.
+
+## References
+
+- Issue: [#174](https://github.com/mlorentedev/hive/issues/174)
+- ADR-010: external-committer coexistence (the `commit=False` / detect-and-defer machinery this builds on)
+- ADR-011: Phase C daemon model (single-owner direction)
+- `detect_obsidian_git` (`src/hive/_helpers.py`) → `## external_committer` block (`src/hive/_vault_health.py`)

--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -267,6 +267,12 @@ def health_report_text(ctx: ServerContext, filter_project: str = "") -> str:
             "and `vault_patch(commit=False)` are safe; the plugin will "
             "auto-commit on its interval."
         )
+        lines.append(
+            "- warning: obsidian-git's auto-commit timer races Hive's semantic "
+            "commits to vault master (merge commits, rejected pushes — #174). "
+            "Set autoSaveInterval=0 + syncMethod=rebase so Hive stays the single "
+            "deliberate committer (see docs/adr/adr-014)."
+        )
         lines.append("")
 
     # ── Ghost-response counter (HIVE-104 Fase C + HIVE-115 PR-3 source) ──

--- a/tests/test_commit_policy.py
+++ b/tests/test_commit_policy.py
@@ -254,6 +254,25 @@ class TestVaultHealthExternalCommitter:
         assert "external_committer" in result
         assert "obsidian-git" in result
 
+    async def test_health_warns_about_commit_race(
+        self,
+        git_vault: Path,
+    ) -> None:
+        """An ON obsidian-git auto-commit timer races Hive's semantic commits to
+        vault master (#174 / adr-014). vault_health must flag the racy config and
+        name the concrete fix so it is visible, not silently tolerated."""
+        plugin_dir = git_vault / ".obsidian" / "plugins" / "obsidian-git"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "data.json").write_text(
+            json.dumps({"commitInterval": 10}),
+            encoding="utf-8",
+        )
+        mcp = create_server(vault_path=git_vault)
+        result = _text(await mcp.call_tool("vault_health", {}))
+        assert "warning" in result.lower()
+        assert "race" in result.lower()
+        assert "autoSaveInterval" in result  # the concrete fix is named
+
     async def test_health_omits_external_committer_when_absent(
         self,
         git_vault: Path,


### PR DESCRIPTION
Resolves #174.

## Context
The vault commits directly to `master` (no PR flow). Two writers acted uncoordinated: Hive's semantic commits and obsidian-git's auto-commit **timer** (which also pushes with merge reconciliation) → merge commits + rejected pushes.

## Key constraint
Hive **commits but never pushes** (no `git push`/`pull` in `src/`), so it cannot itself produce a merge commit or rejected push. The behavioural fix is **vault config** (`autoSaveInterval=0` + `syncMethod=rebase`) — which Hive can't enforce, only surface.

## Change (ADR-014: single deliberate committer)
- **`vault_health` warning**: a `- warning:` line in the `## external_committer` block whenever `detect_obsidian_git` reports a non-zero `commitInterval`, naming the concrete fix. A racy config is made visible, never silently tolerated.
- **ADR-014** records the decision (Hive stays commit-only; the timer-off + rebase config is the precondition; pushing stays the external committer's job).

## Test plan
- New `test_health_warns_about_commit_race` (TDD red→green).
- `make check` green: lint (incl. `ruff format --check`) + `mypy --strict` + full suite.

Closes #174