### PR TITLE
feat(search): accept vault_search `limit` as alias of max_results (#202 Bug 3)

### DIFF
--- a/specs/HIVE-202-mcp-contract-gaps/features.json
+++ b/specs/HIVE-202-mcp-contract-gaps/features.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "HIVE-202-mcp-contract-gaps-f1",
+    "behavior": "vault_search(query=Q, limit=5) raises no validation error (no unexpected_keyword_argument)",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k limit_no_validation_error -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-202-mcp-contract-gaps-f2",
+    "behavior": "flat mode: vault_search(query=Q, limit=N) caps result-file blocks to N when more than N match",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k limit_caps_flat -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-202-mcp-contract-gaps-f3",
+    "behavior": "ranked mode: vault_search(ranked=True, limit=N) is byte-identical to max_results=N",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k limit_aliases_max_results_ranked -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-202-mcp-contract-gaps-f4",
+    "behavior": "recent mode: vault_search(since_days=D, limit=N) caps to N files when more than N changed",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k limit_caps_recent -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-202-mcp-contract-gaps-f5",
+    "behavior": "when both limit and max_results are supplied, the agreed precedence rule holds deterministically",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k limit_max_results_precedence -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-202-mcp-contract-gaps-f6",
+    "behavior": "no registered tool's JSON Schema contains anyOf (the load-bearing | None ban holds)",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k anyof -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-202-mcp-contract-gaps-f7",
+    "behavior": "vault_search docstring names canonical max_results/max_lines and calls out limit as the accepted alias",
+    "verification": "uv run pytest tests/test_tool_param_aliases.py -k wrong_names -q",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/HIVE-202-mcp-contract-gaps/proposal.md
+++ b/specs/HIVE-202-mcp-contract-gaps/proposal.md
@@ -1,0 +1,71 @@
+---
+id: "HIVE-202-mcp-contract-gaps"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-05"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HIVE-202: MCP contract gaps
+
+> **Naming**: file lives at `<repo>/specs/HIVE-202-mcp-contract-gaps/proposal.md`.
+
+## Why
+
+<!-- from 11-tasks.md: HIVE-202 — MCP contract gaps from the Hermes beta test (#202, tested v1.32.3). Four findings, decomposed into atomic PRs; PR1 = Bug 3 (limit). Continues HIVE-119 alias doctrine but adds a real behaviour change. -->
+
+A Hermes-agent beta test against Hive v1.32.3 (issue [#202](https://github.com/mlorentedev/hive/issues/202)) surfaced four MCP-contract gaps where the documented or intuitively-expected tool surface disagrees with the implementation. Each makes a client (Claude or Hermes) call a tool, get an `unexpected_keyword_argument` / "Section is required" rejection, retry, and from the operator's seat Hive *looks* flaky even though the per-call path is healthy — the same DX failure mode that motivated [[HIVE-119]]. This spec frames all four; **PR1 fixes only Bug 3 (`vault_search` `limit`)**, the cleanest and most reproducible gap. Bugs 2/1/4 follow as separate atomic PRs (one logical change each, per the repo's ~300-LOC PR limit).
+
+## What
+
+After **PR1**, `vault_search(query=Q, limit=N)` stops raising `unexpected_keyword_argument` and instead bounds the number of result **files** to `N` — in **all three search modes** (flat, ranked, recent), not just ranked. Concretely:
+
+- `limit` is accepted as an **int alias of `max_results`** (canonical), normalized before the tool body runs — exactly the [[HIVE-119]] alias pattern (`limit = …` resolution at the top of the handler).
+- `max_results` (today only honored in **ranked** mode) is **extended** to cap the result-file count in **flat** and **recent (`since_days`)** modes too. This is a deliberate behaviour change, not a pure alias — see Risks.
+- The JSON Schema stays `anyOf`-free: `limit` is `int = 0` (empty-value default), never `int | None`, per the load-bearing MCP schema rule and [[pattern-mcp-tool-design]].
+
+The remaining three findings are scoped here for context but **out of PR1**:
+
+| Bug | Finding (v1.32.3) | Reality on current `master` | Later PR |
+|---|---|---|---|
+| 2 | `vault_write(project, path, content)` for a new file → "Section is required" | `create` mode **already exists** (needs `operation="create"` + `path` + `doc_type`); the intuitive call falls through to `append`. Ergonomics/discoverability, not a missing feature. | PR2 |
+| 1 | `HIVE_VAULT_PATH` not configurable | Honored via pydantic-settings (+ `VAULT_PATH` alias) but **env-only / undiscoverable**; "Vault not found" gives no hint. | PR3 (docs + error UX) |
+| 4 | No way to delete files | No `vault_delete` / `operation="delete"` anywhere. Destructive → needs guardrails. | PR4 (own spec slice) |
+
+## Out of scope
+
+- **Bugs 2, 1, 4** — separate atomic PRs; not in PR1's diff.
+- **No new `anyOf`.** `limit` is simple-typed with an empty-value default (`int = 0`), never `| None`.
+- **No change to flat/ranked output *shape*** beyond the file-count cap (same headers, same per-file line budget, same `max_lines` truncation as a second, independent guard).
+- **No re-ranking of flat/recent modes.** `limit` caps the existing (alphabetical) ordering; it does NOT turn flat search into relevance-ranked search (that is what `ranked=True` is for).
+- **No removal or renaming of `max_results` or `max_lines`.** Both stay; `limit` is additive.
+
+## Risks / open questions
+
+> Both items below were resolved with the maintainer on 2026-06-05; `tasks.md` is cleared to freeze.
+
+- **[RESOLVED 2026-06-05] Flat/recent capping semantics → alphabetical-first-N.** Flat and recent modes keep their current **alphabetical path order** (`sorted(rglob("*.md"))` / `sorted(git_paths)`); `limit` just slices the first N matching files — no re-ordering. The docstring states the caveat and points callers to `ranked=True` for relevance ordering. (Rejected: sorting flat by match-count, which would change flat's stable path ordering — a larger behaviour change.)
+- **[RESOLVED 2026-06-05] Precedence when BOTH `limit` and `max_results` are supplied → tightest cap.** Both are `max` caps, so the smaller wins: `max_results = min(limit, max_results) if limit else max_results` (a `limit` of `0` means "unset"). Predictable, and never returns *more* than the tighter cap requested. (Rejected: alias-first OR `limit or max_results`, which could return more than an explicit smaller `max_results`; and canonical-wins-when-non-default, which hardcodes the `10` default and cannot detect an explicit `10`.)
+- **Regression surface (LOW).** `limit` is additive with an empty default, so existing callers are unaffected. The *behaviour change* is that flat/recent now cap at `max_results` (default 10) — callers who relied on flat search returning *every* matching file would see at most 10 unless they raise `max_results`/`limit`. Mitigation: default stays 10 (already the ranked default); documented in the docstring + CHANGELOG; covered by a test asserting the pre-change unbounded behaviour is now bounded.
+- **`max_lines` vs file cap interaction.** `max_lines` (output-line truncation) remains an independent second guard applied after the file cap. A test pins that both guards compose (file cap first, line truncation second).
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable. (All MUST-RESOLVE questions resolved 2026-06-05.)
+
+- [x] AC1 — `vault_search(query=Q, limit=5)` raises **no** validation error (no `unexpected_keyword_argument`).
+- [x] AC2 — flat mode: `vault_search(query=Q, limit=N)` returns at most `N` result-file blocks (alphabetical-first-N) when more than `N` files match.
+- [x] AC3 — ranked mode: `vault_search(query=Q, ranked=True, limit=N)` is byte-identical to `vault_search(query=Q, ranked=True, max_results=N)`.
+- [x] AC4 — recent mode: `vault_search(query=Q, since_days=D, limit=N)` returns at most `N` files when more than `N` changed.
+- [x] AC5 — tightest cap wins when both supplied: `vault_search(ranked=True, limit=5, max_results=3)` → ≤3 files; `limit=5, max_results=20` → ≤5.
+- [x] AC6 — no registered tool's JSON Schema contains `anyOf` (schema-introspection test; the load-bearing `| None` ban holds).
+- [x] AC7 — `vault_search`'s docstring leads with the canonical `max_results`/`max_lines` and explicitly calls out `limit` as the accepted alias.
+
+## References
+
+- Vault: `10_projects/hive/11-tasks.md` (backlog entry **HIVE-202**)
+- GitHub issue: [#202](https://github.com/mlorentedev/hive/issues/202) (beta-test findings + maintainer triage comment)
+- Predecessor spec: `specs/HIVE-119-tool-param-aliases/` (the alias doctrine this PR continues)
+- Related patterns: `00_meta/patterns/pattern-mcp-tool-design.md` (the `| None` ban / schema-clean rule)
+- Related: `.claude/CLAUDE.md` "MCP tool schema rules (load-bearing)"

--- a/specs/HIVE-202-mcp-contract-gaps/tasks.md
+++ b/specs/HIVE-202-mcp-contract-gaps/tasks.md
@@ -1,0 +1,51 @@
+---
+tags: [spec, tasks]
+created: "2026-06-05"
+---
+
+# Tasks - HIVE-202-mcp-contract-gaps (PR1: vault_search `limit`)
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+> Scope of THIS tasks.md = **PR1 (Bug 3, `limit`)** only. Bugs 2/1/4 get their own tasks slices.
+
+## Setup
+
+- [x] Branch created from remote base: `feat/HIVE-202-vault-search-limit` off `origin/master`
+- [x] `proposal.md` complete and acceptance criteria testable
+- [x] **Both "MUST-RESOLVE" open questions answered** (flat/recent → alphabetical-first-N; precedence → tightest cap `min`) — 2026-06-05
+
+## Implementation
+
+> Inline normalization at the top of the `vault_search` body (`max_results = … limit …`, per the agreed precedence rule). Extend the existing `max_results` cap from ranked-only to flat + recent. `limit` is simple-typed (`int = 0`) so the JSON Schema stays `anyOf`-free. New tests join `tests/test_tool_param_aliases.py`.
+
+- [x] Write failing test: `vault_search(query=Q, limit=5)` raises no validation error (AC1)
+- [x] Write failing test: ranked mode — `limit=N` == `max_results=N`, byte-identical (AC3)
+- [x] Write failing test: flat mode — `limit=N` caps result-file blocks to N when >N match (AC2)
+- [x] Write failing test: recent mode — `since_days=D, limit=N` caps to N files (AC4)
+- [x] Write failing test: precedence — both `limit` and `max_results` supplied → tightest cap (AC5)
+- [x] Write failing test: `max_lines` still composes as an independent second guard
+- [x] Implement `limit` alias + tightest-cap resolution at top of `vault_search` (`src/hive/_vault_read.py`)
+- [x] Implement `max_results` cap in flat mode (file counter + early break, alphabetical-first-N)
+- [x] Implement `max_results` cap in recent mode (`git_paths` slice after sort)
+- [x] Reuse HIVE-119 schema guard — no registered tool `inputSchema` contains `anyOf` (AC6)
+- [x] Extend `WRONG_NAMES["vault_search"]` with `limit` (AC7)
+- [x] Update `vault_search` docstring (lead with `max_results`, call out `limit`) to make it pass
+- [x] Fix `TestVaultSearchRecent::test_output_truncated` to opt out of the new file cap (`max_results=200`)
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` covered by ≥1 test
+- [ ] Every acceptance criterion has a matching `features.json` entry with a non-vacuous verification command
+- [ ] Type checks pass (`mypy --strict src/`)
+- [ ] Lint passes (`ruff check src/ tests/`)
+- [ ] Full suite green (`make test`)
+- [ ] CHANGELOG-worthy note: flat/recent now cap at `max_results` (behaviour change) — captured in the PR body
+- [ ] No unrelated changes in the diff (no scope creep — Bugs 2/1/4 excluded)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder, addressing the Bug 3 portion of #202
+
+## Machine-readable features
+
+Sibling `features.json` follows [[pattern-feature-list-as-primitive]]. Each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state`, `evidence`.
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state.

--- a/specs/HIVE-202-mcp-contract-gaps/verification.md
+++ b/specs/HIVE-202-mcp-contract-gaps/verification.md
@@ -1,0 +1,46 @@
+---
+tags: [spec, verification]
+created: "2026-06-05"
+---
+
+# Verification - HIVE-202-mcp-contract-gaps (PR1: vault_search `limit`)
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior). All tests in `tests/test_tool_param_aliases.py::TestVaultSearchLimit` unless noted.
+
+- [x] AC1 (no validation error) -> `test_limit_no_validation_error`
+- [x] AC2 (flat cap, alphabetical-first-N) -> `test_limit_caps_flat`
+- [x] AC3 (ranked alias-equivalence, byte-identical) -> `test_limit_aliases_max_results_ranked`
+- [x] AC4 (recent cap) -> `test_limit_caps_recent`
+- [x] AC5 (tightest-cap precedence) -> `test_limit_max_results_precedence_tightest_cap`
+- [x] AC6 (no anyOf; limit is `int = 0`) -> `TestSchemaClean::test_no_tool_schema_contains_anyof`
+- [x] AC7 (docstring call-out) -> `TestDocstringsCallOutWrongNames::test_descriptions_mention_common_wrong_names` (`WRONG_NAMES["vault_search"]` extended with `limit`)
+- [x] Bonus: `max_lines` composes independently with the file cap -> `test_limit_and_max_lines_compose`
+
+## Test status
+
+- Targeted suite: `uv run pytest tests/test_tool_param_aliases.py tests/test_server.py::TestVaultSearchRecent tests/test_server.py::TestVaultSearch -q` -> **37 passed**.
+- ruff: clean. mypy --strict on `src/hive/_vault_read.py`: clean (the 5 strict errors in `src/hive/_deadline.py` are pre-existing POSIX-only-on-Windows artifacts, unrelated; CI Linux+Windows is green).
+- Full suite (`uv run pytest -q`): **680 passed, 19 skipped, 5 failed** (10m36s). 1 failure was `TestVaultSearchRecent::test_output_truncated` — a direct consequence of the intended recent-mode cap; fixed by having that test pass `max_results=200` to opt out of the file cap and still exercise `max_lines` truncation.
+- No regressions introduced: the other **4 failures are pre-existing** (`test_bounded_call`, `test_daemon`, `test_lock_eviction`, `TestVaultHealthRuntime`) — **proven** by stashing this branch's changes and re-running them on the clean base, where they fail identically (none touch `vault_search`). Consistent with the documented pre-existing Windows-env failures.
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections.
+
+- Flat/recent capping semantics: **alphabetical-first-N** — keep flat/recent's stable path ordering, `limit` only slices; `ranked=True` is the relevance path. (decided 2026-06-05)
+- `limit`/`max_results` precedence rule chosen: **tightest cap** — `min(limit, max_results) if limit else max_results`; `limit=0` means unset. (decided 2026-06-05)
+
+## Promotion candidates
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no — one line>
+- [ ] ADR-worthy decision for `docs/adr/`? <likely no — additive contract change, no architectural shift>
+- [ ] New pattern candidate for `00_meta/patterns/`? <no — the alias pattern is already [[pattern-mcp-tool-design]]>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HIVE-202-mcp-contract-gaps/` -> `specs/archive/HIVE-202-mcp-contract-gaps/` (only after ALL four PRs land, or split per-PR if archived incrementally)
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)

--- a/src/hive/_vault_read.py
+++ b/src/hive/_vault_read.py
@@ -329,6 +329,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
         scope: str = "",
         rank_by: str = "bm25",
         regex: bool = False,
+        limit: int = 0,
     ) -> str:
         """Search the vault: full-text, ranked, or recent changes.
 
@@ -346,7 +347,9 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             use_regex: Treat query as regex. Default False. (Use `use_regex`,
                 not `regex` — `regex` is accepted as an alias.)
             ranked: Score results by relevance. Default False.
-            max_results: Max files when ranked. Default 10.
+            max_results: Max result files. Default 10. Caps the file count in
+                all modes (flat, ranked, recent); in flat/recent the cap is by
+                path order (alphabetical) — use ranked=True for relevance order.
             since_days: Show recent changes (0 = disabled). Default 0.
             project: Filter to this project (recent mode only).
             scope: Restrict search to a scope (e.g. 'work', 'projects'). Empty = all.
@@ -356,8 +359,15 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
             regex: Alias of `use_regex` (#151). Prefer `use_regex`. To narrow
                 by location use `scope` / `project`, not `path_filter` /
                 `path_prefix`.
+            limit: Alias of `max_results` (#202). Prefer `max_results`. When
+                both are given the tighter (smaller) cap wins; 0 = unset.
         """
         use_regex = use_regex or regex  # #151: accept `regex` as alias of `use_regex`
+        # #202: `limit` is an int alias of `max_results`; tightest cap wins when
+        # both are set (a 0 on either side means "unset"). After this line
+        # `max_results` is the single effective file cap for all three modes.
+        if limit:
+            max_results = min(limit, max_results) if max_results else limit
         guard = _vault_guard(ctx)
         if guard:
             return track(ctx, "vault_search", guard)
@@ -444,7 +454,10 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
                 f"# Recent Changes (last {since_days} days)",
                 "",
             ]
-            for rel_path in sorted(git_paths):
+            ordered_paths = sorted(git_paths)
+            if max_results > 0:  # #202: limit/max_results caps recent mode too
+                ordered_paths = ordered_paths[:max_results]
+            for rel_path in ordered_paths:
                 full = ctx.vault / rel_path
                 if not full.exists():
                     rlines.append(f"- {rel_path} (deleted)")
@@ -565,10 +578,15 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
                 )
 
         flat_results: list[str] = []
+        files_added = 0
         query_lower = query.lower()
         has_filters = bool(type_filter or status_filter or tag_filter)
 
         for md_file in sorted(search_root.rglob("*.md")):
+            # #202: cap result files (alphabetical-first-N) in flat mode too,
+            # mirroring ranked. max_results <= 0 means "no file cap".
+            if max_results > 0 and files_added >= max_results:
+                break
             content = _safe_read(md_file)
             if content is None:
                 continue
@@ -601,6 +619,7 @@ def register_vault_read(mcp: FastMCP, ctx: ServerContext) -> None:
                 flat_results.append(f"### {file_rel}{meta}")
                 for line in matching_lines[:5]:
                     flat_results.append(f"  - {line}")
+                files_added += 1
 
         if not flat_results:
             return track(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1986,9 +1986,11 @@ class TestVaultSearchRecent:
             check=True,
         )
         mcp = create_server(vault_path=git_vault)
+        # max_results=200 opts out of the #202 default file cap (10) so this
+        # still exercises the independent max_lines line-truncation guard.
         result = await mcp.call_tool(
             "vault_search",
-            {"since_days": 1, "max_lines": 100},
+            {"since_days": 1, "max_lines": 100, "max_results": 200},
         )
         assert "truncated" in _text(result).lower()
 

--- a/tests/test_tool_param_aliases.py
+++ b/tests/test_tool_param_aliases.py
@@ -145,7 +145,7 @@ class TestDocstringsCallOutWrongNames:
     WRONG_NAMES = {
         "vault_list": ["subpath"],
         "vault_query": ["identifier"],
-        "vault_search": ["regex"],
+        "vault_search": ["regex", "limit"],
         "vault_patch": ["old_string", "new_string"],
         "vault_commit": ["project"],
         "session_briefing": ["days"],
@@ -165,3 +165,111 @@ class TestDocstringsCallOutWrongNames:
                 if token not in doc:
                     missing.append(f"{tool}:{token}")
         assert missing == [], f"docstrings missing wrong-name call-outs: {missing}"
+
+
+# ── HIVE-202: vault_search `limit` alias of max_results (#202) ────────────
+#
+# Bug 3 of the Hermes beta test: `vault_search(limit=N)` raised
+# `unexpected_keyword_argument`. `limit` becomes an int alias of the canonical
+# `max_results`, AND `max_results` is extended from ranked-only to also cap the
+# result-file count in flat + recent modes. Precedence when both are supplied:
+# tightest cap wins — `min(limit, max_results) if limit else max_results`
+# (a `limit` of 0 means "unset"). Flat/recent keep their alphabetical path
+# order; `limit` only slices (relevance ordering stays `ranked=True`'s job).
+# Spec: specs/HIVE-202-mcp-contract-gaps/proposal.md.
+
+
+def _count_blocks(text: str) -> int:
+    """Count result-file blocks (``### header`` lines) in a search response."""
+    return sum(1 for ln in text.splitlines() if ln.startswith("### "))
+
+
+def _count_recent(text: str) -> int:
+    """Count file rows (``- path`` lines) in a recent-mode response."""
+    return sum(1 for ln in text.splitlines() if ln.startswith("- "))
+
+
+class TestVaultSearchLimit:
+    async def test_limit_no_validation_error(self, mock_vault: Path) -> None:
+        # 'limit' must be accepted, not rejected at the FastMCP boundary (AC1).
+        mcp = create_server(vault_path=mock_vault)
+        out = _text(await mcp.call_tool("vault_search", {"query": "test", "limit": 5}))
+        assert "unexpected_keyword_argument" not in out.lower()
+        assert "Search:" in out or "Ranked" in out  # a real result, not an error
+
+    async def test_limit_caps_flat(self, mock_vault: Path) -> None:
+        # 'test' matches ≥3 files in the fixture; limit must bound flat results (AC2).
+        mcp = create_server(vault_path=mock_vault)
+        uncapped = _text(await mcp.call_tool("vault_search", {"query": "test"}))
+        capped = _text(await mcp.call_tool("vault_search", {"query": "test", "limit": 2}))
+        assert _count_blocks(uncapped) > 2
+        assert _count_blocks(capped) == 2
+
+    async def test_limit_aliases_max_results_ranked(self, mock_vault: Path) -> None:
+        # In ranked mode, limit=N is byte-identical to max_results=N (AC3).
+        mcp = create_server(vault_path=mock_vault)
+        canonical = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {"query": "test", "ranked": True, "max_results": 3},
+            )
+        )
+        alias = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {"query": "test", "ranked": True, "limit": 3},
+            )
+        )
+        assert alias == canonical
+
+    async def test_limit_caps_recent(self, git_vault: Path) -> None:
+        # Recent mode lists every changed file; limit must bound it (AC4).
+        mcp = create_server(vault_path=git_vault)
+        uncapped = _text(await mcp.call_tool("vault_search", {"since_days": 3650}))
+        capped = _text(await mcp.call_tool("vault_search", {"since_days": 3650, "limit": 2}))
+        assert _count_recent(uncapped) > 2
+        assert _count_recent(capped) == 2
+
+    async def test_limit_max_results_precedence_tightest_cap(self, mock_vault: Path) -> None:
+        # Both supplied -> the smaller cap wins (AC5).
+        mcp = create_server(vault_path=mock_vault)
+        limit_tighter = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {"query": "test", "ranked": True, "limit": 2, "max_results": 4},
+            )
+        )
+        max_tighter = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {"query": "test", "ranked": True, "limit": 4, "max_results": 2},
+            )
+        )
+        both_loose = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {"query": "test", "ranked": True, "max_results": 10},
+            )
+        )
+        assert _count_blocks(limit_tighter) == 2  # limit < max_results -> limit wins
+        assert _count_blocks(max_tighter) == 2  # max_results < limit -> max_results wins
+        assert _count_blocks(both_loose) > 2  # control: caps above genuinely bit
+
+    async def test_limit_and_max_lines_compose(self, mock_vault: Path) -> None:
+        # limit caps FILES; max_lines caps LINES — independent, composable guards.
+        mcp = create_server(vault_path=mock_vault)
+        full = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {"query": "test", "limit": 3, "max_lines": 0},
+            )
+        )
+        assert _count_blocks(full) == 3
+        truncated = _text(
+            await mcp.call_tool(
+                "vault_search",
+                {"query": "test", "limit": 3, "max_lines": 4},
+            )
+        )
+        assert "truncated" in truncated
+        assert len(truncated.splitlines()) < len(full.splitlines())


### PR DESCRIPTION
## What

Bug 3 of the [#202](https://github.com/mlorentedev/hive/issues/202) Hermes beta test: `vault_search(query=Q, limit=N)` raised `unexpected_keyword_argument`. This PR makes `limit` an **int alias of the canonical `max_results`** and extends `max_results` to cap the result-file count in **all three search modes**.

- `limit` is `int = 0` (empty-value default) → the JSON Schema stays `anyOf`-free, per the load-bearing MCP schema rule. Continues the [HIVE-119](specs/HIVE-119-tool-param-aliases/) alias doctrine.
- **Precedence when both supplied → tightest cap wins:** `max_results = min(limit, max_results) if limit else max_results` (a `0` on either side means "unset").
- `max_results` previously bounded **ranked mode only**; it now also caps **flat** and **recent (`since_days`)** modes.

## Behaviour change (intentional)

Flat and recent modes now return **at most `max_results` (default 10)** result files, sliced in their existing **alphabetical path order** (relevance ordering stays `ranked=True`'s job). Callers who relied on flat/recent returning *every* match must raise `max_results`/`limit`. One existing recent-mode test (`TestVaultSearchRecent::test_output_truncated`) now passes `max_results=200` to opt out of the cap and keep exercising the independent `max_lines` line-truncation guard.

## Tests

`tests/test_tool_param_aliases.py::TestVaultSearchLimit` (TDD red→green): no-validation-error, flat cap, ranked alias-equivalence, recent cap, tightest-cap precedence, and `max_lines` composition. Plus the existing `anyOf`-free schema guard and the `WRONG_NAMES` docstring guard (extended with `limit`).

- Targeted: `uv run pytest tests/test_tool_param_aliases.py tests/test_server.py::TestVaultSearchRecent tests/test_server.py::TestVaultSearch -q` → **37 passed**.
- `ruff` clean; `mypy --strict src/hive/_vault_read.py` clean.
- Full suite: 680 passed / 19 skipped / 5 failed. 4 of the 5 are **pre-existing** Windows-env failures (`test_bounded_call`, `test_daemon`, `test_lock_eviction`, `TestVaultHealthRuntime`) — confirmed by stashing this branch and re-running them on the clean base, where they fail identically; none touch `vault_search`. CI (Linux + Windows) is green on master for these.

## Scope

PR1 of a 4-part decomposition of #202. Spec: `specs/HIVE-202-mcp-contract-gaps/`. Bugs 2 (create-mode ergonomics), 1 (vault-path discoverability), and 4 (`vault_delete`) follow as separate atomic PRs. Addresses the Bug 3 portion of #202.