### PR TITLE
feat(runtime): versioned install layout + junction repoint (HIVE-267)

### DIFF
--- a/specs/HIVE-267-upgrade-swap/features.json
+++ b/specs/HIVE-267-upgrade-swap/features.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "HIVE-267-upgrade-swap-f1",
+    "behavior": "An upgrade applied while the daemon is running leaves a valid, resolvable install: current points at the new version (repoint primitive).",
+    "verification": "python -m pytest tests/test_runtime.py::test_repoint_points_current_at_the_target_version tests/test_runtime.py::test_repoint_replaces_an_existing_current -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-267-upgrade-swap-f3",
+    "behavior": "A swap that cannot complete leaves the previous working install intact and surfaces an actionable WHY/FIX error, never a corrupted/dead MCP.",
+    "verification": "python -m pytest tests/test_runtime.py::test_failed_repoint_leaves_the_previous_current_intact -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-267-upgrade-swap-f2",
+    "behavior": "The documented #267 reproduction (uv tool install --upgrade against a running daemon) no longer fails on in-use files.",
+    "verification": "manual: real non-admin Windows re-validation. Pending the `hive self-upgrade` PR that builds each version into its own dir and wires repoint() to the upgrade trigger.",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-267-upgrade-swap-f4",
+    "behavior": "Validated on a real non-admin Windows box (ADR-015 hardware-validation discipline), not only the CI matrix.",
+    "verification": "manual: recorded in specs/HIVE-267-upgrade-swap/verification.md. Pending end-to-end wiring (self-upgrade subcommand + dotfiles trigger swap).",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/HIVE-267-upgrade-swap/tasks.md
+++ b/specs/HIVE-267-upgrade-swap/tasks.md
@@ -9,7 +9,7 @@ created: "2026-06-24"
 
 ## Setup
 
-- [ ] Branch created from main: `feat/HIVE-267-upgrade-swap`
+- [x] Branch created from main: `feat/HIVE-267-upgrade-swap`
 - [ ] `proposal.md` is complete and acceptance criteria are testable
 - [ ] No open questions left in `proposal.md` "Risks / open questions"
 
@@ -29,13 +29,19 @@ created: "2026-06-24"
 > install`; dotfiles upgrade calls `hive self-upgrade`). Likely a new
 > `src/hive/_runtime.py` (layout/junction/GC) + a `hive self-upgrade` subcommand.
 
-- [ ] Write failing test for the junction-repoint primitive (pure, OS-mocked like
-      the existing `_service` renderer tests).
-- [ ] Implement the repoint primitive + versioned-layout paths
-      (`runtime_root()`, `versions_dir()`, `current_link()`, `repoint(current, v)`).
-- [ ] Write failing test: a failed repoint leaves `current` at the previous
-      version (no corruption, previous install intact).
-- [ ] Implement the rollback / no-corruption guarantee + actionable WHY/FIX error.
+- [x] Write failing test for the junction-repoint primitive. Renderer (`mklink /J`
+      argv) asserted as a string like the `_service` renderers; the repoint
+      orchestration runs a **real** symlink on POSIX CI / a real junction on
+      Windows (single OS seam `_make_junction`), so criterion 3 is exercised, not
+      only mocked. `tests/test_runtime.py`.
+- [x] Implement the repoint primitive + versioned-layout paths
+      (`runtime_root()`, `versions_dir()`, `version_path()`, `current_link()`,
+      `repoint(version)`) in `src/hive/_runtime.py`.
+- [x] Write failing test: a failed repoint leaves `current` at the previous
+      version (`test_failed_repoint_leaves_the_previous_current_intact`).
+- [x] Implement the rollback / no-corruption guarantee (stage-then-flip: the
+      fallible `_make_junction` runs before `current` is disturbed) + actionable
+      WHY/FIX `RuntimeError`.
 - [ ] Implement "build a version into a fresh dir" (`uv venv` + `uv pip install
       hive-vault==<v>`), never touching the in-use one; GC old versions once
       unreferenced.

--- a/specs/HIVE-267-upgrade-swap/tasks.md
+++ b/specs/HIVE-267-upgrade-swap/tasks.md
@@ -42,9 +42,11 @@ created: "2026-06-24"
 - [x] Implement the rollback / no-corruption guarantee (stage-then-flip: the
       fallible `_make_junction` runs before `current` is disturbed) + actionable
       WHY/FIX `RuntimeError`.
-- [ ] Implement "build a version into a fresh dir" (`uv venv` + `uv pip install
+- [x] Implement "build a version into a fresh dir" (`uv venv` + `uv pip install
       hive-vault==<v>`), never touching the in-use one; GC old versions once
