### PR TITLE
test: stabilize the suite on a dev box with real local state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,6 +197,49 @@ def openrouter() -> OpenRouterClient:
 
 
 @pytest.fixture(autouse=True)
+def _isolate_hive_data_dir(
+    tmp_path_factory: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Point hive's persistent DBs at a throwaway dir for every test.
+
+    ``create_server`` builds its worker/relevance/lesson DBs — and the
+    ``LockEvictionTracker`` / ``IdempotencyStore`` (both
+    ``db_path.parent / *.db``) — from the *module-level* ``settings`` singleton
+    (``hive.config.settings``), which pydantic-settings froze at import time.
+    Setting ``HIVE_*`` env vars after import therefore never reaches
+    ``create_server``: the singleton already holds the real
+    ``~/.local/share/hive`` paths. Tests then read and *write* the developer's
+    real data dir — eviction counts accumulate across runs, so
+    ``test_runtime_block_includes_lock_eviction`` ("fresh tracker → 0") fails on
+    any box with prior history while staying green on clean CI.
+
+    Fix: mutate the live singleton's path attributes (monkeypatch restores them)
+    so ``create_server`` resolves every DB under a per-test temp dir. The
+    ``HIVE_*`` env vars are *also* set, for any code path that constructs a
+    fresh ``HiveSettings()``. ``test_config``'s own ``_isolate_hive_env`` clears
+    these vars again so its default-value asserts still see the hardcoded
+    defaults (it reconstructs ``HiveSettings()`` and never reads this singleton).
+    """
+    from hive.config import settings
+
+    data = tmp_path_factory.mktemp("hive-data")
+    worker_db = data / "worker.db"
+    relevance_db = data / "relevance.db"
+    lesson_db = data / "lesson.db"
+    log_file = data / "hive.log"
+    monkeypatch.setenv("HIVE_DB_PATH", str(worker_db))
+    monkeypatch.setenv("HIVE_RELEVANCE_DB_PATH", str(relevance_db))
+    monkeypatch.setenv("HIVE_LESSON_DB_PATH", str(lesson_db))
+    monkeypatch.setenv("HIVE_LOG_PATH", str(log_file))
+    # The frozen singleton — not the env — is what create_server actually reads.
+    monkeypatch.setattr(settings, "db_path", str(worker_db))
+    monkeypatch.setattr(settings, "relevance_db_path", str(relevance_db))
+    monkeypatch.setattr(settings, "lesson_db_path", str(lesson_db))
+    monkeypatch.setattr(settings, "log_path", str(log_file))
+
+
+@pytest.fixture(autouse=True)
 def _reset_ghost_response_counter() -> Generator[None, None, None]:
     """Reset the module-level ghost-response counter around every test.
 

--- a/tests/test_bounded_call.py
+++ b/tests/test_bounded_call.py
@@ -300,8 +300,15 @@ async def test_windows_subprocess_terminated_reaches_descendants() -> None:
     registry: list[subprocess.Popen[bytes]] = []
 
     async def spawn_cmd_sleep() -> None:
+        # ``ping -n 61`` delays ~60s WITHOUT reading the console: unlike
+        # ``timeout``, it does not abort with "Input redirection is not
+        # supported" when stdin is redirected (as under pytest/CI). cmd.exe is
+        # still the CREATE_NEW_PROCESS_GROUP parent with ping.exe as its child,
+        # so the descendant-termination path under test is unchanged. Using
+        # ``timeout`` here made the process exit instantly in redirected-stdin
+        # environments, so bounded_call never hit its deadline (#212).
         proc = subprocess.Popen(  # noqa: S603
-            ["cmd", "/c", "timeout", "/t", "60", "/nobreak"],
+            ["cmd", "/c", "ping", "-n", "61", "127.0.0.1"],
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for HiveSettings (pydantic-settings)."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -8,10 +9,27 @@ from pydantic import ValidationError
 from hive.config import HiveSettings
 
 
+@pytest.fixture(autouse=True)
+def _isolate_hive_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip ambient hive configuration before every test.
+
+    ``HiveSettings`` reads ``HIVE_*`` env vars plus the unprefixed
+    ``VAULT_PATH`` / ``OPENROUTER_API_KEY`` deploy aliases. A developer or
+    deploy box with any of these set (a real ``VAULT_PATH`` is the normal
+    case) would otherwise mask the hardcoded defaults and fail the
+    default-value assertions — green in CI, red locally. Clearing here runs
+    before each test body, so the override tests still set their own vars.
+    """
+    for key in list(os.environ):
+        if key.startswith("HIVE_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("VAULT_PATH", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+
 class TestDefaults:
     def test_vault_path_default(self) -> None:
-        s = HiveSettings()
-        assert s.vault_path == Path.home() / "Projects" / "knowledge"
+        assert HiveSettings().vault_path == Path.home() / "Projects" / "knowledge"
 
     def test_ollama_endpoint_default(self) -> None:
         assert HiveSettings().ollama_endpoint == "http://localhost:11434"
@@ -19,9 +37,7 @@ class TestDefaults:
     def test_ollama_model_default(self) -> None:
         assert HiveSettings().ollama_model == "qwen2.5-coder:7b"
 
-    def test_openrouter_api_key_default_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-        monkeypatch.delenv("HIVE_OPENROUTER_API_KEY", raising=False)
+    def test_openrouter_api_key_default_none(self) -> None:
         assert HiveSettings().openrouter_api_key is None
 
     def test_openrouter_budget_default(self) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -8,6 +8,7 @@ drives it with a thin `fastmcp.Client` — the production analogue of the spike.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import socket
 import stat
@@ -275,16 +276,35 @@ async def _session_calls(url: str, token: str, tool: str, args: dict[str, str], 
 
 @pytest.fixture
 def daemon_env(tmp_path: Path) -> tuple[dict[str, str], Path]:
-    """Env pointing every DB + the vault + daemon state dir at a temp dir."""
+    """Env pointing every DB + the vault + daemon state dir at a temp dir.
+
+    The daemon/client subprocesses inherit a *scrubbed* copy of ``os.environ``:
+    every ambient ``HIVE_*`` / ``VAULT_PATH`` is stripped first, then only the
+    test's temp paths are set. Without the scrub a dev box that exports its real
+    ``HIVE_VAULT_PATH`` (which pydantic-settings' ``AliasChoices`` ranks ABOVE
+    the unprefixed ``VAULT_PATH``) would shadow the override below — the
+    subprocess would open the developer's real vault, where the seeded ``demo``
+    project does not exist, and every forwarded query would 404 ("Project 'demo'
+    not found"). This is the #212 class of "passes on clean CI, fails on a dev
+    box with real local state". Both vault aliases are set so neither precedence
+    order can leak. The autouse ``_isolate_hive_data_dir`` only fixes the parent
+    process; these subprocesses re-read the environment, so they need it here.
+    """
     vault = tmp_path / "vault"
     (vault / "10_projects").mkdir(parents=True)
+    base = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("HIVE_") and k != "VAULT_PATH"
+    }
     env = {
-        **os.environ,
+        **base,
         "HIVE_DB_PATH": str(tmp_path / "worker.db"),
         "HIVE_RELEVANCE_DB_PATH": str(tmp_path / "relevance.db"),
         "HIVE_LESSON_DB_PATH": str(tmp_path / "lesson.db"),
         "HIVE_LOG_PATH": str(tmp_path / "hive.log"),
         "VAULT_PATH": str(vault),
+        "HIVE_VAULT_PATH": str(vault),
     }
     return env, tmp_path
 
@@ -294,6 +314,35 @@ def _spawn_daemon(env: dict[str, str], port: int) -> subprocess.Popen[bytes]:
         [sys.executable, "-m", "hive.server", "serve", "--port", str(port)],
         env=env,
     )
+
+
+def _kill_tree(proc: subprocess.Popen[bytes], timeout_s: float = 10.0) -> None:
+    """Kill *proc* AND its descendants, then reap them all.
+
+    ``Popen.kill()`` terminates only the immediate process. On Windows the
+    daemon's ``uvicorn`` server runs the listening socket in a *child*
+    ``python.exe`` (confirmed via ``psutil.net_connections``: the LISTEN owner is
+    the child PID, not ``proc.pid``). Killing only the parent leaves that child
+    bound to the port, so a follow-up ``_wait_ready`` still connects and a
+    "daemon is gone" assertion flaps. ``psutil`` (a hard hive dependency) lets us
+    enumerate and kill the whole tree so the port is actually released. Falls
+    back to a plain ``proc.kill()`` if the process is already gone.
+    """
+    import psutil
+
+    try:
+        parent = psutil.Process(proc.pid)
+        victims = [*parent.children(recursive=True), parent]
+    except psutil.NoSuchProcess:
+        with contextlib.suppress(Exception):
+            proc.kill()
+        return
+    for victim in victims:
+        with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+            victim.kill()
+    psutil.wait_procs(victims, timeout=timeout_s)
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        proc.wait(timeout=timeout_s)
 
 
 def test_hive_serve_answers_tools_list(daemon_env: tuple[dict[str, str], Path]) -> None:
@@ -516,8 +565,9 @@ def test_client_reconnects_to_restarted_daemon_without_duplicate_write(
     def restart() -> None:
         nonlocal daemon_a, daemon_b
         assert daemon_a is not None
-        daemon_a.kill()
-        daemon_a.wait(timeout=10)
+        # Tree-kill so A's listening child (which also holds the singleton
+        # daemon.lock) dies — otherwise B cannot reacquire the lock and publish.
+        _kill_tree(daemon_a)
         daemon_a = None
         daemon_b = _spawn_daemon(env, port_b)
         assert _wait_published(state_dir, port_b), "daemon B never published its port"
@@ -568,11 +618,13 @@ def test_client_degrades_in_process_when_daemon_dies_mid_session(
     def kill() -> None:
         nonlocal daemon
         assert daemon is not None
-        daemon.kill()
-        daemon.wait(timeout=10)
+        # Kill the whole tree: on Windows the listening socket lives in a child
+        # python.exe, so a parent-only kill leaves the port bound (see
+        # _kill_tree). Tree-killing actually frees the port the probe below.
+        _kill_tree(daemon)
         # The shim's per-call factory TCP-probes the now-dead port; a refused
         # connect (loopback RST) flips it to in-process without a restart.
-        assert not _wait_ready(port, deadline_s=2.0), "daemon port still open"
+        assert not _wait_ready(port, deadline_s=5.0), "daemon port still open"
         daemon = None
 
     try:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -292,11 +292,7 @@ def daemon_env(tmp_path: Path) -> tuple[dict[str, str], Path]:
     """
     vault = tmp_path / "vault"
     (vault / "10_projects").mkdir(parents=True)
-    base = {
-        k: v
-        for k, v in os.environ.items()
-        if not k.startswith("HIVE_") and k != "VAULT_PATH"
-    }
+    base = {k: v for k, v in os.environ.items() if not k.startswith("HIVE_") and k != "VAULT_PATH"}
     env = {
         **base,
         "HIVE_DB_PATH": str(tmp_path / "worker.db"),


### PR DESCRIPTION
## Summary
Four suite tests failed only on a dev box with real local state (green on CI). Fixed at the root.

## Changes
- **Per-test DB isolation** (`tests/conftest.py`): `create_server` reads the import-frozen `hive.config.settings` singleton, so `monkeypatch.setenv` never reached it and the lock-eviction count bled in from the real `~/.local/share/hive` DB. The autouse fixture now mutates the live singleton's path attributes (env vars kept for fresh `HiveSettings()`).
- **Windows `bounded_call` flake** (`tests/test_bounded_call.py`): `cmd timeout` aborts instantly under redirected stdin, so the deadline never fired — swapped to `ping -n 61`.
- **Daemon subprocess tests** (`tests/test_daemon.py`): scrub ambient `HIVE_*`/`VAULT_PATH` from the subprocess env (the child re-reads `os.environ`; `HIVE_VAULT_PATH` outranks `VAULT_PATH`), and tree-kill the daemon via `psutil` so the uvicorn listening child releases the port on Windows.
- **`tests/test_config.py`**: strip ambient `HIVE_*`/`VAULT_PATH` so default asserts hold on a dev box.

## Verification
- Full suite: **744 passed, 19 skipped** (local Python 3.14).
- `ruff check src tests` clean. `mypy --strict src`: 5 pre-existing Windows-only `_deadline.py` errors (green on Linux CI), unrelated to this change.

Closes #212.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved isolation by redirecting all persistent Hive storage (DBs/logs) to per-test temporary directories.
  * Cleared ambient `HIVE_*`/vault-related environment variables to keep configuration default assertions deterministic.
  * Enhanced Windows subprocess termination reliability by switching to a command that behaves consistently with redirected stdin.
  * Strengthened daemon shutdown cleanup by terminating the full process tree to prevent lingering child processes and reduce flaky “port still open” failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->