### PR TITLE
chore(ci): track the Dockerfile base image with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@
 #   on supported runners + action versions.
 # - site/ has its own package.json (Astro + Starlight); covered as a
 #   separate npm ecosystem so its bumps don't mix into the Python PR.
+# - The Dockerfile base image (python:3.12-slim) is tracked via the
+#   docker ecosystem so base-image security patches AND Python version
+#   bumps (e.g. 3.13-slim) surface as reviewable PRs instead of a stale
+#   pin. Left unfiltered on purpose — a base-image jump is worth a look.
 
 version: 2
 
@@ -87,3 +91,22 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # ── Docker base image (Dockerfile) ────────────────────────────
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "America/Denver"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      docker-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Add a `docker` ecosystem to `.github/dependabot.yml` so the Dockerfile base
image (`python:3.12-slim`, used in both the builder and runtime stages) gets
Dependabot PRs — it was the one dependency surface not covered (pip,
github-actions and npm already are).

## Config

Same cadence and shape as the existing ecosystems:
- **weekly**, Monday 07:00 America/Denver
- **grouped** into one PR (`docker-all`, `open-pull-requests-limit: 1`)
- `chore(docker)` commit prefix, `dependencies` label

**Left unfiltered on purpose** (per the maintainer's call): unlike the
`minor`+`patch`-only Python/npm groups, the docker group has no `update-types`
filter, so a base-image jump (e.g. `3.13-slim`) also surfaces as a reviewable
PR rather than sitting on a stale pin. Grouping keeps it to a single PR; and
since auto-merge is forbidden repo-wide, nothing lands without review.

## Testing

`yaml.safe_load` parses clean; all four ecosystems present
(pip / github-actions / npm / docker), each weekly + grouped.
