### PR TITLE
feat(runtime): build a version into its own dir + GC (HIVE-267)

### DIFF
--- a/specs/HIVE-267-upgrade-swap/tasks.md
+++ b/specs/HIVE-267-upgrade-swap/tasks.md
@@ -42,9 +42,11 @@ created: "2026-06-24"
 - [x] Implement the rollback / no-corruption guarantee (stage-then-flip: the
       fallible `_make_junction` runs before `current` is disturbed) + actionable
       WHY/FIX `RuntimeError`.
-- [ ] Implement "build a version into a fresh dir" (`uv venv` + `uv pip install
+- [x] Implement "build a version into a fresh dir" (`uv venv` + `uv pip install
       hive-vault==<v>`), never touching the in-use one; GC old versions once
-      unreferenced.
+      unreferenced. `_runtime.build_version()` (cleans a half-built dir on
+      failure), `current_version()`, `remove_version()` (refuses the active
+      version; defers a locked dir instead of crashing).
 - [ ] Add the `hive self-upgrade [<version>]` subcommand wiring the above; the
       launcher (`~/.local/bin`) + supervisor resolve through `current`.
 - [ ] **Companion (dotfiles, cross-repo):** replace the bare `uv tool install

--- a/src/hive/_runtime.py
+++ b/src/hive/_runtime.py
@@ -20,6 +20,7 @@ primitive (``mklink /J``) is validated by real hardware — mirroring how
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -174,3 +175,99 @@ def repoint(version: str) -> None:
     # done, so this tail effectively never fails.
     _remove_link(current_link())
     os.rename(staging, current_link())
+
+
+# ── version lifecycle: build a fresh dir + GC unreferenced ones ──────────
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    """The interpreter inside a uv-built venv, for ``uv pip install --python``."""
+    if sys.platform == "win32":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _run_uv(args: list[str]) -> None:
+    """Run ``uv <args>``, raising an actionable ``RuntimeError`` on failure.
+
+    The single ``uv`` seam (mocked in unit tests; the real tool validated by the
+    CI matrix), mirroring how ``_service`` treats schtasks/systemctl."""
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["uv", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            **_subprocess_run_kwargs(),
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "hive self-upgrade: `uv` is not on PATH — install uv (astral.sh/uv) "
+            "or run the upgrade manually.",
+        ) from exc
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"`uv {' '.join(args)}` failed (rc={proc.returncode}): {proc.stderr.strip()}",
+        )
+
+
+def build_version(version: str, *, package: str = "hive-vault") -> Path:
+    """Build *version* into its own dir under ``versions/``, never touching the
+    in-use install; return the new version dir.
+
+    Uses uv exactly as the manual path would — ``uv venv <dir>`` then
+    ``uv pip install --python <dir> <package>==<version>`` — so uv/pip do the
+    heavy lifting and hive only owns *where* the version lands. A build that
+    fails part-way is cleaned up: a half-built dir must never survive to be
+    repointed-at (that corrupt-dir state is the #267 failure mode)."""
+    target = version_path(version)
+    if target.exists():
+        raise RuntimeError(
+            f"hive self-upgrade: version {version} is already built at {target}; "
+            f"remove it before rebuilding.",
+        )
+    versions_dir().mkdir(parents=True, exist_ok=True)
+    try:
+        _run_uv(["venv", str(target)])
+        _run_uv(["pip", "install", "--python", str(_venv_python(target)), f"{package}=={version}"])
+    except RuntimeError as exc:
+        shutil.rmtree(target, ignore_errors=True)
+        raise RuntimeError(
+            f"hive self-upgrade: could not build version {version} into {target} "
+            f"({exc}). The in-use install is untouched.",
+        ) from exc
+    return target
+
+
+def current_version() -> str | None:
+    """The version the ``current`` junction selects, or ``None`` if unset.
+
+    Resolves through the reparse point and returns the target dir's name (the
+    version string) — the read side GC uses to avoid deleting the active one."""
+    link = current_link()
+    if not (link.is_symlink() or link.is_junction()):
+        return None
+    return link.resolve().name
+
+
+def remove_version(version: str) -> bool:
+    """GC an installed *version* dir; return whether it was actually removed.
+
+    Refuses to remove the active version (that would pull the running install
+    out from under the daemon). A still-locked dir — the old version whose
+    ``python.exe`` the supervisor has not yet released — is a DEFERRED GC, not a
+    crash: return ``False`` so the caller retries after the lock drops (the
+    spike's 'GC old dir once unreferenced' step)."""
+    if version == current_version():
+        raise RuntimeError(
+            f"hive self-upgrade: refusing to remove the active version {version}; "
+            f"repoint to another version first.",
+        )
+    target = version_path(version)
+    if not target.exists():
+        return False
+    try:
+        shutil.rmtree(target)
+    except OSError:
+        return False  # locked / in use — deferred, retried once the lock releases
+    return True

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -141,3 +141,130 @@ def test_repoint_rejects_a_version_that_is_not_installed(
     with pytest.raises(RuntimeError) as excinfo:
         _runtime.repoint("9.9.9")
     assert "9.9.9" in str(excinfo.value)
+
+
+# ── version build + GC (uv mocked; real uv validated by the CI matrix) ────
+
+
+def test_build_version_runs_uv_venv_then_a_pinned_pip_install(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A version is built into its OWN dir with uv exactly as the manual path
+    would: ``uv venv <dir>`` then ``uv pip install --python <dir> pkg==<v>``. uv
+    does the heavy lifting; hive only owns *where* it lands so the swap is a
+    junction repoint (A3), never an in-place rewrite that corrupts a locked
+    install (#267)."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(_runtime, "_run_uv", lambda args: calls.append(args))
+
+    result = _runtime.build_version("1.41.6")
+
+    assert result == _runtime.version_path("1.41.6")
+    # 1) a venv in the version's own dir — never the in-use one.
+    assert calls[0][0] == "venv"
+    assert str(_runtime.version_path("1.41.6")) in calls[0]
+    # 2) the pinned package installed into THAT venv.
+    assert calls[1][:2] == ["pip", "install"]
+    assert "--python" in calls[1]
+    assert "hive-vault==1.41.6" in calls[1]
+
+
+def test_build_version_cleans_up_a_partial_dir_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """If the install fails part-way, the half-built dir must NOT survive to be
+    repointed-at — a corrupt version dir is exactly the #267 failure mode. The
+    error names the version and states the in-use install is untouched."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    def _uv(args: list[str]) -> None:
+        if args[0] == "venv":
+            _runtime.version_path("1.41.6").mkdir(parents=True)  # venv created
+            return
+        raise RuntimeError("uv pip install failed: no network")  # install fails
+
+    monkeypatch.setattr(_runtime, "_run_uv", _uv)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _runtime.build_version("1.41.6")
+
+    assert not _runtime.version_path("1.41.6").exists()
+    assert "1.41.6" in str(excinfo.value)
+
+
+def test_current_version_reads_the_active_junction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """``current_version()`` reports which version the junction selects (or
+    ``None`` before anything is linked) — the GC read-side of the layout."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.6")
+    assert _runtime.current_version() is None  # nothing linked yet
+
+    _runtime.repoint("1.41.6")
+    assert _runtime.current_version() == "1.41.6"
+
+
+def test_remove_version_refuses_the_active_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """GC must never delete the version the junction currently points at — that
+    would pull the running install out from under the daemon."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.6")
+    _runtime.repoint("1.41.6")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _runtime.remove_version("1.41.6")
+    assert "1.41.6" in str(excinfo.value)
+    assert _runtime.version_path("1.41.6").is_dir()  # still there
+
+
+def test_remove_version_drops_an_unreferenced_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """An old, no-longer-current version is GC'd once unreferenced."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.5")
+    _seed_version(_runtime, "1.41.6")
+    _runtime.repoint("1.41.6")
+
+    assert _runtime.remove_version("1.41.5") is True
+    assert not _runtime.version_path("1.41.5").exists()
+
+
+def test_remove_version_defers_when_the_dir_is_locked(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A still-locked old version (its python.exe not yet released) is a DEFERRED
+    GC, not a crash — return False so the caller can retry after the lock drops,
+    exactly as the spike's 'GC old dir once unreferenced' step observed."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.5")
+    _seed_version(_runtime, "1.41.6")
+    _runtime.repoint("1.41.6")
+
+    def _locked(_path) -> None:
+        raise OSError("The process cannot access the file: it is being used")
+
+    monkeypatch.setattr(_runtime.shutil, "rmtree", _locked)
+
+    assert _runtime.remove_version("1.41.5") is False


### PR DESCRIPTION
> **Stacked on #290** (base branch `feat/HIVE-267-upgrade-swap`). Review/merge #290 first; this PR's diff is only the build/GC layer.

## What

Second step of the HIVE-267 A3 sequence — the version-dir lifecycle that feeds the repoint primitive from #290:

- **`build_version(version)`** — `uv venv <dir>` then `uv pip install --python <dir> hive-vault==<v>` into `versions/<v>`. uv/pip do the heavy lifting; hive owns only *where* the version lands so the swap stays a junction repoint (A3), never an in-place rewrite that corrupts a locked install (#267). A build that fails part-way **cleans the half-built dir** and raises an actionable error — a corrupt version dir is the #267 failure mode itself.
- **`current_version()`** — the version the `current` junction resolves to (the GC read side).
- **`remove_version(version)`** — refuses to delete the active version; a still-locked old dir is a **deferred GC** (`False`), not a crash, mirroring the spike's "GC old dir once unreferenced" observation.

## Testing

- `tests/test_runtime.py` (+6, 12 total): mock the single `uv` seam and assert the **commands** (like the `_service` renderer tests assert XML); `current_version`/`remove_version` run against a real junction on Windows / real symlink on POSIX CI.
- Full suite: **781 passed, 19 skipped, 0 failures**.
- `ruff format --check`, `ruff check`, `mypy --strict`: clean.

## Not in this PR

The `hive self-upgrade` subcommand (wires build → repoint → GC), the dotfiles trigger swap, and the e2e real-hardware re-validation (acceptance criteria 2 & 4) follow. Spec: `specs/HIVE-267-upgrade-swap/`. Refs #267.