### PR TITLE
fix(write): skip the vault pre-commit hook on Hive auto-commits

### DIFF
--- a/docs/adr/adr-017-auto-commit-bypasses-vault-pre-commit-hook.md
+++ b/docs/adr/adr-017-auto-commit-bypasses-vault-pre-commit-hook.md
@@ -1,0 +1,52 @@
+---
+id: adr-017-auto-commit-bypasses-vault-pre-commit-hook
+type: adr
+status: accepted
+created: "2026-06-19"
+owner: manu
+tags: [architecture, write-path, git, security, secret-scanning, performance]
+---
+
+# ADR-017: Hive auto-commits bypass the vault pre-commit hook; secret scanning moves push-side
+
+## Status
+
+**Accepted (2026-06-19).** Implements [#255](https://github.com/mlorentedev/hive/issues/255); pairs with the vault-side change [mlorentedev/knowledge#121](https://github.com/mlorentedev/knowledge/issues/121). Supersedes the implicit prior behaviour where `_git_commit` ran the target vault's `pre-commit` hooks on every machine commit.
+
+## Context
+
+Every vault write (`vault_write`, `vault_patch`, `capture_lesson`, and the deferred-flush `vault_commit`) auto-commits to git via `_git_commit` / `_git_commit_all` in `src/hive/_helpers.py`. Those calls ran `git commit` **without `--no-verify`**, so each machine commit fired the target vault's `pre-commit` hook chain.
+
+On the maintainer's vault that chain is `gitleaks` (a full-diff secret scan) plus a `language: python` local hook (`forbid-hardcoded-vault-paths`, ADR-023 of the vault). Measured cost on Windows, warm, single process:
+
+- `git commit` with hooks, 1 staged file: **~8.9 s**
+- `git commit --no-verify`: **~0.5 s** (≈17× faster)
+
+Under cold start (the `language: python` hook builds a venv; gitleaks fetches on first use) and **concurrency** — several machine committers (the Obsidian Git plugin's frequent "vault backup" commits, the `hermes-nan` agent, and Hive) serialise under the vault git filelock — this reaches Hive's **60 s tool deadline**. Production logs show **24 `deadline_exceeded` kills and 6 lock evictions**: `vault_write timed out after 60.0s → killed subprocess → lock_eviction`. The practical effect is that callers avoid `vault_write` / `capture_lesson` because writes hang 60–180 s — i.e. "agents use Hive less."
+
+This was initially blamed on the Phase C daemon (ADR-011). That is refuted: the daemon never ran (install fails `schtasks … Access is denied`; ADR-015 documents the Windows daemon as broken-as-shipped), and the first commit timeout (2026-05-19) **predates** the daemon (2026-05-31). The bottleneck is the pre-commit hook, not the transport model.
+
+A pre-commit hook is a **human-commit** safeguard. Hive is an automated committer; making its machine commits hostage to whatever (arbitrarily slow) hook a given vault installs is the wrong coupling — and it differs per deployment, so the behaviour is non-portable.
+
+## Decision
+
+1. Hive's auto-commits pass **`--no-verify`**, gated by a new setting `HiveSettings.git_commit_no_verify` (env `HIVE_GIT_COMMIT_NO_VERIFY`), **default `True`**. The two write-path commit callsites (`_git_commit`, `_git_commit_all`) build their argv through `_commit_args`, which inserts `--no-verify` when enabled.
+2. Secret scanning **moves push-side**, not away. On the vault, `gitleaks` and the path-guard hook relocate from `pre-commit` to `pre-push` (`stages: [pre-push]`), and the existing CI workflow `vault-guard.yml` already runs `gitleaks` on every push/PR plus a weekly full-history sweep. Secrets are therefore still caught before they **leave the machine**.
+3. Human commits are unaffected — the `pre-commit` stage still exists for the cheap hygiene hooks, and developers committing by hand keep full coverage.
+
+## Consequences
+
+**Positive**
+- Vault writes drop from ~9–60 s to the git baseline (~0.5 s); the 60 s deadline-kill / lock-eviction failure mode disappears.
+- Hive no longer depends on any particular vault's hook configuration — portable across vaults.
+- One lever fixes the write-path latency for *every* machine committer once the vault hook is relocated (Obsidian Git, `hermes-nan`, Hive).
+
+**Negative / accepted trade-offs**
+- A secret can briefly land in **local** git history before a push. It is still caught at `pre-push` (once `pre-commit install --hook-type pre-push` is run) and by CI before reaching the remote — nothing secret leaves the machine uncaught. This is the deliberate trade-off.
+- The `forbid-hardcoded-vault-paths` guard now runs only at push time; `vault-guard.yml` does not yet replicate it, so its local enforcement depends on the pre-push hook being installed. A server-side backstop for it is a follow-up.
+
+## Alternatives considered
+
+- **In-Hive pre-write secret scan** (Hive runs gitleaks on its own content before writing): keeps the net adjacent to the write but adds gitleaks as an operational dependency of Hive and re-introduces latency. Rejected in favour of push-side coverage (option b).
+- **Make the vault hooks fast** (pre-warm venvs, drop the python hook): keeps per-commit scanning but is brittle on a cold box and does not remove the coupling.
+- **Async / outbox commit** (decouple the commit from the tool response; scaffolding exists at `_helpers.py`): complementary, not a substitute — deferred as a separate change (R3).

--- a/src/hive/_helpers.py
+++ b/src/hive/_helpers.py
@@ -851,6 +851,24 @@ def _post_kill_drain() -> float:
     return settings.post_kill_drain_s
 
 
+def _commit_args(message: str) -> list[str]:
+    """Build the ``git commit`` argv, gated on ``git_commit_no_verify``.
+
+    Lazy read of ``settings.git_commit_no_verify`` (default True) so tests
+    can monkeypatch the settings object after import — same idiom as
+    :func:`_lock_timeout`. Hive's auto-commits skip the human-oriented
+    pre-commit hook chain (the slow vault hook hung writes ~60s until the
+    deadline killed them); scanning lives push-side/CI now. Env:
+    ``HIVE_GIT_COMMIT_NO_VERIFY`` (default True).
+    """
+    from hive.config import settings
+
+    args = ["commit", "-m", message]
+    if settings.git_commit_no_verify:
+        args.insert(1, "--no-verify")
+    return args
+
+
 def _acquire_with_telemetry(
     lock: threading.Lock,
     lock_name: str,
@@ -1420,7 +1438,7 @@ def _git_commit(
                         err.strip(),
                     )
                     return
-                rc, _, err = _run_git(["commit", "-m", safe_msg], vault_path)
+                rc, _, err = _run_git(_commit_args(safe_msg), vault_path)
                 if rc != 0:
                     cause = "external_termination" if rc == RC_EXTERNAL_TERMINATION else "git_error"
                     _log.warning(
@@ -1477,7 +1495,7 @@ def _git_commit_all(
                 rc, _, err = _run_git(["add", "-A"], vault_path)
                 if rc != 0:
                     return "error", f"git add -A rc={rc}: {err.strip() or '<empty>'}"
-                rc, _, err = _run_git(["commit", "-m", safe_msg], vault_path)
+                rc, _, err = _run_git(_commit_args(safe_msg), vault_path)
                 if rc != 0:
                     return "error", f"git commit rc={rc}: {err.strip() or '<empty>'}"
                 rc, rev_out, err = _run_git(["rev-parse", "HEAD"], vault_path)

--- a/src/hive/config.py
+++ b/src/hive/config.py
@@ -79,6 +79,14 @@ class HiveSettings(BaseSettings):
     # version to detect an in-place upgrade (`uv tool upgrade`). On drift it
     # clean-stops and exits non-zero so the supervisor restarts into new code.
     upgrade_poll_s: float = Field(default=30.0, gt=0.0, le=3600.0)
+    # Pass ``--no-verify`` on every write-path ``git commit``. Hive is
+    # automation: its auto-commits should never fire the human-oriented
+    # pre-commit hook chain. A slow vault hook (gitleaks + a language:python
+    # local hook) takes ~9s warm and up to 60s cold/under concurrency, which
+    # hung vault_write/vault_patch/capture_lesson for ~60s until the deadline
+    # killed them. Secret scanning now lives push-side/CI on the vault, so
+    # skipping the hook here is safe. Override with HIVE_GIT_COMMIT_NO_VERIFY.
+    git_commit_no_verify: bool = True
 
     @field_validator("vault_scopes")
     @classmethod

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,6 +11,7 @@ import pytest
 from hive._helpers import (
     _default_scopes,
     _git_commit,
+    _git_commit_all,
     _match_and_replace,
     _resolve_project_dir,
     _strip_code,
@@ -525,3 +526,104 @@ class TestGitCommitCoalesce:
         _git_commit(tmp_path, [], "vault: noop")
 
         assert calls == [], f"expected no _run_git calls, got: {calls}"
+
+
+class TestGitCommitNoVerify:
+    """``git_commit_no_verify`` gates ``--no-verify`` on write-path commits.
+
+    Hive's auto-commits should skip the human-oriented pre-commit hook
+    chain (a slow vault hook hung writes ~60s until the deadline killed
+    them; scanning lives push-side/CI now). Default True; overridable via
+    ``HIVE_GIT_COMMIT_NO_VERIFY``. Both ``_git_commit`` and
+    ``_git_commit_all`` are exercised so neither write path regresses.
+    """
+
+    @staticmethod
+    def _capture_run_git(
+        monkeypatch: pytest.MonkeyPatch,
+        calls: list[list[str]],
+    ) -> None:
+        """Replace ``_run_git`` with a recorder that always succeeds."""
+
+        def fake_run_git(
+            args: list[str],
+            _vault: Path,
+            *,
+            registry: object = None,  # noqa: ARG001
+        ) -> tuple[int, str, str]:
+            calls.append(["git", *args])
+            # ``status`` must look dirty so ``_git_commit_all`` reaches commit;
+            # ``rev-parse`` must yield a SHA for its return path.
+            if args[:2] == ["status", "--porcelain"]:
+                return 0, " M a.md\n", ""
+            if args[:1] == ["rev-parse"]:
+                return 0, "0" * 40, ""
+            return 0, "", ""
+
+        monkeypatch.setattr("hive._helpers._run_git", fake_run_git)
+
+    def test_git_commit_includes_no_verify_by_default(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Default (``git_commit_no_verify=True``) → commit argv has --no-verify."""
+        from pathlib import Path as _Path
+
+        monkeypatch.setattr("hive.config.settings.git_commit_no_verify", True)
+        calls: list[list[str]] = []
+        self._capture_run_git(monkeypatch, calls)
+
+        _git_commit(tmp_path, [_Path("a.md")], "msg")
+
+        [commit] = [c for c in calls if c[:2] == ["git", "commit"]]
+        assert commit == ["git", "commit", "--no-verify", "-m", "msg"]
+
+    def test_git_commit_omits_no_verify_when_disabled(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``git_commit_no_verify=False`` → commit argv has no --no-verify."""
+        from pathlib import Path as _Path
+
+        monkeypatch.setattr("hive.config.settings.git_commit_no_verify", False)
+        calls: list[list[str]] = []
+        self._capture_run_git(monkeypatch, calls)
+
+        _git_commit(tmp_path, [_Path("a.md")], "msg")
+
+        [commit] = [c for c in calls if c[:2] == ["git", "commit"]]
+        assert commit == ["git", "commit", "-m", "msg"]
+        assert "--no-verify" not in commit
+
+    def test_git_commit_all_includes_no_verify_by_default(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``_git_commit_all`` also passes --no-verify by default."""
+        monkeypatch.setattr("hive.config.settings.git_commit_no_verify", True)
+        calls: list[list[str]] = []
+        self._capture_run_git(monkeypatch, calls)
+
+        _git_commit_all(tmp_path, "batch update")
+
+        [commit] = [c for c in calls if c[:2] == ["git", "commit"]]
+        assert commit == ["git", "commit", "--no-verify", "-m", "batch update"]
+
+    def test_git_commit_all_omits_no_verify_when_disabled(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``_git_commit_all`` omits --no-verify when the setting is False."""
+        monkeypatch.setattr("hive.config.settings.git_commit_no_verify", False)
+        calls: list[list[str]] = []
+        self._capture_run_git(monkeypatch, calls)
+
+        _git_commit_all(tmp_path, "batch update")
+
+        [commit] = [c for c in calls if c[:2] == ["git", "commit"]]
+        assert commit == ["git", "commit", "-m", "batch update"]
+        assert "--no-verify" not in commit


### PR DESCRIPTION
## Summary
Hive's auto-commit ran the target vault's `pre-commit` hook on every machine write, hanging vault writes ~9–60 s (24 deadline kills + 6 lock evictions on record). Machine commits now pass `--no-verify`.

## Changes
- `HiveSettings.git_commit_no_verify: bool = True` (env `HIVE_GIT_COMMIT_NO_VERIFY`).
- `_git_commit` / `_git_commit_all` build argv via `_commit_args`, inserting `--no-verify` when enabled.
- `docs/adr/adr-017-*.md` records the policy.
- Tests for both the enabled and disabled paths.

## Why this is safe
Secret scanning is not removed — it moves to `pre-push` + the vault's `vault-guard.yml` CI (see mlorentedev/knowledge#121). Human commits keep the hook.

Closes #255.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `git_commit_no_verify` configuration setting to control whether automated commits bypass pre-commit hooks. Enabled by default and configurable via the `HIVE_GIT_COMMIT_NO_VERIFY` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->