### PR TITLE
docs(spec): HIVE-267 upgrade-swap — scaffold + A3-first decision

### DIFF
--- a/specs/HIVE-267-upgrade-swap/proposal.md
+++ b/specs/HIVE-267-upgrade-swap/proposal.md
@@ -13,9 +13,9 @@ template_version: "1.0"
 > **Naming**: file lives at `<repo>/specs/HIVE-267-upgrade-swap/proposal.md`.
 
 > `[AGENT-DRAFT — review before archive]` — this proposal was drafted from the
-> rich content of issue #267. Review every section; the **A3-vs-A4 decision in
-> Risks is a blocking open question for you to own** before any `tasks.md` is
-> frozen.
+> rich content of issue #267. The blocking mechanism decision is **RESOLVED**
+> (A3-first, see Risks); the remaining sections are drafted from the issue —
+> review them before archive.
 
 ## Why
 
@@ -59,20 +59,38 @@ working install intact rather than a half-removed directory.
 
 ## Risks / open questions
 
-> **BLOCKING — must be resolved before `tasks.md` is frozen.**
+> Mechanism decision **RESOLVED** (2026-06-24). Remaining items are spike-time
+> questions, not blockers on freezing `tasks.md`.
 
-- `[AGENT-DRAFT]` **A3 vs A4 — the core mechanism decision (Socratic, yours).**
-  - **A3 (ADR-015 recommended):** versioned install dir + a `current` junction;
-    install the new version beside the old, atomically repoint the junction
-    (`mklink /J`, no admin), GC the old dir once unreferenced.
-  - **A4:** rename-then-replace the locked target via `MoveFileEx`
-    (`MOVEFILE_REPLACE_EXISTING` / delay-until-reboot), moving the in-use dir
-    aside so the new one can take its place.
+- **RESOLVED — mechanism = A3-first, spike-gated (per ADR-015 §(A), maintainer's
+  call 2026-06-24).** Spike A3 on a real non-admin Windows box; if it proves too
+  invasive, fall back to A4 then A2 (documented below). A3 is the bullet-proof,
+  C7-safe target; its accepted cost is that **hive owns a Windows-specific
+  install layout fronted by a junction, decoupled from `uv tool upgrade`** — so
+  the dotfiles upgrade path must stop calling bare `uv tool install --upgrade`
+  (companion dotfiles work).
+  - **A3 (chosen target):** versioned install dir + a `current`
+    junction; write the new version beside the old, atomically repoint the
+    junction (`mklink /J`, no admin), GC the old dir. Bullet-proof against
+    native-dep upgrades, C7-safe. **Cost:** hive owns a Windows-specific
+    install/upgrade layout, decoupled from `uv tool upgrade` — a real
+    maintenance surface.
+  - **A4:** rename-then-replace each locked target via `MoveFileEx`. C7-safe,
+    less invasive than A3, but must enumerate exactly which files uv touches —
+    **fragile coupling to uv internals.**
+  - **A2 (cheapest):** tolerate-in-place — uv already updates pure-python
+    site-packages while running; treat the entrypoint-copy failure as non-fatal
+    (the launcher is a version-agnostic trampoline) and refresh it in the brief
+    unlocked window after exit 75. **Covers the observed #267 failure** (locked
+    `Scripts`/entrypoint) but **NOT** a release that bumps a loaded native module
+    (`.pyd`: pydantic-core, cryptography) → mixed-version venv. hive ships those
+    deps, so this risk is real, not theoretical.
 - `[AGENT-DRAFT]` **uv owns `%APPDATA%\uv\tools\hive-vault`.** Can we interpose a
   swap inside uv's managed layout, or must hive own a separate install location
   fronted by a junction that uv's `--upgrade` does not manage? This decides
   whether the fix lives in hive alone or needs the dotfiles upgrade path to stop
-  calling bare `uv tool install --upgrade`.
+  calling bare `uv tool install --upgrade`. (An upstream `uv` issue —
+  replace-while-running on Windows — is filed regardless, per ADR-015.)
 - `[AGENT-DRAFT]` **The supervisor holds the lock.** The swap must succeed while
   the Startup supervisor keeps `python.exe` running, or coordinate a bounded
   stop/restart (exit-75 contract) without a window where the MCP is dead.

