### PR TITLE
feat(runtime): hive self-upgrade subcommand — end-to-end build/repoint/GC

### DIFF
--- a/specs/HIVE-267-upgrade-swap/features.json
+++ b/specs/HIVE-267-upgrade-swap/features.json
@@ -16,14 +16,21 @@
   {
     "id": "HIVE-267-upgrade-swap-f2",
     "behavior": "The documented #267 reproduction (uv tool install --upgrade against a running daemon) no longer fails on in-use files.",
-    "verification": "manual: real non-admin Windows re-validation. Pending the `hive self-upgrade` PR that builds each version into its own dir and wires repoint() to the upgrade trigger.",
+    "verification": "manual: real non-admin Windows re-validation. CLI wiring landed (`hive self-upgrade <version>`, #292); the remaining gap is running the reproduction on real hardware AND swapping the dotfiles trigger to it.",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "HIVE-267-upgrade-swap-f4",
     "behavior": "Validated on a real non-admin Windows box (ADR-015 hardware-validation discipline), not only the CI matrix.",
-    "verification": "manual: recorded in specs/HIVE-267-upgrade-swap/verification.md. Pending end-to-end wiring (self-upgrade subcommand + dotfiles trigger swap).",
+    "verification": "manual: recorded in specs/HIVE-267-upgrade-swap/verification.md. Subcommand wiring landed (#292); still pending the dotfiles trigger swap + the real-hardware re-validation.",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HIVE-267-upgrade-swap-f5",
+    "behavior": "`hive self-upgrade <version>` builds the version into its own dir, atomically repoints `current`, and GCs unreferenced versions end-to-end: idempotent no-op when already current, retry-safe when a prior build survived, a build failure leaves `current` intact, and a locked old version defers its GC instead of crashing.",
+    "verification": "python -m pytest tests/test_runtime.py -k self_upgrade -q",
     "state": "pending",
     "evidence": ""
   }

--- a/specs/HIVE-267-upgrade-swap/tasks.md
+++ b/specs/HIVE-267-upgrade-swap/tasks.md
@@ -47,8 +47,14 @@ created: "2026-06-24"
       unreferenced. `_runtime.build_version()` (cleans a half-built dir on
       failure), `current_version()`, `remove_version()` (refuses the active
       version; defers a locked dir instead of crashing).
-- [ ] Add the `hive self-upgrade [<version>]` subcommand wiring the above; the
-      launcher (`~/.local/bin`) + supervisor resolve through `current`.
+- [x] Add the `hive self-upgrade <version>` subcommand wiring the above
+      (`_runtime.self_upgrade`: build → repoint → GC; `server._run_self_upgrade`
+      CLI wrapper + `_dispatch` branch). Version-resolution contract
+      **RESOLVED (2026-07-09): explicit `<version>` REQUIRED** — deterministic,
+      network-free; auto-latest-from-PyPI is a follow-up scoped to the dotfiles
+      trigger. The launcher (`~/.local/bin`) + supervisor already resolve through
+      `current` (repoint primitive). Tracked as successor issue #292. Tests in
+      `tests/test_runtime.py` (`self_upgrade` orchestration + CLI wrapper).
 - [ ] **Companion (dotfiles, cross-repo):** replace the bare `uv tool install
       --upgrade` trigger (`setup-windows.ps1` timer / `mcp-servers.json`
       `prerequisite_command`) with `hive self-upgrade`. Document the

