### PR TITLE
docs(spec): resolve interposition (hive-owned layout) for HIVE-267

### DIFF
--- a/specs/HIVE-267-upgrade-swap/proposal.md
+++ b/specs/HIVE-267-upgrade-swap/proposal.md
@@ -85,12 +85,17 @@ working install intact rather than a half-removed directory.
     `Scripts`/entrypoint) but **NOT** a release that bumps a loaded native module
     (`.pyd`: pydantic-core, cryptography) → mixed-version venv. hive ships those
     deps, so this risk is real, not theoretical.
-- `[AGENT-DRAFT]` **uv owns `%APPDATA%\uv\tools\hive-vault`.** Can we interpose a
-  swap inside uv's managed layout, or must hive own a separate install location
-  fronted by a junction that uv's `--upgrade` does not manage? This decides
-  whether the fix lives in hive alone or needs the dotfiles upgrade path to stop
-  calling bare `uv tool install --upgrade`. (An upstream `uv` issue —
-  replace-while-running on Windows — is filed regardless, per ADR-015.)
+- **RESOLVED — interposition = hive owns the versioned layout (2026-06-24).**
+  `uv tool` has no per-version dir (it always rewrites the same dir), so hive
+  manages its own root: `%LOCALAPPDATA%\hive\runtime\versions\<v>\` (each a full
+  venv built fresh by `uv venv` + `uv pip install hive-vault==<v>` — uv/pip still
+  does the heavy lifting), a `current` junction → the active version, and a
+  launcher that resolves through `current`. The dotfiles upgrade trigger calls a
+  new `hive self-upgrade` instead of bare `uv tool install --upgrade`.
+  **Consequence (accepted):** on Windows hive is no longer a plain `uv tool` —
+  `uv tool list` shows a stale/unmanaged entry; documented as expected. (An
+  upstream `uv` issue — replace-while-running on Windows — is filed regardless,
+  per ADR-015.)
 - `[AGENT-DRAFT]` **The supervisor holds the lock.** The swap must succeed while
   the Startup supervisor keeps `python.exe` running, or coordinate a bounded
   stop/restart (exit-75 contract) without a window where the MCP is dead.

--- a/specs/HIVE-267-upgrade-swap/tasks.md
+++ b/specs/HIVE-267-upgrade-swap/tasks.md
@@ -24,16 +24,27 @@ created: "2026-06-24"
       1.41.5 was locked — no "Access is denied"; old-version GC deferred then
       succeeded on release. Evidence in `verification.md`. **A3 confirmed feasible
       — proceed; no fallback to A4/A2 needed.**
+> Interposition = **hive owns the layout** (`%LOCALAPPDATA%\hive\runtime\versions\<v>`
+> + `current` junction + own launcher; versions built via `uv venv` + `uv pip
+> install`; dotfiles upgrade calls `hive self-upgrade`). Likely a new
+> `src/hive/_runtime.py` (layout/junction/GC) + a `hive self-upgrade` subcommand.
+
 - [ ] Write failing test for the junction-repoint primitive (pure, OS-mocked like
       the existing `_service` renderer tests).
-- [ ] Implement the versioned-dir layout + `current` junction repoint helper.
-- [ ] Write failing test: a failed repoint leaves `current` pointing at the
-      previous version (no corruption, previous install intact).
+- [ ] Implement the repoint primitive + versioned-layout paths
+      (`runtime_root()`, `versions_dir()`, `current_link()`, `repoint(current, v)`).
+- [ ] Write failing test: a failed repoint leaves `current` at the previous
+      version (no corruption, previous install intact).
 - [ ] Implement the rollback / no-corruption guarantee + actionable WHY/FIX error.
-- [ ] Wire the swap into the upgrade path (`_service.py` / `_daemon.py`); the
-      supervisor relaunches from `current`; GC the old dir once unreferenced.
-- [ ] Decouple from bare `uv tool install --upgrade` (hive-managed upgrade) —
-      companion dotfiles work, cross-repo, tracked separately.
+- [ ] Implement "build a version into a fresh dir" (`uv venv` + `uv pip install
+      hive-vault==<v>`), never touching the in-use one; GC old versions once
+      unreferenced.
+- [ ] Add the `hive self-upgrade [<version>]` subcommand wiring the above; the
+      launcher (`~/.local/bin`) + supervisor resolve through `current`.
+- [ ] **Companion (dotfiles, cross-repo):** replace the bare `uv tool install
+      --upgrade` trigger (`setup-windows.ps1` timer / `mcp-servers.json`
+      `prerequisite_command`) with `hive self-upgrade`. Document the
+      "no-longer-a-uv-tool on Windows" consequence.
 - [ ] Real-hardware re-validation: the #267 reproduction no longer reproduces
       (manual, recorded in `verification.md`).
 


### PR DESCRIPTION
Follow-up to #277 (spec scaffold + passing A3 spike). Resolves the spec's **second open question** — how hive's A3 versioned-dir+junction layout interposes relative to uv.

## Decision

**hive owns the versioned layout.** `uv tool` has no per-version dir (it always rewrites the same dir — the #267 hazard), so hive manages its own root:

- `%LOCALAPPDATA%\hive\runtime\versions\<v>\` — each a full venv built fresh by `uv venv` + `uv pip install hive-vault==<v>` (uv/pip still does dependency resolution; hive only owns the layout + swap).
- `current` junction → the active version; the launcher (`~/.local/bin`) + supervisor resolve through `current`.
- The dotfiles upgrade trigger calls a new `hive self-upgrade` instead of bare `uv tool install --upgrade`.

**Accepted consequence:** on Windows, hive is no longer a plain `uv tool` (`uv tool list` shows a stale/unmanaged entry) — documented as expected.

## Effect on the spec

- `proposal.md` — the "uv owns the dir" risk is marked RESOLVED with the layout above.
- `tasks.md` — implementation steps concretised: a likely `src/hive/_runtime.py` (layout/junction/GC), a `hive self-upgrade` subcommand, and the cross-repo dotfiles trigger swap.

Both open questions are now resolved; the spec is decision-complete and ready for the first implementation PR (the junction-repoint primitive, TDD). `[AGENT-DRAFT]` review markers remain on the issue-derived sections per the archive lock.

Refs #267