-      unreferenced.
+      unreferenced. `_runtime.build_version()` (cleans a half-built dir on
+      failure), `current_version()`, `remove_version()` (refuses the active
+      version; defers a locked dir instead of crashing).
 - [ ] Add the `hive self-upgrade [<version>]` subcommand wiring the above; the
       launcher (`~/.local/bin`) + supervisor resolve through `current`.
 - [ ] **Companion (dotfiles, cross-repo):** replace the bare `uv tool install

--- a/src/hive/_runtime.py
+++ b/src/hive/_runtime.py
@@ -20,6 +20,7 @@ primitive (``mklink /J``) is validated by real hardware — mirroring how
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -174,3 +175,99 @@ def repoint(version: str) -> None:
     # done, so this tail effectively never fails.
     _remove_link(current_link())
     os.rename(staging, current_link())
+
+
+# ── version lifecycle: build a fresh dir + GC unreferenced ones ──────────
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    """The interpreter inside a uv-built venv, for ``uv pip install --python``."""
+    if sys.platform == "win32":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _run_uv(args: list[str]) -> None:
+    """Run ``uv <args>``, raising an actionable ``RuntimeError`` on failure.
+
+    The single ``uv`` seam (mocked in unit tests; the real tool validated by the
+    CI matrix), mirroring how ``_service`` treats schtasks/systemctl."""
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["uv", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            **_subprocess_run_kwargs(),
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "hive self-upgrade: `uv` is not on PATH — install uv (astral.sh/uv) "
+            "or run the upgrade manually.",
+        ) from exc
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"`uv {' '.join(args)}` failed (rc={proc.returncode}): {proc.stderr.strip()}",
+        )
+
+
+def build_version(version: str, *, package: str = "hive-vault") -> Path:
+    """Build *version* into its own dir under ``versions/``, never touching the
+    in-use install; return the new version dir.
+
+    Uses uv exactly as the manual path would — ``uv venv <dir>`` then
+    ``uv pip install --python <dir> <package>==<version>`` — so uv/pip do the
+    heavy lifting and hive only owns *where* the version lands. A build that
+    fails part-way is cleaned up: a half-built dir must never survive to be
+    repointed-at (that corrupt-dir state is the #267 failure mode)."""
+    target = version_path(version)
+    if target.exists():
+        raise RuntimeError(
+            f"hive self-upgrade: version {version} is already built at {target}; "
+            f"remove it before rebuilding.",
+        )
+    versions_dir().mkdir(parents=True, exist_ok=True)
+    try:
+        _run_uv(["venv", str(target)])
+        _run_uv(["pip", "install", "--python", str(_venv_python(target)), f"{package}=={version}"])
+    except RuntimeError as exc:
+        shutil.rmtree(target, ignore_errors=True)
+        raise RuntimeError(
+            f"hive self-upgrade: could not build version {version} into {target} "
+            f"({exc}). The in-use install is untouched.",
+        ) from exc
+    return target
+
+
+def current_version() -> str | None:
+    """The version the ``current`` junction selects, or ``None`` if unset.
+
+    Resolves through the reparse point and returns the target dir's name (the
+    version string) — the read side GC uses to avoid deleting the active one."""
+    link = current_link()
+    if not (link.is_symlink() or link.is_junction()):
+        return None
+    return link.resolve().name
+
+
+def remove_version(version: str) -> bool:
+    """GC an installed *version* dir; return whether it was actually removed.
+
+    Refuses to remove the active version (that would pull the running install
+    out from under the daemon). A still-locked dir — the old version whose
+    ``python.exe`` the supervisor has not yet released — is a DEFERRED GC, not a
+    crash: return ``False`` so the caller retries after the lock drops (the
+    spike's 'GC old dir once unreferenced' step)."""
+    if version == current_version():
+        raise RuntimeError(
+            f"hive self-upgrade: refusing to remove the active version {version}; "
+            f"repoint to another version first.",
+        )
+    target = version_path(version)
+    if not target.exists():
+        return False
+    try:
+        shutil.rmtree(target)
+    except OSError:
+        return False  # locked / in use — deferred, retried once the lock releases
+    return True

--- a/src/hive/_runtime.py
+++ b/src/hive/_runtime.py
@@ -1,0 +1,176 @@
+"""hive runtime layout — versioned install dirs + a ``current`` junction
+(HIVE-267 / ADR-015 mechanism A3).
+
+On Windows ``uv tool upgrade`` rewrites the one install dir *in place*; while the
+Startup supervisor keeps the venv ``python.exe`` running it holds that dir
+locked, so the upgrade corrupts the in-use install (#267 — ``Access is denied``).
+A3 moves hive to owning its own layout instead: each version lives in its own dir
+under ``versions/`` and a ``current`` junction — a reparse point, NOT a copy —
+selects the active one. An upgrade builds the new version *beside* the old and
+repoints the junction; the locked target files are never touched, so the swap
+that breaks ``uv tool upgrade`` succeeds. Spike-validated on real non-admin
+Windows (2026-06-24, ``specs/HIVE-267-upgrade-swap/verification.md``).
+
+The layout root is env-overridable (``HIVE_RUNTIME_ROOT``) so the pure path logic
+and the repoint orchestration are testable off Windows; the OS-specific swap
+primitive (``mklink /J``) is validated by real hardware — mirroring how
+``hive service`` treats schtasks/systemctl.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from hive._helpers import _subprocess_run_kwargs
+
+CURRENT_LINK_NAME = "current"
+_STAGING_LINK_NAME = ".current.staging"
+
+
+# ── layout paths (env-overridable, host-independent) ─────────────────────
+
+
+def runtime_root() -> Path:
+    """Root hive owns for the versioned layout.
+
+    ``HIVE_RUNTIME_ROOT`` overrides (used in tests and to relocate the install).
+    Default: ``%LOCALAPPDATA%\\hive\\runtime`` on Windows — the per-user,
+    non-roaming store where an app owns its own binaries — and
+    ``~/.local/share/hive/runtime`` elsewhere, matching config's other state
+    paths (``db_path`` et al.).
+    """
+    override = os.environ.get("HIVE_RUNTIME_ROOT")
+    if override:
+        return Path(override)
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        return Path(base) / "hive" / "runtime"
+    return Path.home() / ".local" / "share" / "hive" / "runtime"
+
+
+def versions_dir() -> Path:
+    """Parent of every installed version dir (``<root>/versions``)."""
+    return runtime_root() / "versions"
+
+
+def version_path(version: str) -> Path:
+    """Install dir for a specific version (``<root>/versions/<version>``)."""
+    return versions_dir() / version
+
+
+def current_link() -> Path:
+    """The ``current`` junction that selects the active version."""
+    return runtime_root() / CURRENT_LINK_NAME
+
+
+def _staging_link() -> Path:
+    """Scratch reparse-point name used to stage a new junction before the flip."""
+    return runtime_root() / _STAGING_LINK_NAME
+
+
+# ── the OS-specific swap primitive (real on the host; mocked in unit tests) ──
+
+
+def _junction_command(link: Path, target: Path) -> list[str]:
+    """The ``mklink /J`` argv that creates directory junction *link* → *target*.
+
+    ``mklink`` is a ``cmd`` builtin (no standalone exe), so it runs via
+    ``cmd /c``. ``/J`` = directory junction: needs no admin / developer-mode
+    (unlike ``/D`` symlinks), and repointing it never touches the target's files
+    — the property that makes it immune to the in-use lock that breaks
+    ``uv tool upgrade`` (#267)."""
+    return ["cmd", "/c", "mklink", "/J", str(link), str(target)]
+
+
+def _make_junction(link: Path, target: Path) -> None:
+    """Create reparse point *link* pointing at directory *target*.
+
+    Windows: a directory junction via ``mklink /J`` (no admin). Elsewhere (CI,
+    POSIX dev): a directory symlink, which shares the one property the swap
+    relies on — it redirects without copying the target. Raises ``OSError`` on
+    failure so the caller's no-corruption path (criterion 3) can react."""
+    if sys.platform == "win32":
+        proc = subprocess.run(  # noqa: S603
+            _junction_command(link, target),
+            check=False,
+            capture_output=True,
+            text=True,
+            **_subprocess_run_kwargs(),
+        )
+        if proc.returncode != 0:
+            raise OSError(f"mklink /J failed (rc={proc.returncode}): {proc.stderr.strip()}")
+    else:
+        os.symlink(target, link, target_is_directory=True)
+
+
+def _remove_link(link: Path) -> None:
+    """Remove a reparse point WITHOUT deleting its target tree.
+
+    On Windows ``os.rmdir`` on a junction drops only the reparse point (the
+    locked target files are untouched — the whole point of A3). On POSIX
+    ``unlink`` drops the symlink. A real directory sitting at *link* is refused,
+    not silently nuked; a missing link is a no-op."""
+    if link.is_symlink():
+        link.unlink()
+    elif link.is_junction():
+        os.rmdir(link)
+    elif link.exists():
+        raise RuntimeError(
+            f"refusing to repoint: {link} is a real directory, not a hive junction",
+        )
+
+
+# ── the swap orchestration ───────────────────────────────────────────────
+
+
+def repoint(version: str) -> None:
+    """Point ``current`` at an installed *version*, so that a failure never
+    corrupts the running install (acceptance criterion 3).
+
+    Primitives available:
+
+    * ``version_path(version)`` — the target dir; guarded below to exist.
+    * ``current_link()`` / ``_staging_link()`` — the live and scratch reparse
+      points (siblings under ``runtime_root()``, so ``os.rename`` between them is
+      a same-volume flip).
+    * ``_make_junction(link, target)`` — create a reparse point. **FALLIBLE**:
+      raises ``OSError``; this is the step that fails in the #267 scenario.
+    * ``_remove_link(link)`` — drop a reparse point without touching its target.
+    * ``os.rename(src, dst)`` — flip a staged link onto ``current`` (cheap, and
+      effectively never fails once the junction exists).
+
+    Correctness constraint (criterion 3): the FALLIBLE step (``_make_junction``)
+    must run BEFORE ``current`` is disturbed, so a failure leaves the previous
+    install still pointed-to. Clear any stale ``_staging_link()`` first (a prior
+    crash may have left one). On failure, raise a ``RuntimeError`` that names the
+    version and gives a WHY/FIX (``pattern-agent-oriented-errors``) — never let a
+    bare ``OSError`` escape.
+    """
+    target = version_path(version)
+    if not target.is_dir():
+        raise RuntimeError(
+            f"hive self-upgrade: version {version} is not installed "
+            f"({target} does not exist). Build it into its own dir first, then repoint.",
+        )
+    # Stage the new junction under a scratch name FIRST — the fallible step — so a
+    # failure here leaves `current` untouched (acceptance criterion 3). A prior
+    # crash may have left a stale staging link; clear it before creating.
+    staging = _staging_link()
+    _remove_link(staging)
+    try:
+        _make_junction(staging, target)
+    except OSError as exc:
+        raise RuntimeError(
+            f"hive self-upgrade: could not stage version {version} at {staging} "
+            f"({exc}). The previous install is untouched — retry, or check disk "
+            f"space / permissions.",
+        ) from exc
+    # `current` still points at the previous version; now flip. The sub-ms window
+    # where `current` is absent (between remove and rename) is tolerated by the
+    # supervisor's relaunch loop (verification.md); the fallible work is already
+    # done, so this tail effectively never fails.
+    _remove_link(current_link())
+    os.rename(staging, current_link())

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,143 @@
+"""Unit tests for the hive runtime layout — versioned install dirs + a
+``current`` junction (HIVE-267 / ADR-015 mechanism A3).
+
+Like ``hive service``, the OS-specific swap primitive (Windows ``mklink /J``) is
+validated on real non-admin Windows hardware; these tests exercise the pure
+layout/command renderers (host-independent) and the *repoint* orchestration with
+a real POSIX symlink standing in for the junction on CI. That keeps the
+rollback / no-corruption guarantee (acceptance criterion 3) exercised on every
+push instead of only mocked — the junction and the symlink share the one
+property that matters here: repointing touches only the reparse point, never the
+locked target files that break ``uv tool upgrade`` (#267).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ── layout paths (host-independent, env-overridable) ─────────────────────
+
+
+def test_runtime_layout_is_versioned_under_an_overridable_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """hive owns its own install root on Windows (``%LOCALAPPDATA%\\hive\\runtime``)
+    because ``uv tool`` always rewrites the same dir — no per-version layout. The
+    root is env-overridable (``HIVE_RUNTIME_ROOT``) so the whole layout is
+    testable off Windows, exactly like ``_service._config_root()``."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    assert _runtime.runtime_root() == tmp_path
+    assert _runtime.versions_dir() == tmp_path / "versions"
+    assert _runtime.version_path("1.41.6") == tmp_path / "versions" / "1.41.6"
+    assert _runtime.current_link() == tmp_path / "current"
+
+
+def test_junction_command_uses_mklink_slash_j_for_a_non_admin_swap() -> None:
+    """A directory junction (``mklink /J``) is the C7-safe, non-admin swap
+    primitive: unlike a symlink it needs no elevation / developer-mode, and it
+    repoints the reparse point without ever touching the locked target files —
+    the exact #267 failure mode, avoided. Spike-validated on real non-admin
+    Windows (2026-06-24, verification.md)."""
+    from pathlib import PureWindowsPath
+
+    from hive._runtime import _junction_command
+
+    link = PureWindowsPath(r"C:\Users\u\AppData\Local\hive\runtime\current")
+    target = PureWindowsPath(r"C:\Users\u\AppData\Local\hive\runtime\versions\1.41.6")
+    cmd = _junction_command(link, target)
+
+    # `mklink` is a cmd builtin, so it must run via `cmd /c`; `/J` = directory
+    # junction (no admin), NOT `/D` (symlink, needs elevation).
+    assert cmd[:4] == ["cmd", "/c", "mklink", "/J"]
+    assert cmd[4].endswith(r"runtime\current")  # link first (mklink LINK TARGET)
+    assert cmd[5].endswith(r"versions\1.41.6")  # target second
+
+
+# ── repoint orchestration (real symlink on POSIX; junction on Windows) ────
+
+
+def _seed_version(runtime, version: str) -> None:
+    """Create a fake installed version dir with a version marker file."""
+    vdir = runtime.version_path(version)
+    vdir.mkdir(parents=True, exist_ok=True)
+    (vdir / "VERSION").write_text(version, encoding="utf-8")
+
+
+def test_repoint_points_current_at_the_target_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """After a repoint, reads through ``current`` resolve to the new version's
+    files (acceptance criterion 1: the swap leaves a valid, resolvable install)."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.6")
+    _runtime.repoint("1.41.6")
+
+    assert (_runtime.current_link() / "VERSION").read_text(encoding="utf-8") == "1.41.6"
+
+
+def test_repoint_replaces_an_existing_current(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Repointing over a live ``current`` is the upgrade itself: the old version
+    stays locked/running, the reparse point flips to the new one."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.5")
+    _seed_version(_runtime, "1.41.6")
+    _runtime.repoint("1.41.5")
+    assert (_runtime.current_link() / "VERSION").read_text(encoding="utf-8") == "1.41.5"
+
+    _runtime.repoint("1.41.6")  # repoint over an existing current
+    assert (_runtime.current_link() / "VERSION").read_text(encoding="utf-8") == "1.41.6"
+
+
+def test_failed_repoint_leaves_the_previous_current_intact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Acceptance criterion 3 — the anti-#267 guarantee. A swap that cannot
+    complete must leave the PREVIOUS working install pointed-to (never absent or
+    corrupted) and raise an actionable error, not a bare traceback."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.5")
+    _seed_version(_runtime, "1.41.6")
+    _runtime.repoint("1.41.5")  # working install at 1.41.5
+
+    # The swap to the new version fails part-way (e.g. a transient OS error).
+    def _boom(link, target) -> None:
+        raise OSError("Access is denied (os error 5)")
+
+    monkeypatch.setattr(_runtime, "_make_junction", _boom)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _runtime.repoint("1.41.6")
+
+    # Previous install still resolvable — no corruption, no dead MCP.
+    assert (_runtime.current_link() / "VERSION").read_text(encoding="utf-8") == "1.41.5"
+    # Actionable WHY/FIX (pattern-agent-oriented-errors), not a bare OSError.
+    message = str(excinfo.value)
+    assert "1.41.6" in message
+
+
+def test_repoint_rejects_a_version_that_is_not_installed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Repointing at a version dir that was never built is a caller error, caught
+    loudly up front rather than leaving ``current`` dangling at a missing target."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _runtime.repoint("9.9.9")
+    assert "9.9.9" in str(excinfo.value)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -141,3 +141,130 @@ def test_repoint_rejects_a_version_that_is_not_installed(
     with pytest.raises(RuntimeError) as excinfo:
         _runtime.repoint("9.9.9")
     assert "9.9.9" in str(excinfo.value)
+
+
+# ── version build + GC (uv mocked; real uv validated by the CI matrix) ────
+
+
+def test_build_version_runs_uv_venv_then_a_pinned_pip_install(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A version is built into its OWN dir with uv exactly as the manual path
+    would: ``uv venv <dir>`` then ``uv pip install --python <dir> pkg==<v>``. uv
+    does the heavy lifting; hive only owns *where* it lands so the swap is a
+    junction repoint (A3), never an in-place rewrite that corrupts a locked
+    install (#267)."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(_runtime, "_run_uv", lambda args: calls.append(args))
+
+    result = _runtime.build_version("1.41.6")
+
+    assert result == _runtime.version_path("1.41.6")
+    # 1) a venv in the version's own dir — never the in-use one.
+    assert calls[0][0] == "venv"
+    assert str(_runtime.version_path("1.41.6")) in calls[0]
+    # 2) the pinned package installed into THAT venv.
+    assert calls[1][:2] == ["pip", "install"]
+    assert "--python" in calls[1]
+    assert "hive-vault==1.41.6" in calls[1]
+
+
+def test_build_version_cleans_up_a_partial_dir_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """If the install fails part-way, the half-built dir must NOT survive to be
+    repointed-at — a corrupt version dir is exactly the #267 failure mode. The
+    error names the version and states the in-use install is untouched."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    def _uv(args: list[str]) -> None:
+        if args[0] == "venv":
+            _runtime.version_path("1.41.6").mkdir(parents=True)  # venv created
+            return
+        raise RuntimeError("uv pip install failed: no network")  # install fails
+
+    monkeypatch.setattr(_runtime, "_run_uv", _uv)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _runtime.build_version("1.41.6")
+
+    assert not _runtime.version_path("1.41.6").exists()
+    assert "1.41.6" in str(excinfo.value)
+
+
+def test_current_version_reads_the_active_junction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """``current_version()`` reports which version the junction selects (or
+    ``None`` before anything is linked) — the GC read-side of the layout."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.6")
+    assert _runtime.current_version() is None  # nothing linked yet
+
+    _runtime.repoint("1.41.6")
+    assert _runtime.current_version() == "1.41.6"
+
+
+def test_remove_version_refuses_the_active_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """GC must never delete the version the junction currently points at — that
+    would pull the running install out from under the daemon."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.6")
+    _runtime.repoint("1.41.6")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _runtime.remove_version("1.41.6")
+    assert "1.41.6" in str(excinfo.value)
+    assert _runtime.version_path("1.41.6").is_dir()  # still there
+
+
+def test_remove_version_drops_an_unreferenced_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """An old, no-longer-current version is GC'd once unreferenced."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.5")
+    _seed_version(_runtime, "1.41.6")
+    _runtime.repoint("1.41.6")
+
+    assert _runtime.remove_version("1.41.5") is True
+    assert not _runtime.version_path("1.41.5").exists()
+
+
+def test_remove_version_defers_when_the_dir_is_locked(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A still-locked old version (its python.exe not yet released) is a DEFERRED
+    GC, not a crash — return False so the caller can retry after the lock drops,
+    exactly as the spike's 'GC old dir once unreferenced' step observed."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.5")
+    _seed_version(_runtime, "1.41.6")
+    _runtime.repoint("1.41.6")
+
+    def _locked(_path) -> None:
+        raise OSError("The process cannot access the file: it is being used")
+
+    monkeypatch.setattr(_runtime.shutil, "rmtree", _locked)
+
+    assert _runtime.remove_version("1.41.5") is False


### PR DESCRIPTION
## Why

ADR-015 flags mechanism (A) "upgrade-swap" as load-bearing, and it bit on a real
non-admin Windows box: `uv tool install --upgrade` against a running daemon
silently corrupts the in-use install (`Access is denied`), taking the hive MCP
down for a whole session (#267). Mechanism **A3** (spike-validated 2026-06-24)
has hive own a versioned install layout fronted by a `current` junction,
swappable without ever touching in-use files.

## What

First PR of the HIVE-267 sequence — the layout + swap primitive in a new
`src/hive/_runtime.py`:

- Versioned-layout paths (`runtime_root` / `versions_dir` / `version_path` /
  `current_link`); root env-overridable via `HIVE_RUNTIME_ROOT` so the layout is
  testable off Windows, mirroring `_service._config_root()`.
- `repoint(version)` — **stage-then-flip**: the fallible `mklink /J` runs before
  `current` is disturbed, so a failed swap leaves the previous install intact and
  raises an actionable WHY/FIX `RuntimeError` (acceptance criterion 3). Reuses
  `_helpers._subprocess_run_kwargs()` to suppress the console-window flash (#249).

## Acceptance criteria

- [x] **Criterion 1** — a swap leaves a valid, resolvable install (`current` → new
  version): `test_repoint_points_current_at_the_target_version`,
  `test_repoint_replaces_an_existing_current`.
- [x] **Criterion 3** — a failed swap leaves the previous install intact + actionable
  error: `test_failed_repoint_leaves_the_previous_current_intact`.
- [ ] **Criteria 2 & 4** — e2e #267 reproduction on real non-admin Windows: follow-up
  PR that wires `repoint()` into `hive self-upgrade` + the dotfiles trigger.

## Testing

- `tests/test_runtime.py` (6 tests): pure `mklink /J` renderer asserted as a
  string; the repoint orchestration runs a **real junction on Windows / real
  symlink on POSIX CI** (single OS seam `_make_junction`) — the no-corruption
  guarantee is exercised, not only mocked.
- Full suite: **775 passed, 19 skipped, 0 failures**.
- `ruff format --check`, `ruff check`, `mypy --strict`: clean.

Spec: `specs/HIVE-267-upgrade-swap/` (tasks ticked, `features.json` added). Refs #267.