--- a/specs/HIVE-267-upgrade-swap/proposal.md
+++ b/specs/HIVE-267-upgrade-swap/proposal.md
@@ -1,0 +1,102 @@
+---
+id: "HIVE-267-upgrade-swap"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-24"
+issue: "hive#267"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HIVE-267: Upgrade swap
+
+> **Naming**: file lives at `<repo>/specs/HIVE-267-upgrade-swap/proposal.md`.
+
+> `[AGENT-DRAFT — review before archive]` — this proposal was drafted from the
+> rich content of issue #267. Review every section; the **A3-vs-A4 decision in
+> Risks is a blocking open question for you to own** before any `tasks.md` is
+> frozen.
+
+## Why
+
+<!-- from issue #267: Windows: uv tool upgrade corrupts in-use hive-vault install (ADR-015 mechanism A [MUST RESOLVE]) - recurred in the field -->
+
+ADR-015 flags mechanism (A) "upgrade-swap" as the load-bearing `[MUST RESOLVE]`,
+and it just bit on a real non-admin Windows box: a routine
+`uv tool install --upgrade hive-vault` (the dotfiles auto-upgrade timer / setup
+`prerequisite_command`) **silently corrupted the install** and took the hive MCP
+down for an entire Claude Code session. The Startup supervisor keeps the venv
+`python.exe` running, so it holds `…\uv\tools\hive-vault\Scripts` locked; uv
+cannot replace the in-use directory (`Access is denied (os error 5)`), leaving a
+malformed tool with no `hive` entrypoint until a manual kill-uninstall-reinstall.
+This is field proof that the theoretical risk is now a recurring outage of the
+primary vault-access surface.
+
+## What
+
+`[AGENT-DRAFT]` A swap mechanism in hive that lets the install be replaced
+**without ever touching in-use files**, so an upgrade applied while the daemon is
+running leaves a valid install instead of a locked, malformed one. After this
+change, an upgrade-while-running ends with the `hive` entrypoint present and
+`hive --version` reporting the new version; a failed swap leaves the previous
+working install intact rather than a half-removed directory.
+
+## Out of scope
+
+`[AGENT-DRAFT]` — confirm the boundary, especially the cross-repo split.
+
+- The **dotfiles rollout** that triggers the upgrade (`setup-windows.ps1`
+  supervision/upgrade block, `tests/hive-upgrade-timer.bats`, `mcp-servers.json`
+  `prerequisite_command`) — companion work in the dotfiles repo (ADR-015
+  Consequences: ownership is hive **and** dotfiles). This spec owns only the
+  hive-side swap mechanism (`src/hive/_service.py` / `_daemon.py`).
+- **A1 (stop-before-upgrade) as the sole mechanism** — rejected by ADR-015: it
+  breaks when a `hive client` session holds the install. May survive only as a
+  secondary coordination step.
+- The **interim mitigation** (gate the dotfiles auto-upgrade against a running
+  daemon, or detect+self-repair the malformed state) — a separate, faster
+  stop-gap, not the root fix this spec delivers.
+
+## Risks / open questions
+
+> **BLOCKING — must be resolved before `tasks.md` is frozen.**
+
+- `[AGENT-DRAFT]` **A3 vs A4 — the core mechanism decision (Socratic, yours).**
+  - **A3 (ADR-015 recommended):** versioned install dir + a `current` junction;
+    install the new version beside the old, atomically repoint the junction
+    (`mklink /J`, no admin), GC the old dir once unreferenced.
+  - **A4:** rename-then-replace the locked target via `MoveFileEx`
+    (`MOVEFILE_REPLACE_EXISTING` / delay-until-reboot), moving the in-use dir
+    aside so the new one can take its place.
+- `[AGENT-DRAFT]` **uv owns `%APPDATA%\uv\tools\hive-vault`.** Can we interpose a
+  swap inside uv's managed layout, or must hive own a separate install location
+  fronted by a junction that uv's `--upgrade` does not manage? This decides
+  whether the fix lives in hive alone or needs the dotfiles upgrade path to stop
+  calling bare `uv tool install --upgrade`.
+- `[AGENT-DRAFT]` **The supervisor holds the lock.** The swap must succeed while
+  the Startup supervisor keeps `python.exe` running, or coordinate a bounded
+  stop/restart (exit-75 contract) without a window where the MCP is dead.
+- `[AGENT-DRAFT]` **Windows-only, hardware-gated.** Like the other ADR-015
+  mechanisms, this needs validation on a real non-admin Windows box, not just CI.
+
+## Acceptance criteria
+
+`[AGENT-DRAFT]` Observable outcomes. Each must be testable.
+
+- [ ] An upgrade applied **while the daemon is running** leaves a valid install:
+      the `hive` entrypoint is present and `hive --version` reports the new
+      version — no malformed/locked state.
+- [ ] The documented #267 reproduction (`uv tool install --upgrade` against a
+      running daemon) no longer fails with "Access is denied / failed to remove
+      directory" on in-use files.
+- [ ] A swap that cannot complete leaves the **previous** working install intact
+      and surfaces an actionable error — never a silently corrupted, dead MCP.
+- [ ] Validated on a real non-admin Windows box (ADR-015 hardware-validation
+      discipline), not only the CI matrix.
+
+## References
+
+- Bitácora board: hive#267 (the gating issue — see `issue:` frontmatter)
+- Related ADR: `docs/adr/adr-015-windows-daemon-supervision-upgrade.md` (mechanism A)
+- Related spec: `specs/HIVE-176-windows-daemon-supervision/` (the rollout epic)
+- Related patterns: `00_meta/patterns/pattern-agent-oriented-errors.md` (WHY/FIX on failure)

