### PR TITLE
feat(service): Windows daemon supervision — windowless S4U + supervisor-loop restart

### DIFF
--- a/docs/adr/adr-015-windows-daemon-supervision-upgrade.md
+++ b/docs/adr/adr-015-windows-daemon-supervision-upgrade.md
@@ -1,0 +1,90 @@
+---
+id: adr-015-windows-daemon-supervision-upgrade
+type: adr
+status: proposed
+created: "2026-06-04"
+owner: manu
+tags: [architecture, daemon, windows, supervision, auto-update, cross-os, mcp]
+---
+
+# ADR-015: Windows Daemon Supervision & Auto-Upgrade (amends ADR-011 §4)
+
+## Status
+
+**Proposed (2026-06-04).** Amends [adr-011-phase-c-daemon-model.md](adr-011-phase-c-daemon-model.md) §4 ("Resilience…"), whose cross-OS restart-on-upgrade contract holds on Linux (systemd) but is **broken on Windows** as shipped. Drives `specs/HIVE-176-windows-daemon-supervision/` (to be scaffolded).
+
+Two of the three Windows mechanisms are **already validated on real hardware** this session (see Context): the wrapper-loop supervisor (restart) and the S4U windowless task (no console window), both non-elevated. One residual `[MUST RESOLVE]` blocks acceptance: the **upgrade-swap mechanism (A)** must be validated by a spike — Windows cannot replace a running executable or a loaded native module in place, which `uv tool upgrade` assumes. `tasks.md` stays unfrozen until that spike passes and this ADR is accepted. This mirrors the discipline ADR-011 used for its own Windows transport `[MUST RESOLVE]`.
+
+## Context
+
+ADR-011 §4 specified supervised auto-restart as "systemd `--user` `Restart=on-failure` (launchd `KeepAlive` / **Windows service recovery**)" and auto-update as "the running daemon adopts [the upgrade] via an **atomic restart-on-upgrade** (drain → stop → swap → start)." The Windows transport was spiked and cleared before ADR-011 was accepted; the **Windows supervision + upgrade path was not** — the `[MUST RESOLVE]` was scoped to transport/token/ACLs only.
+
+The **first real Windows rollout validation** (issue #176, 2026-06-04, on the maintainer's primary Windows box) exercised that unspiked path and found it broken in three ways:
+
+- **(A) `uv tool upgrade` cannot swap a running install on Windows.** The package site-packages updated in place (the daemon's `importlib.metadata` read the new version live), but copying the on-PATH `hive.exe` launcher failed: `os error 32` (sharing violation) — the running daemon (and every `hive client` session Claude Code spawns from the same `uv tool` install) holds the executable open. POSIX replaces an in-use binary by inode swap; Windows refuses. This is **structural**: with the daemon model, hive is *always* running, so the swap can *never* complete cleanly. A naïve `--reinstall` is worse — it tries to remove the locked venv directory (`os error 5`) and corrupts the install.
+- **(B) Task Scheduler `<RestartOnFailure>` does not restart on the daemon's exit 75.** Drift detection works (log `hive.daemon.upgrade.detected boot=1.32.3 installed=1.32.4`, task `LastTaskResult=75`), but 6 minutes after the clean exit the task was `Ready`, no process, `/health` refused. `RestartOnFailure` reacts to the task *engine* failing to launch the action, **not** to an application's non-zero exit code — it is **not** a 1:1 mapping of systemd `Restart=on-failure`.
+- **(C) The daemon shows a console window at every start/logon.** `render_windows_task_xml` registers a console-app `<Exec>` under an interactive-token `LogonTrigger`, so Windows allocates a visible console window — no parity with the silent `systemd --user` unit.
+
+What works on Windows (validated this session): loopback Streamable-HTTP + bearer token (`/health` `{status:ok, ready:true, version}`, MCP `initialize` HTTP 200), drift detection, clean stop, exit 75.
+
+Root cause beyond the bugs: ADR-011 generalized the supervision + upgrade *mechanism* across OSes from a **single** reference (Linux/systemd) without auditing a second OS instance — the failure mode Regla del 3 (ADR-015-of-the-vault / the audit-is-the-evidence rule) exists to prevent.
+
+### Reference audit (Regla del 3)
+
+| Ref | Instance | Restart on exit≠0 | Replace in-use binary | Windowless |
+|---|---|---|---|---|
+| R0 (gold) | `systemd --user Restart=on-failure` (Linux) | yes, reliable | yes (inode replace) | yes (no TTY) |
+| R1 (audited 2026-06-04) | Task Scheduler `<RestartOnFailure>` (Windows, as shipped) | **no** (ignores app exit code) | **no** (copy fails, locked) | **no** (console window) |
+| R2 | NSSM / WinSW (Windows service supervisors) | yes (`AppExit=Restart` default, per-code configurable) | (still needs a swap step) | yes (runs in session 0) |
+| R3 | Self-update idiom (Chrome/VS Code) | n/a | yes — **rename-then-replace** (rename the in-use file aside, write the new one) | n/a |
+
+**Divergence log.** *Shared contract (generalizable, cross-OS — keep as-is):* single-owner daemon, thin client, drift detection, clean stop with a distinct exit code, transparent stdio fallback. *OS-specific mechanism (NOT generalizable — ADR-011 over-generalized here):* (1) restart trigger — systemd `Restart=on-failure` ≠ Task Scheduler `RestartOnFailure`; (2) binary-swap — inode replace (POSIX) ≠ direct copy (Windows, fails on lock); (3) windowless execution — implicit (systemd) ≠ requires S4U / service (Windows).
+
+## Decision
+
+Keep ADR-011's **shared daemon contract** unchanged; make the **Windows supervision + upgrade mechanism explicitly divergent**, no admin rights required (preserving the `setup-windows.ps1` "no admin" constraint). Three mechanisms:
+
+### (B) Restart — in-task wrapper-loop supervisor — VALIDATED
+
+The Task Scheduler action runs a thin supervising loop (a hive-owned `hive serve --supervised` subcommand, or an equivalent wrapper) that relaunches `hive serve` while it exits non-zero and stops on exit 0 — reproducing systemd `Restart=on-failure` semantics that `<RestartOnFailure>` does not provide. **Validated 2026-06-04:** killing the inner `hive serve` (exit −1) made the wrapper relaunch it (`/health` recovered on a new port + PID); `Stop-ScheduledTask` terminates the whole tree → a clean stop does not relaunch.
+
+### (C) Windowless — S4U principal — VALIDATED
+
+Register the task with `<Principal><LogonType>S4U</LogonType><RunLevel>LeastPrivilege</RunLevel></Principal>` so it runs in session 0 (no console window), at logon, with no stored password and **no admin**. **Validated 2026-06-04:** `schtasks /Create /XML` with an S4U principal succeeded non-elevated; the daemon served `/health` with **no console window** (operator-confirmed).
+
+### (A) Upgrade-swap — `[MUST RESOLVE]` (spike-gated)
+
+The load-bearing unknown. `uv tool upgrade` does a direct copy that fails on the in-use `hive.exe` / loaded `.pyd`. Options considered (the spike picks one):
+
+- **A1 — stop-before-upgrade.** The upgrade task stops the daemon, upgrades, restarts. *Rejected as sole mechanism:* fails when any `hive client` session holds the install (constraint C7) — cannot require "close all agent sessions to update."
+- **A2 — tolerate-in-place + post-exit refresh.** `uv tool upgrade` already updates pure-python site-packages while running; treat the entrypoint-copy failure as non-fatal (the launcher is a version-agnostic trampoline) and the wrapper refreshes the launcher in the brief unlocked window after exit 75. *Risk:* a release that changes a loaded **native** module (`.pyd`: pydantic-core, cryptography) cannot be replaced while any hive process runs → mixed-version venv. Cheap, but not bullet-proof.
+- **A3 — versioned-dir + atomic junction swap (recommended target).** Install each version in its own directory; a `current` junction points to the active one; upgrade writes a fresh dir (never touching in-use files) and atomically repoints the junction; the wrapper relaunches from `current`; the old dir is GC'd once unreferenced. Bullet-proof against native-dep upgrades and C7-safe. *Cost:* hive owns a Windows-specific install/upgrade layout, decoupled from `uv tool upgrade` — a real maintenance surface.
+- **A4 — rename-then-replace (R3 idiom).** Wrap the upgrade to rename each locked target aside (`MoveFileEx`) before writing the new file. C7-safe and less invasive than A3, but must enumerate exactly which files uv will touch — fragile coupling to uv internals.
+
+The spike validates A3 (preferred) feasibility with uv on Windows; if too invasive, fall back to A4, then A2. An upstream `uv` issue (replace-while-running on Windows) is filed regardless.
+
+## Consequences
+
+### Positive
+
+- The shipped ADR-011 daemon contract becomes actually deliverable on Windows: restart-on-upgrade works (B), no console window (C), no admin.
+- The cross-OS abstraction is honest: shared contract, per-OS mechanism — auditable against R0–R3, not speculated from one OS.
+
+### Negative
+
+- Windows-specific supervision (wrapper-loop) and upgrade (A3/A4) code — a maintenance surface that Linux/systemd gets for free. The upgrade path may diverge from `uv tool upgrade` (A3 = hive owns the Windows install layout).
+- A multi-PR, cross-repo change: hive (`_service.py` `render_windows_task_xml`, a supervised-serve subcommand, the upgrade mechanism) + dotfiles (`setup-windows.ps1` `DotfilesHiveUpgrade`, `tests/hive-upgrade-timer.bats`).
+
+### Neutral
+
+- The stdio fallback (ADR-011 §3) remains the safety net throughout — a Windows daemon outage still degrades to in-process stdio, never breaks a session.
+- The Linux/macOS mechanism is untouched; this ADR only adds the Windows branch.
+
+## References
+
+- Amends: [adr-011-phase-c-daemon-model.md](adr-011-phase-c-daemon-model.md) §4.
+- Issue: #176 (Phase C activation / rollout — Windows leg). Validation evidence captured 2026-06-04.
+- Code: `src/hive/_service.py` (`render_windows_task_xml`), `src/hive/_daemon.py` (`run_serve`, `EXIT_RESTART_ON_UPGRADE`, `_watch_for_upgrade`).
+- Rollout: `mlorentedev/dotfiles` `setup-windows.ps1` (daemon-supervision block), `tests/hive-upgrade-timer.bats`.
+- External (reference audit): Windows self-update rename-then-replace idiom; NSSM `AppExit=Restart` supervisor semantics; Task Scheduler `RestartOnFailure` schema.
+- Spike (to land in spec): S4U windowless + wrapper-loop restart validated 2026-06-04; upgrade-swap (A) pending.

--- a/specs/HIVE-176-windows-daemon-supervision/proposal.md
+++ b/specs/HIVE-176-windows-daemon-supervision/proposal.md
@@ -1,0 +1,35 @@
+# HIVE-176 — Windows daemon supervision & auto-upgrade
+
+> **Why (upstream):** [ADR-015](../../docs/adr/adr-015-windows-daemon-supervision-upgrade.md) — amends ADR-011 §4. The first real Windows rollout validation (#176) proved the daemon's restart-on-upgrade is broken on Windows in three ways (A upgrade-swap, B restart trigger, C console window). This spec implements the per-OS divergent Windows mechanism.
+
+## Problem (validated 2026-06-04 on real Windows hardware)
+
+- **A** — `uv tool upgrade` cannot replace the in-use `hive.exe` / loaded `.pyd` on Windows (`os error 32`). Structural: hive is always running under the daemon model.
+- **B** — Task Scheduler `<RestartOnFailure>` does not restart on the daemon's exit 75 (confirmed: 6 min later task `Ready`, no process). Not a 1:1 map of systemd `Restart=on-failure`.
+- **C** — the daemon shows a console window at every start/logon (interactive-token task action of a console app).
+
+## What
+
+A per-OS Windows mechanism (no admin), keeping ADR-011's shared daemon contract:
+
+- **B (restart)** — the task action becomes an inline supervisor loop (PowerShell) that relaunches `hive serve` while it exits non-zero, breaks on exit 0. Replaces the non-functional `<RestartOnFailure>` as the restart mechanism.
+- **C (windowless)** — register under an `S4U` `<Principal>` → session 0, no console window, non-elevated, no stored password.
+- **A (upgrade-swap)** — spike-gated (A3 versioned-dir + junction swap preferred; A4 rename-replace fallback). Decoupled from `uv tool upgrade`, which cannot replace in-use files.
+
+## Acceptance criteria
+
+- **AC-1 (C)** `render_windows_task_xml` emits an S4U `<Principal>` (`<LogonType>S4U</LogonType>`); daemon runs windowless. *(spike-validated)*
+- **AC-2 (B)** The task action is a supervisor loop that relaunches `hive serve` on non-zero exit and stops on exit 0. *(spike-validated)*
+- **AC-3 (A)** `uv tool upgrade` while the daemon runs no longer leaves a broken/half-upgraded install; the daemon restarts onto the new version. *(needs spike — blocks ADR-015 acceptance)*
+- **AC-4** Linux/macOS rendering + behaviour unchanged (no regression in `render_systemd_unit` / install dispatch).
+- **AC-5** `make check` green (ruff + mypy --strict + pytest) on the cross-OS CI matrix.
+
+## Decomposition (atomic PRs)
+
+- **PR1 (hive)** — AC-1 + AC-2: S4U principal + supervisor-loop in `render_windows_task_xml` + tests. *(this branch)*
+- **PR2 (hive)** — AC-3: A upgrade-swap (after spike) + upstream `uv` issue.
+- **PR3 (dotfiles)** — wire `setup-windows.ps1` + `tests/hive-upgrade-timer.bats` to the new mechanism.
+
+## Non-goals
+
+- Changing the Linux/macOS mechanism. Changing the MCP tool surface. Activating the daemon where ROI is unproven (the stdio fallback stays the safety net throughout).

--- a/specs/HIVE-176-windows-daemon-supervision/tasks.md
+++ b/specs/HIVE-176-windows-daemon-supervision/tasks.md
@@ -1,0 +1,27 @@
+# HIVE-176 — Tasks (TDD order)
+
+> Why: [ADR-015](../../docs/adr/adr-015-windows-daemon-supervision-upgrade.md). Proposal: [proposal.md](proposal.md).
+
+## PR1 — S4U principal + supervisor-loop (AC-1, AC-2) — this branch
+
+- [ ] **T1 (red)** Update `test_render_windows_task_xml_*`: assert the action is a PowerShell supervisor loop relaunching `hive serve` on non-zero exit (not a bare `<Arguments>serve</Arguments>`), and assert an `<LogonType>S4U</LogonType>` principal. Add a test that a clean exit 0 path is expressed (`if($LASTEXITCODE -eq 0){break}`).
+- [ ] **T2 (red)** Update `test_install_windows_registers_scheduled_task` to assert the new XML (S4U + supervisor loop).
+- [ ] **T3 (green)** `_service.render_windows_task_xml`: add S4U `<Principal>` (+ `<Actions Context="Author">`), change the action to the inline PowerShell supervisor loop. Add `user` param; `_install_windows` resolves the current Windows user.
+- [ ] **T4 (green)** Keep `<RestartOnFailure>` as a secondary net for engine-launch failure; keep LogonTrigger / IgnoreNew / `PT0S`.
+- [ ] **T5 (refactor)** Keep `render_windows_task_xml` < 40 lines; mypy --strict + ruff clean.
+- [ ] **T6 (verify)** `uv run pytest tests/test_service.py` green; `make check` green.
+
+## PR2 — A upgrade-swap (AC-3) — after spike
+
+- [ ] **S1 (spike)** Validate A3 (versioned-dir + junction swap) feasibility with `uv` on Windows; characterise which files lock (entrypoint `.exe`, loaded `.pyd`). Fall back A4 (rename-replace) then A2 (tolerate-in-place).
+- [ ] **S2** File upstream `uv` issue: replace-while-running on Windows.
+- [ ] **T7+** Implement the chosen mechanism + tests. Then flip ADR-015 → accepted.
+
+## PR3 — dotfiles wiring
+
+- [ ] **T8** `setup-windows.ps1` daemon-supervision block → new mechanism (S4U task install + new upgrade flow).
+- [ ] **T9** `tests/hive-upgrade-timer.bats` expectations updated.
+
+## Verification
+
+- [ ] `verification.md` filled with test output + spike evidence + the 2026-06-04 hardware-validation log lines.

--- a/src/hive/_service.py
+++ b/src/hive/_service.py
@@ -71,6 +71,16 @@ def _resolve_exec() -> str:
     return f"{sys.executable} -m hive.server"
 
 
+def _current_windows_user() -> str:
+    """The S4U principal account (``DOMAIN\\user`` or bare user), read from the
+    environment at install time — the daemon runs as the installing user. S4U
+    needs an explicit account; an empty result omits ``<UserId>`` and lets
+    schtasks default to the current user."""
+    domain = os.environ.get("USERDOMAIN", "")
+    user = os.environ.get("USERNAME", "")
+    return f"{domain}\\{user}" if domain and user else user
+
+
 # ── pure renderers (host-OS independent) ─────────────────────────────────
 
 
@@ -100,41 +110,77 @@ def render_systemd_unit(exec_start: str, *, vault: str) -> str:
     )
 
 
-def render_windows_task_xml(command: str, arguments: str = "serve") -> str:
-    """A Task Scheduler definition: a LogonTrigger auto-starts the daemon and
-    RestartOnFailure restarts it whenever the last run exits non-zero (exit 75
-    / crash) — the Windows mapping of ``Restart=on-failure``. A daemon runs
-    indefinitely, hence ``ExecutionTimeLimit=PT0S`` (no limit)."""
-    return (
-        '<?xml version="1.0" encoding="UTF-16"?>\n'
-        '<Task version="1.2" '
-        'xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n'
-        "  <RegistrationInfo>\n"
-        "    <Description>Hive vault daemon (single-owner MCP over loopback)"
-        "</Description>\n"
-        "  </RegistrationInfo>\n"
-        "  <Triggers>\n"
-        "    <LogonTrigger>\n"
-        "      <Enabled>true</Enabled>\n"
-        "    </LogonTrigger>\n"
-        "  </Triggers>\n"
-        "  <Settings>\n"
-        "    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n"
-        "    <StartWhenAvailable>true</StartWhenAvailable>\n"
-        "    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>\n"
-        "    <RestartOnFailure>\n"
-        "      <Interval>PT1M</Interval>\n"
-        "      <Count>3</Count>\n"
-        "    </RestartOnFailure>\n"
-        "    <Enabled>true</Enabled>\n"
-        "  </Settings>\n"
-        "  <Actions>\n"
-        "    <Exec>\n"
-        f"      <Command>{escape(command)}</Command>\n"
-        f"      <Arguments>{escape(arguments)}</Arguments>\n"
-        "    </Exec>\n"
-        "  </Actions>\n"
-        "</Task>\n"
+_WINDOWS_TASK_TEMPLATE = (
+    '<?xml version="1.0" encoding="UTF-16"?>\n'
+    '<Task version="1.2" '
+    'xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n'
+    "  <RegistrationInfo>\n"
+    "    <Description>Hive vault daemon (single-owner MCP over loopback)"
+    "</Description>\n"
+    "  </RegistrationInfo>\n"
+    "  <Triggers>\n"
+    "    <LogonTrigger>\n"
+    "      <Enabled>true</Enabled>\n"
+    "    </LogonTrigger>\n"
+    "  </Triggers>\n"
+    "  <Principals>\n"
+    '    <Principal id="Author">\n'
+    "{principal_user}"
+    "      <LogonType>S4U</LogonType>\n"
+    "      <RunLevel>LeastPrivilege</RunLevel>\n"
+    "    </Principal>\n"
+    "  </Principals>\n"
+    "  <Settings>\n"
+    "    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n"
+    "    <StartWhenAvailable>true</StartWhenAvailable>\n"
+    "    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>\n"
+    "    <RestartOnFailure>\n"
+    "      <Interval>PT1M</Interval>\n"
+    "      <Count>3</Count>\n"
+    "    </RestartOnFailure>\n"
+    "    <Enabled>true</Enabled>\n"
+    "  </Settings>\n"
+    '  <Actions Context="Author">\n'
+    "    <Exec>\n"
+    "      <Command>powershell.exe</Command>\n"
+    "      <Arguments>{arguments}</Arguments>\n"
+    "    </Exec>\n"
+    "  </Actions>\n"
+    "</Task>\n"
+)
+
+
+def render_windows_task_xml(
+    command: str,
+    arguments: str = "serve",
+    *,
+    user: str = "",
+) -> str:
+    """A Task Scheduler definition for the Phase C daemon on Windows (ADR-015).
+
+    Two Windows mechanisms replace ADR-011's POSIX assumptions, both validated
+    on real hardware (2026-06-04):
+
+    * **Supervisor loop (restart).** ``<RestartOnFailure>`` does NOT restart on
+      an application's non-zero exit — it reacts to the engine failing to launch
+      — so it cannot map ``systemd Restart=on-failure``. The action is instead an
+      inline PowerShell loop that relaunches ``<command> serve`` while it exits
+      non-zero and stops on a clean exit 0 (drift → 75 → relaunch onto new code;
+      clean stop / singleton-decline → 0 → no relaunch). ``<RestartOnFailure>``
+      is kept only as a secondary net for an engine-launch failure.
+    * **S4U principal (windowless).** ``<LogonType>S4U</LogonType>`` runs the task
+      in session 0 — no console window — at logon, no stored password, no admin
+      (the per-user analogue of ``systemd --user``).
+    """
+    loop = (
+        f"while($true){{ & '{command}' {arguments}; "
+        f"if($LASTEXITCODE -eq 0){{break}} Start-Sleep -Seconds 1 }}"
+    )
+    ps_arguments = f'-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -Command "{loop}"'
+    principal_user = f"      <UserId>{escape(user)}</UserId>\n" if user else ""
+    return _WINDOWS_TASK_TEMPLATE.format(
+        principal_user=principal_user,
+        arguments=escape(ps_arguments),
     )
 
 
@@ -215,7 +261,7 @@ def _install_systemd(*, enable: bool) -> int:
 
 
 def _install_windows(*, enable: bool) -> int:
-    xml = render_windows_task_xml(_resolve_exec())
+    xml = render_windows_task_xml(_resolve_exec(), user=_current_windows_user())
     if not enable:
         path = _config_root() / "hive" / f"{WINDOWS_TASK_NAME}.xml"
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -38,20 +38,30 @@ def test_render_systemd_unit_encodes_the_exit75_restart_contract() -> None:
     assert "EnvironmentFile=-" in unit
 
 
-def test_render_windows_task_xml_has_logon_trigger_and_restart_on_failure() -> None:
-    """The Windows Scheduled Task is the per-user analogue of `systemd --user`:
-    a LogonTrigger auto-starts it at login and RestartOnFailure restarts it when
-    the last run exits non-zero (exit 75 / crash) — the same contract as
-    `Restart=on-failure`, with a non-zero exit mapping to a failed run."""
+def test_render_windows_task_xml_uses_s4u_principal_and_supervisor_loop() -> None:
+    """ADR-015: Task Scheduler's `<RestartOnFailure>` does NOT restart on an
+    application's exit 75 (it reacts to the engine failing to launch), so it
+    cannot map `systemd Restart=on-failure`. The action is instead an inline
+    PowerShell supervisor loop that relaunches `hive serve` on a non-zero exit
+    and stops on a clean exit 0. An S4U principal runs it in session 0 — no
+    console window — non-elevated. Both validated on real Windows hardware
+    (2026-06-04)."""
     from hive._service import render_windows_task_xml
 
-    xml = render_windows_task_xml(r"C:\Users\u\hive.exe")
+    xml = render_windows_task_xml(r"C:\Users\u\hive.exe", user="WINBOX\\u")
 
+    # Windowless, non-elevated: a session-0 S4U principal.
+    assert "<LogonType>S4U</LogonType>" in xml
+    assert "<UserId>WINBOX\\u</UserId>" in xml
+    assert '<Actions Context="Author">' in xml
+    # Restart mechanism = supervisor loop (the `<RestartOnFailure>` is kept only
+    # as a secondary net for an engine-launch failure).
+    assert "<Command>powershell.exe</Command>" in xml
+    assert "while($true)" in xml
+    assert r"'C:\Users\u\hive.exe' serve" in xml
+    assert "if($LASTEXITCODE -eq 0){break}" in xml  # clean exit 0 → stop, no relaunch
+    # LogonTrigger auto-starts at login; a daemon runs indefinitely.
     assert "<LogonTrigger>" in xml
-    assert "<RestartOnFailure>" in xml
-    assert "<Command>C:\\Users\\u\\hive.exe</Command>" in xml
-    assert "<Arguments>serve</Arguments>" in xml
-    # A daemon runs indefinitely: no execution time limit.
     assert "<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>" in xml
 
 
@@ -119,7 +129,8 @@ def test_install_windows_registers_scheduled_task(
 
     assert rc == 0
     assert "<LogonTrigger>" in str(recorded["xml"])
-    assert "<RestartOnFailure>" in str(recorded["xml"])
+    assert "<LogonType>S4U</LogonType>" in str(recorded["xml"])
+    assert "while($true)" in str(recorded["xml"])
 
 
 def test_install_macos_is_a_clear_stub(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Why

ADR-015 (included in this PR). The first real Windows rollout validation (#176) found the Phase C daemon's restart-on-upgrade broken on Windows three ways:

- **B** — Task Scheduler `<RestartOnFailure>` does not restart on the daemon's exit 75 (it reacts to the task engine failing to launch, not an application exit code) — it is not a 1:1 map of systemd `Restart=on-failure`.
- **C** — the daemon task shows a console window at every start/logon.
- **A** — `uv tool upgrade` cannot replace a running executable on Windows (`os error 32`) — addressed in a follow-up.

## What (this PR — B + C, both validated on real Windows hardware)

`render_windows_task_xml` now:

- emits an **S4U `<Principal>`** → the task runs in session 0 with **no console window**, non-elevated, no stored password (the per-user analogue of `systemd --user`);
- replaces the bare `hive serve` action with an inline **PowerShell supervisor loop** that relaunches `hive serve` while it exits non-zero and stops on a clean exit 0 — the `systemd Restart=on-failure` semantics `<RestartOnFailure>` does not provide (kept only as a secondary net for an engine-launch failure).

## Validation (2026-06-04, real Windows box)

- The S4U task registers non-elevated and serves `/health` with **no console window** (operator-confirmed).
- Killing the inner `hive serve` (exit ≠ 0) → the wrapper relaunches it; `Stop-ScheduledTask` stops the tree cleanly (no relaunch).
- End-to-end: the actual `render_windows_task_xml` output registers via `schtasks`, serves, and restarts.
- `tests/test_service.py` 9/9 green; `ruff` + `mypy --strict` (module) clean.

## Not in this PR

- **A (upgrade-swap)** — the Windows-safe upgrade flow + the dotfiles rollout wiring land in follow-ups (spec `HIVE-176`). ADR-015 stays `proposed` until A is validated.

Refs #176.
