### PR TITLE
fix(vault): accept slash-form project ids in resolution

### DIFF
--- a/src/hive/_helpers.py
+++ b/src/hive/_helpers.py
@@ -357,6 +357,15 @@ def _resolve_project_dir(
 
     explicit_scope, slug = _parse_project_ref(project)
 
+    # Postel's law (#235): accept the slash form that ``vault_list`` advertises
+    # (``<scope>/<project>``), not just the colon form. Only when the leading
+    # segment names a known scope — otherwise ``/`` keeps its literal
+    # relative-path meaning within a scope (e.g. ``20-products/hydra3d-plus``).
+    if explicit_scope is None and "/" in project:
+        head, _, rest = project.partition("/")
+        if rest and head in scopes:
+            explicit_scope, slug = head, rest
+
     if explicit_scope is not None:
         dir_name = scopes.get(explicit_scope)
         if dir_name is None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -339,6 +339,47 @@ class TestResolveProjectDir:
         assert result[0] == mock_vault / "00_meta"
         assert result[1] == "meta"
 
+    # ── slash-form round-trip (#235) ──
+
+    def test_slash_form_scope_qualified_resolves(self, tmp_path: Path) -> None:
+        """The slash form `vault_list` advertises (`agents/Hermes-NaN`) round-trips:
+        a leading segment that names a scope is treated as `scope:slug` (#235)."""
+        (tmp_path / "80_agents" / "Hermes-NaN").mkdir(parents=True)
+        scopes = {"projects": "10_projects", "agents": "80_agents"}
+        result = _resolve_project_dir(tmp_path, "agents/Hermes-NaN", scopes)
+        assert result is not None
+        assert result[0] == tmp_path / "80_agents" / "Hermes-NaN"
+        assert result[1] == "agents"
+
+    def test_slash_form_matches_colon_form(self, tmp_path: Path) -> None:
+        """The slash and colon forms resolve identically for a scope-qualified id."""
+        (tmp_path / "10_projects" / "testproject").mkdir(parents=True)
+        scopes = {"projects": "10_projects"}
+        slash = _resolve_project_dir(tmp_path, "projects/testproject", scopes)
+        colon = _resolve_project_dir(tmp_path, "projects:testproject", scopes)
+        assert slash is not None
+        assert slash == colon
+
+    def test_slash_form_nested_path_round_trips(self, tmp_path: Path) -> None:
+        """A full slash form `<scope>/<category>/<entity>` resolves like the colon
+        form `<scope>:<category>/<entity>` — only the first `/` is the scope."""
+        (tmp_path / "50_work" / "20-products" / "hydra3d-plus").mkdir(parents=True)
+        scopes = {"work": "50_work"}
+        result = _resolve_project_dir(tmp_path, "work/20-products/hydra3d-plus", scopes)
+        assert result is not None
+        assert result[0] == tmp_path / "50_work" / "20-products" / "hydra3d-plus"
+        assert result[1] == "work"
+
+    def test_slash_relative_path_non_scope_head_unaffected(self, tmp_path: Path) -> None:
+        """Regression: a `/` form whose head is NOT a scope key keeps its literal
+        relative-path meaning in auto-scan (the existing `_search_scope` feature)."""
+        (tmp_path / "50_work" / "20-products" / "hydra3d-plus").mkdir(parents=True)
+        scopes = {"projects": "10_projects", "work": "50_work"}
+        result = _resolve_project_dir(tmp_path, "20-products/hydra3d-plus", scopes)
+        assert result is not None
+        assert result[0] == tmp_path / "50_work" / "20-products" / "hydra3d-plus"
+        assert result[1] == "work"
+
 
 class TestStripCode:
     """Tests for _strip_code — relocated from _vault_health (HIVE-97)."""


### PR DESCRIPTION
## Problem

`vault_list()` advertises scope-qualified project ids in **slash** form (`<scope>/<project>`, e.g. `agents/hermes-nan`), but the resolver only accepted the **colon** form (`<scope>:<project>`) or the bare leaf. Feeding the advertised string back to any consumer failed:

```
vault_query(project="agents/hermes-nan", section="context")
  -> Project 'agents/hermes-nan' not found in vault.
```

The one identifier the server emits was the one form that did not round-trip.

## Fix

Normalize the leading slash-separated segment to a scope in `_resolve_project_dir` **only when it names a known scope** (Postel's law). Key points:

- Scope-aware: lives in `_resolve_project_dir` where `settings.vault_scopes` is available — no dir-name literal is hardcoded in the resolver.
- Preserves the literal relative-path meaning of `/` within a scope (e.g. `20-products/hydra3d-plus` in auto-scan) — a blind `replace('/', ':')` would have broken that and the `scope:cat/entity` colon form.
- Only the first separator is the scope boundary, so nested forms like `work/20-products/hydra3d-plus` round-trip too.

## Tests

Added to `TestResolveProjectDir` (TDD red→green):

- `test_slash_form_scope_qualified_resolves` — `agents/Hermes-NaN` resolves.
- `test_slash_form_matches_colon_form` — slash and colon forms resolve identically.
- `test_slash_form_nested_path_round_trips` — `work/20-products/hydra3d-plus`.
- `test_slash_relative_path_non_scope_head_unaffected` — regression guard for the literal relative-path feature.

`ruff` + `mypy --strict` clean; `test_helpers.py` (58) and vault-tool tests (71) green locally. Full suite via CI.

Closes #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project references now support slash-form syntax (`scope/project`) alongside the existing colon format (`scope:project`).
  * Known scope names are automatically recognized and parsed in slash-form references.
  * Backward compatibility maintained for existing relative path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->