### PR TITLE
fix(service): surface the child's stderr when a service command fails

### DIFF
--- a/src/hive/_service.py
+++ b/src/hive/_service.py
@@ -197,7 +197,13 @@ def _run(cmd: list[str]) -> int:
         print(f"hive: command not available: {cmd[0]}", file=sys.stderr)
         return 1
     if proc.returncode != 0:
-        _log.warning("hive.service %s rc=%s %s", cmd, proc.returncode, proc.stderr.strip())
+        stderr = proc.stderr.strip()
+        _log.warning("hive.service %s rc=%s %s", cmd, proc.returncode, stderr)
+        # Logging is unconfigured in the normal CLI path, so the warning above
+        # is invisible — surface the child's stderr so the user sees WHY it
+        # failed instead of a bare non-zero exit (#252).
+        if stderr:
+            print(stderr, file=sys.stderr)
     return proc.returncode
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -193,3 +193,50 @@ def test_cli_service_status_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("hive._service.service_status", lambda: 3)
     assert server._run_service(["status"]) == 3
+
+
+# ── _run surfaces failures to the user (#252 bug 1) ──────────────────────
+
+
+def test_run_prints_child_stderr_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """On a non-zero exit, _run prints the child's stderr to sys.stderr so the
+    CLI user sees WHY it failed. Logging is unconfigured in the normal CLI case,
+    so the _log.warning alone left `hive service install` exiting 1 with zero
+    output (#252)."""
+    import subprocess
+
+    import hive._service as svc
+
+    def _fake_run(*_a: object, **_k: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["schtasks"],
+            returncode=1,
+            stdout="",
+            stderr="ERROR: Access is denied.\n",
+        )
+
+    monkeypatch.setattr(svc.subprocess, "run", _fake_run)
+    rc = svc._run(["schtasks", "/Create"])
+    assert rc == 1
+    assert "Access is denied" in capsys.readouterr().err
+
+
+def test_run_is_quiet_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A successful command prints nothing — no spurious stderr noise."""
+    import subprocess
+
+    import hive._service as svc
+
+    def _fake_run(*_a: object, **_k: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["schtasks"], returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(svc.subprocess, "run", _fake_run)
+    rc = svc._run(["schtasks", "/Query"])
+    assert rc == 0
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Problem (#252, bug 1)

On Windows, `hive service install` exits non-zero with **no output** for a standard (non-admin) user, so the failure is invisible and reads as a hard break.

`_service._run()` ran the supervisor command (`schtasks`) with `capture_output=True` and, on a non-zero exit, only `_log.warning(...)`'d the captured stderr. Logging is unconfigured in the normal CLI path, so that warning goes nowhere — the user gets a bare exit code and no reason.

## Fix

`_run` now also `print(stderr, file=sys.stderr)` on a non-zero exit (when stderr is non-empty), mirroring what the missing-binary (`except`) branch already does. The user now sees the real error — e.g. `ERROR: Access is denied.` — instead of silence. A clean (zero) exit stays quiet.

## Tests (TDD)

- `test_run_prints_child_stderr_on_failure` — a mocked non-zero `subprocess.run` with stderr surfaces that stderr to `sys.stderr` (asserted via `capsys`).
- `test_run_is_quiet_on_success` — a zero exit prints nothing (no spurious noise).

`ruff check` + `ruff format --check` + `mypy --strict` clean; `test_service.py` (11) green.

## Out of scope (deferred)

Bug 2 of #252 — the hardcoded `S4U` logon type with no fallback when Task Scheduler is policy-locked (needs a Startup-folder / `HKCU\…\Run` autostart fallback) — is a larger, separate change and is intentionally **not** in this PR. This PR fixes the *silent* failure so that, when bug 2 bites, the user at least sees why.

Addresses #252 (bug 1).