--- a/specs/HIVE-267-upgrade-swap/verification.md
+++ b/specs/HIVE-267-upgrade-swap/verification.md
@@ -29,6 +29,11 @@ Map every acceptance criterion from `proposal.md` to concrete proof (commit hash
 Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
 
 - **A3 validated on real non-admin Windows hardware (2026-06-24) — proceed with A3; no fallback to A4/A2 needed.** Junction ops touch only the reparse point, never the locked target files, so the repoint is immune to the in-use lock that breaks `uv tool upgrade` (#267).
+- **`self_upgrade` orchestration decisions (2026-07-09, successor issue #292):**
+  - **Version-resolution contract = explicit `<version>` REQUIRED.** Deterministic and network-free (tests need no PyPI); auto-`latest` is deferred to the dotfiles-trigger follow-up so it lands with the network seam it actually needs.
+  - **`self_upgrade` does NOT restart the daemon.** It only builds + repoints + GCs; the supervisor's existing exit-75 restart-on-upgrade contract relaunches `hive serve` through the freshly repointed `current`. Keeping restart out of the swap keeps this PR scoped to the mechanism (no scope creep).
+  - **GC retention = remove every non-current version; locked ones defer.** A still-locked old version (the supervisor holding its `python.exe`) returns `False` from `remove_version` and survives to the next run — no rollback-retention policy yet (out of scope; the acceptance criteria don't require keeping N previous versions).
+  - **Idempotent + retry-safe.** No-op when already on the target (the unattended trigger can fire repeatedly); an already-built dir from a crashed prior run is reused rather than rebuilt (a rebuild would hit `build_version`'s 'already built' guard).
 - Spike harness correction: an initial `Start-Process` lock-holder was racy (PowerShell startup latency left the file briefly unlocked, producing a false result). Switched to an in-process `[IO.File]::Open(..., FileShare.None)` for a deterministic lock — recorded so the next person does not repeat the race.
 - Implementation note: the practical repoint (`rmdir` junction + recreate) has a sub-millisecond non-atomic window where `current` is absent; tolerated by the supervisor's relaunch loop. A fully atomic swap (create `current.new`, rename over `current`) is an optional refinement, not a feasibility blocker.
 

--- a/src/hive/_runtime.py
+++ b/src/hive/_runtime.py
@@ -271,3 +271,58 @@ def remove_version(version: str) -> bool:
     except OSError:
         return False  # locked / in use — deferred, retried once the lock releases
     return True
+
+
+# ── the end-to-end upgrade: build → repoint → GC (HIVE-267 / #292) ───────
+
+
+def _gc_other_versions(keep: str) -> list[str]:
+    """GC every installed version except *keep*; return the ones whose GC was
+    DEFERRED because they were still locked.
+
+    The old version is exactly the one whose ``python.exe`` the supervisor has
+    not yet released, so its ``remove_version`` returns ``False`` (deferred, not
+    a crash). The leftover is cleaned by the next ``self_upgrade`` once the lock
+    drops — the spike's 'GC old dir once unreferenced'. A missing/empty
+    ``versions`` dir yields nothing to do."""
+    root = versions_dir()
+    if not root.is_dir():
+        return []
+    deferred: list[str] = []
+    for child in sorted(root.iterdir()):
+        if not child.is_dir() or child.name == keep:
+            continue
+        if not remove_version(child.name):
+            deferred.append(child.name)
+    return deferred
+
+
+def self_upgrade(version: str) -> str | None:
+    """Upgrade the install to *version* without ever touching in-use files
+    (HIVE-267 / ADR-015 mechanism A3); return the PREVIOUS version (``None`` on a
+    first install), so the CLI can report the transition.
+
+    Three steps, ordered so a failure never corrupts the running install:
+
+    1. **build** *version* into its own dir beside the running one — skipped when
+       the dir already exists, making a retry after a crashed prior run
+       idempotent (a rebuild would hit ``build_version``'s 'already built' guard);
+    2. **repoint** ``current`` at it (stage-then-flip: a failure here leaves the
+       previous install pointed-to, criterion 3);
+    3. **GC** the now-unreferenced old versions (a still-locked one defers).
+
+    A no-op when *version* is already ``current``, so the unattended dotfiles
+    trigger can fire repeatedly without churn. Does NOT restart the running
+    daemon: the supervisor's exit-75 restart-on-upgrade contract relaunches
+    ``hive serve`` through the freshly repointed ``current`` (see ``_service`` /
+    ``_daemon``). ``build_version`` / ``repoint`` raise an actionable
+    ``RuntimeError`` on failure; the CLI wrapper turns that into a non-zero exit.
+    """
+    previous = current_version()
+    if version == previous:
+        return previous  # already selected — idempotent no-op
+    if not version_path(version).is_dir():
+        build_version(version)  # raises RuntimeError on failure — current untouched
+    repoint(version)  # stage-then-flip — raises on failure — previous stays pointed-to
+    _gc_other_versions(keep=version)
+    return previous

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -650,6 +650,39 @@ def _run_service(argv: list[str]) -> int:
     return service_status()
 
 
+def _run_self_upgrade(argv: list[str]) -> int:
+    """``hive self-upgrade <version>`` — build the given hive-vault version beside
+    the running install and atomically repoint ``current`` at it (HIVE-267 /
+    ADR-015 mechanism A3), so an upgrade applied while the daemon is running
+    never corrupts the in-use install (#267). Returns a process exit code for
+    the caller (the dotfiles upgrade trigger).
+
+    The version is a REQUIRED explicit argument — deterministic and network-free;
+    resolving 'latest from PyPI' when omitted is a deliberate follow-up scoped to
+    the unattended trigger (#292)."""
+    import argparse
+
+    from hive._runtime import self_upgrade
+
+    parser = argparse.ArgumentParser(prog="hive self-upgrade")
+    parser.add_argument(
+        "version",
+        help="the hive-vault version to install and switch to, e.g. 1.41.8",
+    )
+    opts = parser.parse_args(argv)
+    try:
+        previous = self_upgrade(opts.version)
+    except RuntimeError as exc:
+        # Actionable WHY/FIX from _runtime — surface it, never a silent success.
+        print(str(exc), file=sys.stderr)
+        return 1
+    if previous == opts.version:
+        print(f"hive self-upgrade: already on {opts.version}; nothing to do.")
+    else:
+        print(f"hive self-upgrade: switched {previous or 'none'} -> {opts.version}.")
+    return 0
+
+
 _USAGE = """\
 usage: hive [COMMAND]
 
@@ -658,6 +691,7 @@ Commands:
   serve                                run the single-owner daemon (ADR-011)
   client                               run the thin stdio shim that proxies to the daemon
   service {install,uninstall,status}   manage the daemon as a per-user OS service
+  self-upgrade <version>               build + atomically swap to a hive-vault version (ADR-015 A3)
 
 Options:
   -V, --version                        print the installed hive-vault version and exit
@@ -697,6 +731,8 @@ def _dispatch(argv: list[str]) -> int:
         return _run_serve(argv[1:])
     if cmd == "service":
         return _run_service(argv[1:])
+    if cmd == "self-upgrade":
+        return _run_self_upgrade(argv[1:])
     if cmd == "client":
         _run_client(argv[1:])
         return 0

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -268,3 +268,207 @@ def test_remove_version_defers_when_the_dir_is_locked(
     monkeypatch.setattr(_runtime.shutil, "rmtree", _locked)
 
     assert _runtime.remove_version("1.41.5") is False
+
+
+# ── self_upgrade orchestration: build → repoint → GC (HIVE-267 / #292) ────
+
+
+def test_self_upgrade_builds_repoints_then_gcs_the_old_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """The end-to-end swap: build the new version beside the running one, flip
+    ``current`` to it, then GC the now-unreferenced old version. Returns the
+    PREVIOUS version so the CLI can report the transition."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.5")
+    _runtime.repoint("1.41.5")  # currently running 1.41.5
+
+    built: list[str] = []
+
+    def _fake_build(version: str, *, package: str = "hive-vault"):
+        _seed_version(_runtime, version)  # uv stands in — just land the dir
+        built.append(version)
+        return _runtime.version_path(version)
+
+    monkeypatch.setattr(_runtime, "build_version", _fake_build)
+
+    previous = _runtime.self_upgrade("1.41.6")
+
+    assert previous == "1.41.5"
+    assert built == ["1.41.6"]  # the new version was built, once
+    assert _runtime.current_version() == "1.41.6"  # `current` flipped
+    assert not _runtime.version_path("1.41.5").exists()  # old version GC'd
+
+
+def test_self_upgrade_is_a_noop_when_already_on_the_target(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Re-running the upgrade for the version already selected must not rebuild
+    or repoint — it is idempotent, so the unattended dotfiles trigger can fire
+    it repeatedly without churn."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.6")
+    _runtime.repoint("1.41.6")
+
+    def _must_not_build(*_a: object, **_k: object):
+        raise AssertionError("must not build when already on the target version")
+
+    monkeypatch.setattr(_runtime, "build_version", _must_not_build)
+
+    assert _runtime.self_upgrade("1.41.6") == "1.41.6"
+    assert _runtime.current_version() == "1.41.6"
+
+
+def test_self_upgrade_skips_build_when_the_version_is_already_built(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A prior run that built the version but crashed before the flip must be
+    retry-safe: the existing dir is reused (rebuilding would hit
+    ``build_version``'s 'already built' guard and fail the retry)."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.5")
+    _runtime.repoint("1.41.5")
+    _seed_version(_runtime, "1.41.6")  # already built by a crashed prior run
+
+    def _must_not_build(*_a: object, **_k: object):
+        raise AssertionError("must not rebuild an already-built version dir")
+
+    monkeypatch.setattr(_runtime, "build_version", _must_not_build)
+
+    assert _runtime.self_upgrade("1.41.6") == "1.41.5"
+    assert _runtime.current_version() == "1.41.6"
+
+
+def test_self_upgrade_leaves_current_intact_when_the_build_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A build failure (no network, bad version) must never touch the running
+    install: ``current`` still resolves to the previous version and the error
+    propagates for the CLI to surface as a non-zero exit (criterion 3)."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.5")
+    _runtime.repoint("1.41.5")
+
+    def _boom(*_a: object, **_k: object):
+        raise RuntimeError("could not build version 1.41.6: no network")
+
+    monkeypatch.setattr(_runtime, "build_version", _boom)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _runtime.self_upgrade("1.41.6")
+
+    assert "1.41.6" in str(excinfo.value)
+    assert _runtime.current_version() == "1.41.5"  # untouched
+
+
+def test_self_upgrade_defers_gc_of_a_locked_old_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """The old version is exactly the one still locked (the supervisor has not
+    released its ``python.exe``). Its GC must DEFER — the swap still succeeds and
+    the locked dir survives to be cleaned by the next run, never crashing the
+    upgrade."""
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    from hive import _runtime
+
+    _seed_version(_runtime, "1.41.5")
+    _runtime.repoint("1.41.5")
+
+    def _fake_build(version: str, *, package: str = "hive-vault"):
+        _seed_version(_runtime, version)
+        return _runtime.version_path(version)
+
+    monkeypatch.setattr(_runtime, "build_version", _fake_build)
+
+    real_rmtree = _runtime.shutil.rmtree
+
+    def _locked_rmtree(path, *a: object, **k: object) -> None:
+        if path == _runtime.version_path("1.41.5"):
+            raise OSError("being used by another process")
+        real_rmtree(path, *a, **k)
+
+    monkeypatch.setattr(_runtime.shutil, "rmtree", _locked_rmtree)
+
+    previous = _runtime.self_upgrade("1.41.6")
+
+    assert previous == "1.41.5"
+    assert _runtime.current_version() == "1.41.6"  # swap still succeeded
+    assert _runtime.version_path("1.41.5").exists()  # GC deferred, not crashed
+
+
+# ── CLI wrapper: `hive self-upgrade <version>` ───────────────────────────
+
+
+def test_cli_self_upgrade_requires_an_explicit_version() -> None:
+    """The version-resolution contract (2026-07-09): an explicit ``<version>`` is
+    REQUIRED — deterministic and network-free. A missing version is an argparse
+    usage error (exit 2), never a silent no-op or an implicit 'latest'."""
+    from hive import server
+
+    with pytest.raises(SystemExit) as excinfo:
+        server._run_self_upgrade([])
+    assert excinfo.value.code == 2
+
+
+def test_cli_self_upgrade_dispatches_the_version_to_the_orchestrator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``hive self-upgrade 1.41.6`` reaches ``_runtime.self_upgrade('1.41.6')``
+    and returns exit 0 on success."""
+    from hive import server
+
+    seen: dict[str, object] = {}
+
+    def _fake(version: str) -> str:
+        seen["version"] = version
+        return "1.41.5"
+
+    monkeypatch.setattr("hive._runtime.self_upgrade", _fake)
+    assert server._run_self_upgrade(["1.41.6"]) == 0
+    assert seen["version"] == "1.41.6"
+
+
+def test_cli_self_upgrade_surfaces_failure_as_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An orchestration failure is surfaced to the CLI user: the actionable
+    error prints to stderr and the command exits non-zero (never a silent
+    success — the #246/#252 lesson), so the dotfiles trigger sees the failure."""
+    from hive import server
+
+    def _boom(version: str) -> str:
+        raise RuntimeError("could not build version 1.41.6: no network")
+
+    monkeypatch.setattr("hive._runtime.self_upgrade", _boom)
+    rc = server._run_self_upgrade(["1.41.6"])
+
+    assert rc == 1
+    assert "1.41.6" in capsys.readouterr().err
+
+
+def test_cli_dispatch_routes_self_upgrade(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``hive self-upgrade …`` is wired into the top-level dispatcher, not just
+    reachable via the private helper."""
+    from hive import server
+
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        "hive._runtime.self_upgrade",
+        lambda version: seen.setdefault("version", version),
+    )
+    assert server._dispatch(["self-upgrade", "1.41.7"]) == 0
+    assert seen["version"] == "1.41.7"


### PR DESCRIPTION
## What

Wire the A3 versioned-layout primitives (`build_version` → `repoint` →
`remove_version`, from #290) behind a `hive self-upgrade <version>` CLI
subcommand, so an upgrade applied while the daemon is running swaps to the new
version **without ever touching in-use files** (#267 / ADR-015 mechanism A3).

## How

- **`_runtime.self_upgrade(version)`** — the end-to-end orchestration:
  1. build the version into its own dir beside the running one — *skipped when
     already built*, so a retry after a crashed prior run is idempotent;
  2. atomically **repoint `current`** (stage-then-flip: a failure leaves the
     previous install pointed-to, acceptance criterion 3);
  3. **GC** the now-unreferenced versions — a still-locked old one *defers*
     (returns cleanly, cleaned next run) instead of crashing.
  A no-op when already on the target. Does **not** restart the daemon: the
  supervisor's existing exit-75 restart-on-upgrade contract relaunches
  `hive serve` through the freshly repointed `current` (keeps this PR scoped to
  the mechanism).
- **`server._run_self_upgrade`** + `_dispatch` branch + usage line — the thin
  argparse wrapper (mirrors `hive service`). Actionable errors go to stderr with
  a non-zero exit; never a silent success.

## Contract decision (2026-07-09)

The version is a **required explicit argument** — deterministic and network-free.
Auto-`latest`-from-PyPI is a deliberate follow-up scoped to the unattended
dotfiles trigger, so it lands with the network seam it actually needs.

## Scope / follow-ups

Advances #292 (does **not** close it): the dotfiles trigger swap and the
real-hardware #267 re-validation remain. Spec updated:
`specs/HIVE-267-upgrade-swap/` (tasks / features / verification).

## Testing

- `tests/test_runtime.py`: 9 new tests (`self_upgrade` orchestration — happy
  path, idempotent no-op, already-built retry, build-failure-leaves-current,
  deferred GC — plus the CLI wrapper: required arg, dispatch, failure exit).
- Full suite: 790 passed, 19 skipped. `ruff check` + `ruff format --check` clean;
  `mypy --strict` clean on the changed files.
- Real CLI drive (Windows): missing arg → exit 2; `--help` clean; idempotent
  no-op with a real junction → "already on X", exit 0.

Related: #267 (closed, mechanism), #290 (primitives), #292 (tracking issue).
