### PR TITLE
fix(service): fall back to a Startup-folder launcher when Task Scheduler is locked

### DIFF
--- a/src/hive/_service.py
+++ b/src/hive/_service.py
@@ -172,16 +172,57 @@ def render_windows_task_xml(
       in session 0 — no console window — at logon, no stored password, no admin
       (the per-user analogue of ``systemd --user``).
     """
-    loop = (
-        f"while($true){{ & '{command}' {arguments}; "
-        f"if($LASTEXITCODE -eq 0){{break}} Start-Sleep -Seconds 1 }}"
+    ps_arguments = (
+        f"-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden "
+        f'-Command "{_supervisor_ps_command(command, arguments)}"'
     )
-    ps_arguments = f'-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -Command "{loop}"'
     principal_user = f"      <UserId>{escape(user)}</UserId>\n" if user else ""
     return _WINDOWS_TASK_TEMPLATE.format(
         principal_user=principal_user,
         arguments=escape(ps_arguments),
     )
+
+
+def _supervisor_ps_command(command: str, arguments: str) -> str:
+    """The PowerShell relaunch loop shared by the Scheduled Task and the
+    Startup-folder fallback — a single SSOT for the restart contract: relaunch
+    ``<command> <arguments>`` while it exits non-zero, stop on a clean exit 0
+    (drift → 75 → relaunch onto new code; clean stop / singleton-decline → 0)."""
+    return (
+        f"while($true){{ & '{command}' {arguments}; "
+        f"if($LASTEXITCODE -eq 0){{break}} Start-Sleep -Seconds 1 }}"
+    )
+
+
+def render_startup_vbs(command: str, arguments: str = "serve") -> str:
+    """A windowless Startup-folder launcher for the daemon — the fallback used
+    when Task Scheduler is policy-locked for a non-admin/domain user (#252).
+
+    ``WScript.Shell.Run(cmd, 0, False)`` launches the PowerShell supervisor loop
+    with a hidden window (style 0) and does not block — the per-user analogue of
+    the S4U Scheduled Task, carrying the identical restart contract. It writes to
+    ``shell:startup`` only, which a standard user can write, so it needs neither
+    admin nor Task Scheduler.
+    """
+    ps = (
+        f"powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden "
+        f'-Command "{_supervisor_ps_command(command, arguments)}"'
+    )
+    # A double-quote inside a VBS string literal is escaped by doubling it.
+    vbs_arg = ps.replace('"', '""')
+    return f'Set sh = CreateObject("WScript.Shell")\r\nsh.Run "{vbs_arg}", 0, False\r\n'
+
+
+def _startup_dir() -> Path:
+    """The current user's Startup folder — writable without admin, unlike the
+    policy-lockable Task Scheduler (``shell:startup``)."""
+    appdata = os.environ.get("APPDATA", "")
+    return Path(appdata) / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "Startup"
+
+
+def startup_vbs_path() -> Path:
+    """Path of the Startup-folder launcher used as the Task Scheduler fallback."""
+    return _startup_dir() / "hive-serve.vbs"
 
 
 # ── supervisor invocation (mocked in tests; real on the CI matrix) ───────
@@ -274,7 +315,36 @@ def _install_windows(*, enable: bool) -> int:
     rc = _schtasks_create(WINDOWS_TASK_NAME, xml=xml)
     if rc == 0:
         print(f"hive: registered scheduled task {WINDOWS_TASK_NAME}")
-    return rc
+        return 0
+    # Task Scheduler can be policy-locked for a non-admin/domain user; fall back
+    # to a per-user Startup launcher that needs no admin (#252).
+    return _install_windows_startup_fallback()
+
+
+def _install_windows_startup_fallback() -> int:
+    """Write a per-user Startup-folder launcher when Task Scheduler is locked.
+
+    Returns 0 on success; on a write failure it prints an actionable message and
+    returns non-zero — never a silent success that hides a broken install."""
+    exe = _resolve_exec()
+    path = startup_vbs_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(render_startup_vbs(exe), encoding="utf-8")
+    except OSError as exc:
+        print(
+            f"hive: Task Scheduler is unavailable and the Startup-folder fallback "
+            f"could not be written ({exc}). Launch `{exe} serve` at logon yourself, "
+            f"or retry `hive service install` as administrator.",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"hive: Task Scheduler unavailable — installed a per-user Startup launcher "
+        f"at {path}. The daemon starts at your next logon; run `{exe} serve` now to "
+        f"start it this session.",
+    )
+    return 0
 
 
 def install_service(*, enable: bool = True) -> int:
@@ -303,8 +373,28 @@ def uninstall_service() -> int:
         print("hive: service removed")
         return rc if rc == 0 else 0
     if plat == "windows":
-        return _run(["schtasks", "/Delete", "/TN", WINDOWS_TASK_NAME, "/F"])
+        rc = _run(["schtasks", "/Delete", "/TN", WINDOWS_TASK_NAME, "/F"])
+        # Also remove the Startup-folder fallback — it may be the only mechanism
+        # installed (Task Scheduler was locked), so a failed task delete is fine.
+        removed_fallback = _remove_startup_fallback()
+        if rc == 0 or removed_fallback:
+            print("hive: service removed")
+            return 0
+        return rc
     return _unsupported("uninstall")
+
+
+def _remove_startup_fallback() -> bool:
+    """Remove the Startup-folder launcher if present; True if it was removed."""
+    path = startup_vbs_path()
+    if not path.exists():
+        return False
+    try:
+        path.unlink()
+    except OSError as exc:
+        _log.warning("hive.service could not remove %s: %s", path, exc)
+        return False
+    return True
 
 
 def service_status() -> int:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -65,6 +65,40 @@ def test_render_windows_task_xml_uses_s4u_principal_and_supervisor_loop() -> Non
     assert "<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>" in xml
 
 
+def test_render_startup_vbs_launches_supervisor_windowless() -> None:
+    """The Startup-folder fallback (#252) launches the daemon with no window:
+    WScript.Shell.Run(..., 0, False) → hidden, non-blocking. It carries the same
+    supervisor loop as the Scheduled Task and needs no admin (shell:startup)."""
+    from hive._service import render_startup_vbs
+
+    vbs = render_startup_vbs(r"C:\Users\u\hive.exe")
+
+    assert 'CreateObject("WScript.Shell")' in vbs
+    assert ".Run " in vbs
+    assert ", 0, False" in vbs  # window style 0 (hidden), no wait
+    assert "-WindowStyle Hidden" in vbs
+    assert r"'C:\Users\u\hive.exe' serve" in vbs
+    assert "while($true)" in vbs
+    assert "if($LASTEXITCODE -eq 0){break}" in vbs  # clean exit 0 → stop
+
+
+def test_supervisor_loop_is_shared_by_task_and_startup_vbs() -> None:
+    """The relaunch loop is a single SSOT — the Scheduled Task XML and the
+    Startup-folder VBS render the identical supervisor command (no duplication)."""
+    from xml.sax.saxutils import escape
+
+    from hive._service import (
+        _supervisor_ps_command,
+        render_startup_vbs,
+        render_windows_task_xml,
+    )
+
+    loop = _supervisor_ps_command(r"C:\hive.exe", "serve")
+    assert loop in render_startup_vbs(r"C:\hive.exe")
+    # The task XML XML-escapes its arguments, so compare the escaped form.
+    assert escape(loop) in render_windows_task_xml(r"C:\hive.exe")
+
+
 # ── platform-dispatching install / uninstall / status ────────────────────
 
 
@@ -131,6 +165,72 @@ def test_install_windows_registers_scheduled_task(
     assert "<LogonTrigger>" in str(recorded["xml"])
     assert "<LogonType>S4U</LogonType>" in str(recorded["xml"])
     assert "while($true)" in str(recorded["xml"])
+
+
+def test_install_windows_falls_back_to_startup_when_schtasks_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When Task Scheduler is policy-locked (schtasks fails), install falls back
+    to a per-user Startup-folder launcher and reports success (#252 bug 2)."""
+    import hive._service as svc
+
+    vbs_path = tmp_path / "Startup" / "hive-serve.vbs"
+    monkeypatch.setattr(svc, "_platform", lambda: "windows")
+    monkeypatch.setattr(svc, "_resolve_exec", lambda: r"C:\hive.exe")
+    monkeypatch.setattr(svc, "_schtasks_create", lambda *a, **k: 1)  # policy-locked
+    monkeypatch.setattr(svc, "startup_vbs_path", lambda: vbs_path)
+
+    rc = svc.install_service(enable=True)
+
+    assert rc == 0
+    assert vbs_path.exists()
+    assert "serve" in vbs_path.read_text(encoding="utf-8")
+
+
+def test_install_windows_fallback_failure_is_not_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """If the Startup fallback can't be written either, install returns non-zero
+    with an actionable message — never a silent success (the #246 lesson)."""
+    import hive._service as svc
+
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir")  # mkdir under a file raises OSError
+    vbs_path = blocker / "sub" / "hive-serve.vbs"
+    monkeypatch.setattr(svc, "_platform", lambda: "windows")
+    monkeypatch.setattr(svc, "_resolve_exec", lambda: r"C:\hive.exe")
+    monkeypatch.setattr(svc, "_schtasks_create", lambda *a, **k: 1)
+    monkeypatch.setattr(svc, "startup_vbs_path", lambda: vbs_path)
+
+    rc = svc.install_service(enable=True)
+
+    assert rc != 0
+    assert not vbs_path.exists()
+    assert "hive" in capsys.readouterr().err.lower()
+
+
+def test_uninstall_windows_removes_startup_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Uninstall removes the Startup-folder launcher even when no Scheduled Task
+    exists (only the fallback was installed) and still reports success."""
+    import hive._service as svc
+
+    vbs_path = tmp_path / "Startup" / "hive-serve.vbs"
+    vbs_path.parent.mkdir(parents=True)
+    vbs_path.write_text("stub", encoding="utf-8")
+    monkeypatch.setattr(svc, "_platform", lambda: "windows")
+    monkeypatch.setattr(svc, "startup_vbs_path", lambda: vbs_path)
+    monkeypatch.setattr(svc, "_run", lambda *a, **k: 1)  # no Scheduled Task to delete
+
+    rc = svc.uninstall_service()
+
+    assert rc == 0
+    assert not vbs_path.exists()
 
 
 def test_install_macos_is_a_clear_stub(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem (#252, bug 2)

On a domain-joined / non-admin Windows box, **registering** the S4U Scheduled Task can be blocked by machine policy entirely (it is not the logon type — `schtasks /Create` of any kind returns `Access is denied`). So `hive service install` had no way to autostart the daemon for exactly the users who most need the per-user fallback.

(Companion PR #274 fixes bug 1 — `_run` swallowing the stderr that told you *why* `schtasks` failed. That made this failure mode look like a hard break; this PR gives it a recovery path.)

## Fix

When `_schtasks_create` fails, install now falls back to a **per-user Startup-folder launcher** — the true Windows analogue of `systemd --user` on a locked-down box:

- A `.vbs` in `shell:startup` (`%APPDATA%\…\Startup`, writable without admin) that launches the daemon **windowless**: `WScript.Shell.Run(cmd, 0, False)` (hidden window, non-blocking) running the same PowerShell supervisor loop with `-WindowStyle Hidden`.
- The relaunch loop is extracted into `_supervisor_ps_command`, so the Scheduled Task XML and the VBS render from **one SSOT** (no duplicated restart contract).
- `uninstall` removes the launcher even when no Scheduled Task exists (the fallback may be the only thing installed).
- A fallback that **cannot** be written reports a non-zero exit with an actionable WHY/FIX message — never a silent success (the #246 lesson).

### Design notes
- **VBS over `HKCU\…\Run`**: `Run(…, 0)` is genuinely windowless; an `HKCU\Run` launching `hive serve` directly would flash a console. Complementary to #251 (which suppresses the console flash of the daemon's *git* child processes) — together they make the fallback-launched daemon fully silent.
- **VBS over `.lnk`**: a VBS is a plain text file — trivial to render, test, and remove; a shortcut needs COM.
- **Double-launch** is harmless: the daemon is single-owner (a second `serve` declines with exit 0), and the VBS is only written when the task registration actually failed.

## Tests (TDD)

- `test_render_startup_vbs_launches_supervisor_windowless` — the renderer: `WScript.Shell.Run(…, 0, False)`, hidden PS, the supervisor loop.
- `test_supervisor_loop_is_shared_by_task_and_startup_vbs` — the loop is one SSOT across both renderers.
- `test_install_windows_falls_back_to_startup_when_schtasks_blocked` — schtasks fails → VBS written, rc 0.
- `test_install_windows_fallback_failure_is_not_silent` — write also fails → non-zero rc + actionable stderr.
- `test_uninstall_windows_removes_startup_fallback` — uninstall removes the VBS even with no task present.

`ruff check` + `ruff format --check` + `mypy --strict` clean; `test_service.py` (14) green.

Closes #252