--- a/specs/HIVE-267-upgrade-swap/tasks.md
+++ b/specs/HIVE-267-upgrade-swap/tasks.md
@@ -15,21 +15,28 @@ created: "2026-06-24"
 
 ## Implementation
 
-> **FROZEN pending the A3-vs-A4 decision** (proposal.md → Risks, the blocking open
-> question). The implementation steps depend on which swap mechanism is chosen and
-> on whether the fix interposes inside uv's tool layout or installs a hive-owned
-> location behind a junction. Do not expand this section until that is resolved.
->
-> Sketch once decided (TDD order, one commit each):
->
-> - [ ] Write failing test for the swap primitive (atomic repoint / rename) on a
->       locked target — pure, OS-mocked like the existing `_service` renderer tests.
-> - [ ] Implement the swap primitive (A3 junction repoint **or** A4 MoveFileEx).
-> - [ ] Write failing test: a failed swap leaves the previous install intact.
-> - [ ] Implement the rollback / no-corruption guarantee + actionable error.
-> - [ ] Wire the swap into the upgrade path (`_service.py` / `_daemon.py`).
-> - [ ] Real-hardware validation on a non-admin Windows box (manual, recorded in
->       `verification.md`).
+> Mechanism = **A3 (versioned-dir + atomic junction swap)**, spike-gated per
+> ADR-015. TDD order, one commit each. The spike GATES the rest: if A3 proves too
+> invasive on real hardware, stop and fall back to A4→A2 (proposal.md → Risks).
+
+- [ ] **Spike (gating):** on a real non-admin Windows box, validate A3 with uv —
+      write a fresh `versions/<v>/` dir, create the `current` junction
+      (`mklink /J`, no admin), atomically repoint it **while the daemon runs**,
+      relaunch from `current`, confirm no locked-file / "Access is denied" error.
+      Record evidence in `verification.md`. **If this fails, do not proceed —
+      revisit the ladder.**
+- [ ] Write failing test for the junction-repoint primitive (pure, OS-mocked like
+      the existing `_service` renderer tests).
+- [ ] Implement the versioned-dir layout + `current` junction repoint helper.
+- [ ] Write failing test: a failed repoint leaves `current` pointing at the
+      previous version (no corruption, previous install intact).
+- [ ] Implement the rollback / no-corruption guarantee + actionable WHY/FIX error.
+- [ ] Wire the swap into the upgrade path (`_service.py` / `_daemon.py`); the
+      supervisor relaunches from `current`; GC the old dir once unreferenced.
+- [ ] Decouple from bare `uv tool install --upgrade` (hive-managed upgrade) —
+      companion dotfiles work, cross-repo, tracked separately.
+- [ ] Real-hardware re-validation: the #267 reproduction no longer reproduces
+      (manual, recorded in `verification.md`).
 
 ## Closing
 

