### PR TITLE
test: harden four false-green checks found by the CLI-dispatch audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
 
   cross_worker_lock:
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -304,7 +304,14 @@ class TestMaxLinesSweep:
             snr = _signal_ratio(text) * 100
             print(f"{project:<25s}  {tokens:>8d}  {lines:>7d}  {snr:>12.1f}%")
 
-        assert True  # informational
+            # Regression guard: session_briefing's whole purpose is a compact
+            # context pack (~50 lines, not ~800). Observed baselines are
+            # 66-93 lines / 1034-1435 tokens; these generous ~2x caps catch a
+            # real blow-up without flaking on content variance, and the
+            # non-empty guard catches a regression that returns nothing.
+            assert text.strip(), f"{project}: session_briefing returned empty"
+            assert lines < 200, f"{project}: briefing ballooned to {lines} lines"
+            assert tokens < 3000, f"{project}: briefing ballooned to {tokens} tokens"
 
 
 # ── 3. Signal-to-noise by tool ────────────────────────────────────

--- a/tests/test_cross_worker_lock.py
+++ b/tests/test_cross_worker_lock.py
@@ -5,7 +5,8 @@ Promoted from Red-phase placeholder (PR-1) to green (PR-2) once
 wired into the supervisor.
 
 POSIX-first; Windows variant promoted to CI matrix lane in HIVE-116 PR-3
-(``cross_worker_lock`` job on ``windows-latest``, allowed-to-fail for 14d).
+(``cross_worker_lock`` job on ``windows-latest``). The lane is gating after a
+14-day soak (2026-05-27 → 2026-06-10) that stayed green on both OSes.
 """
 
 from __future__ import annotations

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -16,6 +16,7 @@ import sys
 import time
 from typing import TYPE_CHECKING
 
+import httpx
 import pytest
 
 if TYPE_CHECKING:
@@ -329,7 +330,10 @@ def test_hive_serve_rejects_bad_token(daemon_env: tuple[dict[str, str], Path]) -
     proc = _spawn_daemon(env, port)
     try:
         assert _wait_ready(port)
-        with pytest.raises(Exception):  # noqa: B017, PT011 — any auth refusal
+        # A bad bearer token is refused at the transport with HTTP 401 — not a
+        # generic failure. Asserting the status distinguishes auth refusal from
+        # an unrelated server error (which would surface a different code).
+        with pytest.raises(httpx.HTTPStatusError, match="401"):
             asyncio.run(_list_tools(f"http://{HOST}:{port}/mcp", "not-the-token"))
     finally:
         proc.terminate()

--- a/tests/test_transport_recovery.py
+++ b/tests/test_transport_recovery.py
@@ -57,7 +57,7 @@ class TestInMemoryCancellation:
         task = asyncio.create_task(vault_mcp.call_tool("vault_list", {}))
         await asyncio.sleep(0)
         task.cancel()
-        with pytest.raises(BaseException):  # noqa: B017,PT011
+        with pytest.raises(asyncio.CancelledError):
             await task
 
         result = await vault_mcp.call_tool("vault_list", {})
@@ -68,7 +68,7 @@ class TestInMemoryCancellation:
             task = asyncio.create_task(vault_mcp.call_tool("vault_list", {}))
             await asyncio.sleep(0)
             task.cancel()
-            with pytest.raises(BaseException):  # noqa: B017,PT011
+            with pytest.raises(asyncio.CancelledError):
                 await task
 
         result = await vault_mcp.call_tool("vault_list", {})


### PR DESCRIPTION
## Context

Fixing the docker smoke false-green in #203 (a check that passed without ever running the code it claimed) prompted an audit of the rest of CI + tests for the same failure class: **checks that go green without exercising what they assert**. Four found and hardened here.

## Findings

| # | Where | Before | After |
|---|---|---|---|
| 1 | `ci.yml` `cross_worker_lock` job | `continue-on-error: true` — failures never blocked a PR | gating (line dropped) |
| 2 | `test_benchmark.py::test_session_briefing_cost` | `assert True  # informational` — token cost could balloon and stay green | `<200` lines, `<3000` tokens, non-empty (vs 66–93 / 1034–1435 observed) |
| 3 | `test_daemon.py::test_hive_serve_rejects_bad_token` | `pytest.raises(Exception)` — any failure passed | `httpx.HTTPStatusError` matching `401` (the actual auth refusal) |
| 4 | `test_transport_recovery.py` (×2) | `pytest.raises(BaseException)` — over-broad | `asyncio.CancelledError` (the exact type a cancelled task raises) |

## #1 is safe to flip now

The `continue-on-error` was an **intentional 14-day soak** (2026-05-27 → 2026-06-10) on the newly-added Windows lane, documented in the test docstring (now updated). Evidence it's ready: the last **8 master CI runs were green on both `ubuntu-latest` and `windows-latest`** (16/16 job-runs). Its pass should now block regressions like any other job.

## Verification

- #2/#3/#4 confirmed locally (Windows): `test_session_briefing_cost`, `test_hive_serve_rejects_bad_token`, `TestInMemoryCancellation` all green. #3's `401` was determined empirically (a bad bearer token raises `httpx.HTTPStatusError` with "401 Unauthorized").
- `ruff check` + `ruff format --check` clean on all changed files.
- No production code changed — `test:`/`ci:` only, no version bump.