### PR TITLE
refactor(compat): drop redundant RequestResponder.__exit__ patch

### DIFF
--- a/src/hive/_compat.py
+++ b/src/hive/_compat.py
@@ -1,29 +1,38 @@
-"""Compatibility shims for upstream MCP library bugs.
+"""Compatibility shim for an upstream MCP library cancellation race.
 
-This module monkey-patches two methods on
-``mcp.shared.session.RequestResponder`` to keep the stdio receive loop
-alive across two related cancellation races:
+This module monkey-patches ``mcp.shared.session.RequestResponder.respond``
+to keep the stdio receive loop alive when a response is produced *after*
+the request has already been cancelled.
 
-1. **``__exit__``** — swallow the spurious ``CancelledError`` that the
-   anyio cancel scope re-raises after we have already responded to a
-   cancelled request (hive issue #75).
-2. **``respond``** — when a handler finishes *after* the client has
-   already sent ``notifications/cancelled`` (so ``_completed`` is True),
-   the original assertion ``assert not self._completed`` fires inside
-   ``_handle_request``, propagates to the receive loop's
-   ``anyio.create_task_group()``, and kills the server with
-   ``AssertionError('Request already responded to')``. Subsequent calls
-   from any session sharing the process get ``Connection closed``. The
-   patched version short-circuits silently with a debug log.
+When a handler finishes (or a late worker thread responds) *after* the
+client has already sent ``notifications/cancelled`` — so ``_completed``
+is True — the upstream assertion ``assert not self._completed`` fires in
+``RequestResponder.respond``, propagates to the receive loop's
+``anyio.create_task_group()``, and kills the server with
+``AssertionError('Request already responded to')``. Subsequent calls
+from any session sharing the process get ``Connection closed``. The
+patched ``respond`` short-circuits silently in exactly that state and
+records the event on :data:`GHOST_RESPONSES` (see below). Tracked
+upstream at modelcontextprotocol/python-sdk#2416 (open on ``mcp`` 1.27.x).
 
-Without either patch, a slow tool call that the client cancels mid-flight
-poisons the transport — the process either stops reading stdin or exits
-with the assertion. Recovery requires restarting Claude Code.
+hive is unusually exposed to this race: a tool that offloads sync work
+to a worker thread can call ``respond()`` *late*, after a cancel.
 
-Both patches are self-gated to the exact failure mode (responder already
-``_completed``) so if upstream fixes the bug the patch becomes inert.
+The patch is self-gated to the exact failure mode (responder already
+``_completed``) so it becomes inert if upstream guards ``respond()``.
 If ``RequestResponder`` is renamed/removed in a future ``mcp`` release,
 ``apply()`` logs a warning and returns without touching anything.
+
+History: a companion ``__exit__`` patch (hive issue #75; upstream
+modelcontextprotocol/python-sdk#2610, fix proposed in the still-open
+PR #2624) was removed once we confirmed the issue-#75 symptom no longer
+reproduces on the pinned ``mcp`` (>=1.27): ``Server._handle_request``
+catches the in-flight handler cancellation (``except
+anyio.get_cancelled_exc_class(): ... return`` when ``message.cancelled``)
+before it can reach ``RequestResponder.__exit__``, masking the leak
+regardless of whether #2610/#2624 land. Empirically re-validated on
+``mcp`` 1.27.2; ``tests/test_transport_recovery.py`` guards
+cross-platform against a regression in that masking behaviour.
 """
 
 from __future__ import annotations
@@ -31,19 +40,13 @@ from __future__ import annotations
 import logging
 import threading
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal
-
-import anyio
-
-if TYPE_CHECKING:
-    from types import TracebackType
+from typing import Any, Literal
 
 GhostSource = Literal["cancellation", "deadline"]
 
 _log = logging.getLogger(__name__)
 
 _PATCH_APPLIED_ATTR = "_hive_cancellation_patch_applied"
-_REQUIRED_ATTRS = ("_completed", "_on_complete", "_entered", "_cancel_scope")
 
 
 class _GhostResponseCounter:
@@ -112,35 +115,6 @@ class _GhostResponseCounter:
 
 
 GHOST_RESPONSES = _GhostResponseCounter()
-
-
-def _make_patched_exit(original_exit: Any) -> Any:  # noqa: ARG001 (kept for symmetry)
-    def _patched_exit(
-        self: Any,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        try:
-            if self._completed:
-                self._on_complete(self)
-        finally:
-            self._entered = False
-            if not self._cancel_scope:
-                raise RuntimeError("No active cancel scope")
-            try:
-                self._cancel_scope.__exit__(exc_type, exc_val, exc_tb)
-            except BaseException as exc:
-                cancelled_cls = anyio.get_cancelled_exc_class()
-                if self._completed and isinstance(exc, cancelled_cls):
-                    _log.debug(
-                        "Swallowed spurious cancellation on completed responder %s (issue #75)",
-                        self.request_id,
-                    )
-                    return
-                raise
-
-    return _patched_exit
 
 
 def _make_patched_respond(original_respond: Any) -> Any:
@@ -212,7 +186,7 @@ def _tool_name_from_responder(responder: Any) -> str | None:
 
 
 def apply() -> None:
-    """Apply the cancellation-safety patch to ``RequestResponder.__exit__``.
+    """Apply the respond-after-cancel patch to ``RequestResponder.respond``.
 
     Idempotent and best-effort: if the upstream API has shifted such
     that the patch cannot be applied safely, log a warning and return.
@@ -222,7 +196,7 @@ def apply() -> None:
     except ImportError as exc:
         _log.warning(
             "Could not import mcp.shared.session.RequestResponder — "
-            "cancellation patch skipped (issue #75): %s",
+            "respond-after-cancel patch skipped (#2416): %s",
             exc,
         )
         return
@@ -230,40 +204,18 @@ def apply() -> None:
     if getattr(RequestResponder, _PATCH_APPLIED_ATTR, False):
         return
 
-    missing = [
-        a
-        for a in _REQUIRED_ATTRS
-        if a not in RequestResponder.__dict__ and not hasattr(RequestResponder, a)
-    ]
-    # Instance attrs aren't in the class dict; we test via __init__ source.
-    # A simpler heuristic: just check __exit__ exists, then trust it at call
-    # time — our patch only short-circuits when the attrs are set on the
-    # instance, so a shape change degrades to the original behaviour.
-    if not hasattr(RequestResponder, "__exit__"):
-        _log.warning(
-            "RequestResponder has no __exit__ — cancellation patch skipped "
-            "(issue #75). Missing attrs hint: %s",
-            missing,
-        )
-        return
-
-    original_exit = RequestResponder.__exit__
-    RequestResponder.__exit__ = _make_patched_exit(original_exit)  # type: ignore[method-assign]
-
     if hasattr(RequestResponder, "respond"):
         original_respond = RequestResponder.respond
         RequestResponder.respond = _make_patched_respond(  # type: ignore[method-assign]
             original_respond,
         )
+        setattr(RequestResponder, _PATCH_APPLIED_ATTR, True)
         _log.debug(
-            "Applied RequestResponder.respond patch (respond-after-cancel)",
+            "Applied RequestResponder.respond patch (respond-after-cancel, #2416)",
         )
     else:
         _log.warning(
             "RequestResponder has no respond — respond-after-cancel patch "
-            "skipped. Server may crash with AssertionError if a handler "
-            "completes after a client cancellation.",
+            "skipped (#2416). Server may crash with AssertionError if a "
+            "handler completes after a client cancellation.",
         )
-
-    setattr(RequestResponder, _PATCH_APPLIED_ATTR, True)
-    _log.debug("Applied RequestResponder.__exit__ cancellation patch (issue #75)")

--- a/src/hive/_diagnostics.py
+++ b/src/hive/_diagnostics.py
@@ -10,8 +10,9 @@ request when the log level is INFO or below. It does not buffer or
 serialise the payload.
 
 If the request handler raises ``CancelledError``, the middleware logs
-it explicitly and re-raises — the patch in :mod:`hive._compat` is what
-keeps the cancellation from killing the receive loop.
+it explicitly and re-raises. The in-flight cancellation is then absorbed
+by ``mcp``'s own ``Server._handle_request`` guard; the residual
+respond-after-cancel race is handled by the patch in :mod:`hive._compat`.
 """
 
 from __future__ import annotations

--- a/tests/test_transport_recovery.py
+++ b/tests/test_transport_recovery.py
@@ -7,14 +7,36 @@ calls returned ``MCP error -32000: Connection closed``, then
 
 Root cause: ``RequestResponder.__exit__`` in the upstream ``mcp``
 library let the anyio ``CancelScope`` re-raise a ``CancelledError``
-after the responder had already sent its error response. That exception
+after a cancelled tool call had already responded. That exception
 propagated to the receive loop's ``anyio.create_task_group()`` and
-killed it, so the server stopped reading stdin. ``hive._compat`` patches
-the responder to swallow that spurious cancellation.
+killed it, so the server stopped reading stdin.
 
-These tests exercise both the in-memory FastMCP boundary and the real
-stdio transport via a subprocess. The subprocess case is the one that
-actually reproduces the bug in unpatched ``mcp``.
+hive originally shipped a ``__exit__`` monkey-patch for this (upstream
+modelcontextprotocol/python-sdk#2610; fix proposed in the still-open
+PR #2624). It was removed once we confirmed the symptom no longer
+reproduces on the pinned ``mcp`` (>=1.27): ``Server._handle_request``
+catches the in-flight handler cancellation (``except
+anyio.get_cancelled_exc_class(): ... return`` when ``message.cancelled``)
+before it can reach ``RequestResponder.__exit__``. A *separate*
+respond-after-cancel race — the ``assert not self._completed`` in
+``RequestResponder.respond`` (#2416), which #2624 does not touch — is
+still patched in ``hive._compat`` and guarded by
+``tests/test_compat_shim.py``.
+
+These tests are the guard that lets us depend on the upstream behaviour
+instead of the workaround:
+
+* ``TestInMemoryCancellation`` cancels at the in-process FastMCP
+  boundary — fast, every platform.
+* ``TestProtocolLevelCancellation`` drives a real lowlevel ``Server``
+  receive loop over in-memory streams and sends an actual
+  ``notifications/cancelled`` mid-handler — the same protocol path
+  issue #75 broke, deterministic and cross-platform.
+* ``TestSubprocessTransportRecovery`` drives a real stdio subprocess;
+  closest reproduction but Windows-only (timing-sensitive on Linux CI).
+
+If a future ``mcp`` upgrade regresses the cancellation handling, the
+cross-platform tests fail in CI, signalling the workaround must return.
 """
 
 from __future__ import annotations
@@ -25,7 +47,12 @@ import os
 import sys
 from typing import TYPE_CHECKING
 
+import anyio
+import mcp.types as types
 import pytest
+from mcp.server.lowlevel import Server
+from mcp.shared.exceptions import McpError
+from mcp.shared.memory import create_connected_server_and_client_session
 
 from hive.server import create_server
 
@@ -198,3 +225,97 @@ class TestSubprocessTransportRecovery:
             assert "result" in second or "error" in second
         finally:
             await self._shutdown(proc)
+
+
+# ── Protocol-level cancellation (cross-platform, real receive loop) ────
+
+
+class _CancellationProbe:
+    """Coordinates a deterministic mid-handler cancellation.
+
+    ``started`` is set by the blocking handler the instant it begins
+    executing — and only then does the test send the cancellation, so
+    the responder is guaranteed to be ``_entered`` (otherwise
+    ``RequestResponder.cancel`` would lose the cancellation against a
+    not-yet-entered scope). ``request_id`` is captured *server-side*, so
+    the test never has to guess the client's id sequence.
+    """
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.request_id: int | str | None = None
+
+
+def _build_cancellation_server(probe: _CancellationProbe) -> Server:
+    """A minimal lowlevel MCP server with one blocking and one fast tool."""
+    server: Server = Server("hive-cancellation-probe")
+    empty_schema = {"type": "object", "properties": {}}
+
+    @server.list_tools()
+    async def _list_tools() -> list[types.Tool]:
+        return [
+            types.Tool(
+                name="block",
+                description="Blocks until cancelled.",
+                inputSchema=empty_schema,
+            ),
+            types.Tool(
+                name="ping",
+                description="Returns immediately.",
+                inputSchema=empty_schema,
+            ),
+        ]
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: dict[str, object]) -> list[types.ContentBlock]:
+        if name == "block":
+            # Capture the id first, then announce: the test reads both.
+            probe.request_id = server.request_context.request_id
+            probe.started.set()
+            await anyio.sleep_forever()  # cancelled via notifications/cancelled
+        return [types.TextContent(type="text", text="pong")]
+
+    return server
+
+
+class TestProtocolLevelCancellation:
+    """A real notifications/cancelled mid-handler must not poison the loop.
+
+    Cross-platform counterpart to the Windows-only subprocess test: it
+    drives the genuine lowlevel ``Server`` receive loop + task group over
+    in-memory streams, exercising the same path issue #75 broke. It now
+    relies on the upstream mcp cancel guard rather than hive's removed
+    ``__exit__`` workaround — if that guard regresses, this fails on every
+    platform.
+    """
+
+    async def test_cancelled_handler_does_not_poison_transport(self) -> None:
+        probe = _CancellationProbe()
+        server = _build_cancellation_server(probe)
+
+        async with create_connected_server_and_client_session(server) as client:
+            block_call = asyncio.create_task(client.call_tool("block", {}))
+
+            # Cancel only once the handler is provably in-flight.
+            await asyncio.wait_for(probe.started.wait(), timeout=5.0)
+            assert probe.request_id is not None
+
+            await client.send_notification(
+                types.ClientNotification(
+                    types.CancelledNotification(
+                        params=types.CancelledNotificationParams(
+                            requestId=probe.request_id,
+                            reason="user rejected",
+                        ),
+                    ),
+                ),
+            )
+
+            # The cancelled call surfaces as an MCP error, not a hang.
+            with pytest.raises(McpError):
+                await asyncio.wait_for(block_call, timeout=5.0)
+
+            # The transport must still serve subsequent calls.
+            result = await asyncio.wait_for(client.call_tool("ping", {}), timeout=5.0)
+            assert result.isError is False
+            assert _text(result) == "pong"


### PR DESCRIPTION
## What

Removes the `RequestResponder.__exit__` monkey-patch from `hive._compat` and replaces its coverage with a deterministic, cross-platform regression test. Keeps the `respond()` patch (a different, still-live race).

## Why

Resolves the overdue decision gate in #127.

`hive._compat` carried two patches for two distinct cancellation races:

1. **`__exit__` leak** (issue #75; upstream [python-sdk#2610](https://github.com/modelcontextprotocol/python-sdk/issues/2610), proposed fix in the still-open PR #2624) — the anyio cancel scope re-raising `CancelledError` after a cancelled request already responded.
2. **`respond()` assertion** (upstream [python-sdk#2416](https://github.com/modelcontextprotocol/python-sdk/issues/2416)) — `assert not self._completed` firing when a late `respond()` lands after a cancel.

On the pinned `mcp` (>=1.27), `Server._handle_request` now catches the in-flight handler cancellation (`except anyio.get_cancelled_exc_class(): ... return` when `message.cancelled`) **before** it reaches `RequestResponder.__exit__`. That masks the issue-#75 symptom regardless of whether #2610/#2624 ever land, so the `__exit__` patch is redundant.

#2624 fixes only `__exit__`; it does **not** touch the `respond()` assertion, so the respond patch (and its ghost-response observability) stays.

## Validation

- Empirically re-validated on **mcp 1.27.2**: a real `notifications/cancelled` mid-handler on a bare lowlevel `Server` with **no hive patches** survives (transport not poisoned) — so the `__exit__` patch adds nothing on the pinned range.
- New `TestProtocolLevelCancellation` (cross-platform) guards this: it drives the genuine receive loop + task group and fails on **any** platform if the upstream cancel guard regresses. Previously this path was covered only by a Windows-only subprocess test.
- `ruff` + `mypy --strict` clean; the cancellation-path suites (`test_transport_recovery`, `test_compat_shim`, `test_concurrency_fixes`) pass on mcp 1.27.2.

Refs #127


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a race condition in cancellation handling that could interfere with response delivery when operations are cancelled concurrently.
  * Enhanced stability and reliability during operation cancellation to prevent transport-level disruptions.

* **Tests**
  * Added comprehensive protocol-level cancellation tests to ensure transport remains stable and functional when cancellations occur during request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->