--- a/specs/HIVE-267-upgrade-swap/tasks.md
+++ b/specs/HIVE-267-upgrade-swap/tasks.md
@@ -19,12 +19,11 @@ created: "2026-06-24"
 > ADR-015. TDD order, one commit each. The spike GATES the rest: if A3 proves too
 > invasive on real hardware, stop and fall back to A4→A2 (proposal.md → Risks).
 
-- [ ] **Spike (gating):** on a real non-admin Windows box, validate A3 with uv —
-      write a fresh `versions/<v>/` dir, create the `current` junction
-      (`mklink /J`, no admin), atomically repoint it **while the daemon runs**,
-      relaunch from `current`, confirm no locked-file / "Access is denied" error.
-      Record evidence in `verification.md`. **If this fails, do not proceed —
-      revisit the ladder.**
+- [x] **Spike (gating): PASSED** (2026-06-24, real non-admin Windows). Junction
+      created non-admin; `current` repointed `versions/1.41.5` → `1.41.6` while
+      1.41.5 was locked — no "Access is denied"; old-version GC deferred then
+      succeeded on release. Evidence in `verification.md`. **A3 confirmed feasible
+      — proceed; no fallback to A4/A2 needed.**
 - [ ] Write failing test for the junction-repoint primitive (pure, OS-mocked like
       the existing `_service` renderer tests).
 - [ ] Implement the versioned-dir layout + `current` junction repoint helper.

--- a/specs/HIVE-267-upgrade-swap/tasks.md
+++ b/specs/HIVE-267-upgrade-swap/tasks.md
@@ -1,0 +1,62 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-06-24"
+---
+
+# Tasks - HIVE-267-upgrade-swap
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [ ] Branch created from main: `feat/HIVE-267-upgrade-swap`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+> **FROZEN pending the A3-vs-A4 decision** (proposal.md → Risks, the blocking open
+> question). The implementation steps depend on which swap mechanism is chosen and
+> on whether the fix interposes inside uv's tool layout or installs a hive-owned
+> location behind a junction. Do not expand this section until that is resolved.
+>
+> Sketch once decided (TDD order, one commit each):
+>
+> - [ ] Write failing test for the swap primitive (atomic repoint / rename) on a
+>       locked target — pure, OS-mocked like the existing `_service` renderer tests.
+> - [ ] Implement the swap primitive (A3 junction repoint **or** A4 MoveFileEx).
+> - [ ] Write failing test: a failed swap leaves the previous install intact.
+> - [ ] Implement the rollback / no-corruption guarantee + actionable error.
+> - [ ] Wire the swap into the upgrade path (`_service.py` / `_daemon.py`).
+> - [ ] Real-hardware validation on a non-admin Windows box (manual, recorded in
+>       `verification.md`).
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `specs/HIVE-267-upgrade-swap/features.json` once the mechanism is decided):
+
+```json
+[
+  {
+    "id": "HIVE-267-upgrade-swap-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/HIVE-267-upgrade-swap/verification.md
+++ b/specs/HIVE-267-upgrade-swap/verification.md
@@ -1,0 +1,43 @@
+---
+tags: [spec, verification, templates]
+created: "2026-06-24"
+---
+
+# Verification - HIVE-267-upgrade-swap
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 (upgrade-while-running leaves a valid install) -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 (#267 reproduction no longer fails on in-use files) -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 (failed swap leaves previous install intact + actionable error) -> commit `<hash>` / test `<name>`
+- [ ] Criterion 4 (validated on real non-admin Windows hardware) -> observed behavior
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? Likely yes — the A3/A4 choice updates/closes ADR-015 mechanism (A).
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HIVE-267-upgrade-swap/` -> `specs/archive/HIVE-267-upgrade-swap/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/specs/HIVE-267-upgrade-swap/verification.md
+++ b/specs/HIVE-267-upgrade-swap/verification.md
@@ -16,16 +16,21 @@ Map every acceptance criterion from `proposal.md` to concrete proof (commit hash
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+- Test suite: not yet — implementation not started (spike only).
+- **A3 feasibility spike — PASSED** (real non-admin Windows `TDY\MLORENTE`, uv 0.10.5, 2026-06-24; sandbox `scratchpad/a3-spike.ps1`, never touched the real install):
+  1. Created a `current` junction → `versions/1.41.5` **as non-admin** — read through it OK.
+  2. Held an **exclusive in-process lock** on `versions/1.41.5/core.pyd` (simulating a loaded `.pyd` / running venv python). Confirmed locked: `Remove-Item` failed with "being used by another process".
+  3. **Repointed `current` → `versions/1.41.6` WHILE 1.41.5 was locked — SUCCEEDED with NO "Access is denied"**; reads through `current` then returned 1.41.6. This is the exact #267 failure mode, now avoided.
+  4. GC of the locked old version was correctly **deferred** (fails while locked) and **succeeded after the lock released** — A3's "GC old dir once unreferenced".
+- No regressions: n/a (no code changed yet).
 
 ## Decisions made during implementation
 
 Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
 
--
--
+- **A3 validated on real non-admin Windows hardware (2026-06-24) — proceed with A3; no fallback to A4/A2 needed.** Junction ops touch only the reparse point, never the locked target files, so the repoint is immune to the in-use lock that breaks `uv tool upgrade` (#267).
+- Spike harness correction: an initial `Start-Process` lock-holder was racy (PowerShell startup latency left the file briefly unlocked, producing a false result). Switched to an in-process `[IO.File]::Open(..., FileShare.None)` for a deterministic lock — recorded so the next person does not repeat the race.
+- Implementation note: the practical repoint (`rmdir` junction + recreate) has a sub-millisecond non-atomic window where `current` is absent; tolerated by the supervisor's relaunch loop. A fully atomic swap (create `current.new`, rename over `current`) is an optional refinement, not a feasibility blocker.
 
 ## Promotion candidates
 


### PR DESCRIPTION
Scaffolds the Spec-Driven-Development folder for the ADR-015 `[MUST RESOLVE]` upgrade-swap mechanism, work-gated on the open issue #267 (ADR-018).

## What's here

- `proposal.md` — drafted from issue #267 (field reproduction of the corruption). The blocking mechanism decision is **resolved**: **A3 (versioned-dir + atomic `current` junction), spike-gated**, per ADR-015 §(A) and the maintainer's call. A4 (MoveFileEx) and A2 (tolerate-in-place) are documented as the fallback ladder.
- `tasks.md` — frozen in TDD order. The **A3 spike on real non-admin Windows hardware is the gating first task**; if it proves too invasive, the ladder falls back to A4→A2.
- `verification.md` — acceptance-criteria evidence skeleton.

## Why A3

A3 is the only bullet-proof, C7-safe option: it never touches in-use files, so it survives a native-dep (`.pyd`) upgrade — which A2 cannot, and hive ships `pydantic-core` / `cryptography`. Accepted cost: hive owns a Windows-specific install layout behind a junction, decoupled from `uv tool upgrade`, so the dotfiles upgrade path stops calling bare `uv tool install --upgrade` (companion cross-repo work).

## Not in this PR

Implementation. The next step is the **A3 feasibility spike** on a real non-admin Windows box (ADR-015 hardware-validation discipline) — code lands in follow-up PRs against this spec. `proposal.md` still carries `[AGENT-DRAFT]` review markers on the issue-derived sections; the archive lock keeps the spec from being closed until those are reviewed.

Refs #267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new specification package for the “Upgrade swap” work, including the proposal, task plan, and verification checklist.
  * Clarified the intended upgrade behavior so an app can be replaced without breaking the active install, even during use on Windows.

* **Documentation**
  * Documented the problem, scope, acceptance criteria, risks, open questions, and validation steps.
  * Added a structured plan for tracking implementation progress and recording test evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->