### PR TITLE
feat(runtime): resolve latest hive-vault from PyPI when self-upgrade version omitted

### DIFF
--- a/specs/HIVE-267-upgrade-swap/tasks.md
+++ b/specs/HIVE-267-upgrade-swap/tasks.md
@@ -55,10 +55,17 @@ created: "2026-06-24"
       trigger. The launcher (`~/.local/bin`) + supervisor already resolve through
       `current` (repoint primitive). Tracked as successor issue #292. Tests in
       `tests/test_runtime.py` (`self_upgrade` orchestration + CLI wrapper).
+- [x] **Auto-latest resolution (#292):** make `hive self-upgrade`'s version
+      argument optional — omitted, it resolves the newest `hive-vault` release
+      from PyPI's JSON API (`_runtime.latest_version`, the module's single
+      network seam, bounded timeout, actionable WHY/FIX on failure) so the
+      unattended trigger can fire a bare `hive self-upgrade`. An explicit version
+      stays deterministic and network-free. Tests in `tests/test_runtime.py`
+      (`latest_version` happy/timeout/bad-payload + CLI omitted-vs-explicit).
 - [ ] **Companion (dotfiles, cross-repo):** replace the bare `uv tool install
       --upgrade` trigger (`setup-windows.ps1` timer / `mcp-servers.json`
-      `prerequisite_command`) with `hive self-upgrade`. Document the
-      "no-longer-a-uv-tool on Windows" consequence.
+      `prerequisite_command`) with `hive self-upgrade` (now bare — auto-latest
+      landed above). Document the "no-longer-a-uv-tool on Windows" consequence.
 - [ ] Real-hardware re-validation: the #267 reproduction no longer reproduces
       (manual, recorded in `verification.md`).
 

--- a/src/hive/_runtime.py
+++ b/src/hive/_runtime.py
@@ -25,10 +25,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+import httpx
+
 from hive._helpers import _subprocess_run_kwargs
 
 CURRENT_LINK_NAME = "current"
 _STAGING_LINK_NAME = ".current.staging"
+
+# PyPI's per-project JSON API — ``info.version`` is the newest published release.
+# Bounded so a wedged/slow PyPI fails fast instead of hanging the trigger; the
+# caller always has the explicit-version escape hatch.
+_PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
+_PYPI_TIMEOUT_S = 10.0
 
 
 # ── layout paths (env-overridable, host-independent) ─────────────────────
@@ -271,6 +279,57 @@ def remove_version(version: str) -> bool:
     except OSError:
         return False  # locked / in use — deferred, retried once the lock releases
     return True
+
+
+# ── resolve the target version from PyPI (the auto-latest path, #292) ─────
+
+
+def latest_version(package: str = "hive-vault") -> str:
+    """The newest *package* release published to PyPI (``info.version``).
+
+    Lets the unattended dotfiles trigger call a bare ``hive self-upgrade`` without
+    hard-coding a version number — the auto-latest follow-up to the explicit
+    ``<version>`` contract (#292). The single network seam in this module (mocked
+    in unit tests; real PyPI exercised only by the trigger), bounded by
+    ``_PYPI_TIMEOUT_S`` so a wedged PyPI fails fast rather than hanging the
+    timer. Every failure — timeout, network/HTTP error, or an unexpected payload
+    shape — raises an actionable ``RuntimeError`` (``pattern-agent-oriented-errors``)
+    that names the escape hatch (``hive self-upgrade <version>``), never a bare
+    httpx traceback nor a bogus/empty version string that would repoint ``current``
+    at nothing."""
+    url = _PYPI_JSON_URL.format(package=package)
+    try:
+        response = httpx.get(url, timeout=_PYPI_TIMEOUT_S, follow_redirects=True)
+        response.raise_for_status()
+    except httpx.TimeoutException as exc:
+        # Umbrella class (AGENTS.md load-bearing rule): a slow PyPI surfaces as
+        # ReadTimeout, which ConnectTimeout alone would miss.
+        raise RuntimeError(
+            f"hive self-upgrade: timed out reaching PyPI to resolve the latest "
+            f"{package} version ({exc}). Retry, or pin one: "
+            f"`hive self-upgrade <version>`.",
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise RuntimeError(
+            f"hive self-upgrade: could not reach PyPI to resolve the latest "
+            f"{package} version ({exc}). Check the network, or pin one: "
+            f"`hive self-upgrade <version>`.",
+        ) from exc
+    try:
+        version = response.json()["info"]["version"]
+    except (ValueError, KeyError, TypeError) as exc:
+        # ValueError covers a non-JSON body (json.JSONDecodeError); KeyError /
+        # TypeError cover a renamed field or a non-dict payload.
+        raise RuntimeError(
+            f"hive self-upgrade: PyPI returned an unexpected payload for {package} "
+            f"({exc}). Pin a version instead: `hive self-upgrade <version>`.",
+        ) from exc
+    if not version or not isinstance(version, str):
+        raise RuntimeError(
+            f"hive self-upgrade: PyPI reported no usable version for {package} "
+            f"(got {version!r}). Pin one: `hive self-upgrade <version>`.",
+        )
+    return version
 
 
 # ── the end-to-end upgrade: build → repoint → GC (HIVE-267 / #292) ───────

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -651,35 +651,40 @@ def _run_service(argv: list[str]) -> int:
 
 
 def _run_self_upgrade(argv: list[str]) -> int:
-    """``hive self-upgrade <version>`` — build the given hive-vault version beside
+    """``hive self-upgrade [version]`` — build the target hive-vault version beside
     the running install and atomically repoint ``current`` at it (HIVE-267 /
     ADR-015 mechanism A3), so an upgrade applied while the daemon is running
     never corrupts the in-use install (#267). Returns a process exit code for
     the caller (the dotfiles upgrade trigger).
 
-    The version is a REQUIRED explicit argument — deterministic and network-free;
-    resolving 'latest from PyPI' when omitted is a deliberate follow-up scoped to
-    the unattended trigger (#292)."""
+    An explicit ``<version>`` is deterministic and network-free. Omitting it
+    resolves the latest release from PyPI (``_runtime.latest_version``) so the
+    unattended trigger can fire a bare ``hive self-upgrade`` (#292); a PyPI
+    failure surfaces as a non-zero exit, never an implicit no-op."""
     import argparse
 
-    from hive._runtime import self_upgrade
+    from hive import _runtime
 
     parser = argparse.ArgumentParser(prog="hive self-upgrade")
     parser.add_argument(
         "version",
-        help="the hive-vault version to install and switch to, e.g. 1.41.8",
+        nargs="?",
+        default="",
+        help="the hive-vault version to install and switch to, e.g. 1.41.8; "
+        "omit to resolve the latest release from PyPI",
     )
     opts = parser.parse_args(argv)
     try:
-        previous = self_upgrade(opts.version)
+        version = opts.version or _runtime.latest_version()
+        previous = _runtime.self_upgrade(version)
     except RuntimeError as exc:
         # Actionable WHY/FIX from _runtime — surface it, never a silent success.
         print(str(exc), file=sys.stderr)
         return 1
-    if previous == opts.version:
-        print(f"hive self-upgrade: already on {opts.version}; nothing to do.")
+    if previous == version:
+        print(f"hive self-upgrade: already on {version}; nothing to do.")
     else:
-        print(f"hive self-upgrade: switched {previous or 'none'} -> {opts.version}.")
+        print(f"hive self-upgrade: switched {previous or 'none'} -> {version}.")
     return 0
 
 
@@ -691,7 +696,7 @@ Commands:
   serve                                run the single-owner daemon (ADR-011)
   client                               run the thin stdio shim that proxies to the daemon
   service {install,uninstall,status}   manage the daemon as a per-user OS service
-  self-upgrade <version>               build + atomically swap to a hive-vault version (ADR-015 A3)
+  self-upgrade [version]               build + swap to a hive-vault version (PyPI latest if omitted)
 
 Options:
   -V, --version                        print the installed hive-vault version and exit

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -409,18 +409,127 @@ def test_self_upgrade_defers_gc_of_a_locked_old_version(
     assert _runtime.version_path("1.41.5").exists()  # GC deferred, not crashed
 
 
-# ── CLI wrapper: `hive self-upgrade <version>` ───────────────────────────
+# ── latest-version resolution from PyPI (httpx mocked; real PyPI never hit) ──
 
 
-def test_cli_self_upgrade_requires_an_explicit_version() -> None:
-    """The version-resolution contract (2026-07-09): an explicit ``<version>`` is
-    REQUIRED — deterministic and network-free. A missing version is an argparse
-    usage error (exit 2), never a silent no-op or an implicit 'latest'."""
+class _FakePyPIResponse:
+    """Stand-in for ``httpx.Response``: just enough for ``latest_version()``."""
+
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> object:
+        return self._payload
+
+
+def test_latest_version_reads_info_version_from_pypis_json_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``hive self-upgrade`` with no version resolves the newest published release
+    from PyPI's JSON API (``info.version``) so the unattended dotfiles trigger
+    need not know the number — the point of the auto-latest follow-up (#292). The
+    query is bounded by a timeout (never an unbounded network wait)."""
+    from hive import _runtime
+
+    seen: dict[str, object] = {}
+
+    def _fake_get(url: str, **kwargs: object) -> _FakePyPIResponse:
+        seen["url"] = url
+        seen["timeout"] = kwargs.get("timeout")
+        return _FakePyPIResponse({"info": {"version": "1.42.1"}})
+
+    monkeypatch.setattr(_runtime.httpx, "get", _fake_get)
+
+    assert _runtime.latest_version() == "1.42.1"
+    assert "hive-vault" in str(seen["url"])  # queried the right distribution
+    assert seen["timeout"]  # bounded — no unbounded hang on a wedged PyPI
+
+
+def test_latest_version_raises_actionable_error_on_network_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A PyPI outage/timeout must NOT escape as a bare httpx traceback: raise an
+    actionable ``RuntimeError`` pointing at the explicit-version escape hatch —
+    the same WHY/FIX contract as the rest of self-upgrade. Catching the
+    ``TimeoutException`` umbrella (not ``ConnectTimeout`` alone) is a load-bearing
+    rule (AGENTS.md): a slow PyPI surfaces as ``ReadTimeout``."""
+    import httpx
+
+    from hive import _runtime
+
+    def _timeout(url: str, **kwargs: object) -> object:
+        raise httpx.ReadTimeout("timed out")  # subclass of TimeoutException
+
+    monkeypatch.setattr(_runtime.httpx, "get", _timeout)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _runtime.latest_version()
+    message = str(excinfo.value)
+    assert "PyPI" in message
+    assert "hive self-upgrade <version>" in message  # the explicit-version fallback
+
+
+def test_latest_version_raises_actionable_error_on_unexpected_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PyPI reachable but the JSON shape is not what we expect (renamed field, an
+    HTML error page decoded as JSON, an empty version) — surface an actionable
+    error rather than repointing ``current`` at a bogus/empty version string."""
+    from hive import _runtime
+
+    def _weird(url: str, **kwargs: object) -> _FakePyPIResponse:
+        return _FakePyPIResponse({"info": {}})  # no 'version' key
+
+    monkeypatch.setattr(_runtime.httpx, "get", _weird)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _runtime.latest_version()
+    assert "hive-vault" in str(excinfo.value)
+
+
+# ── CLI wrapper: `hive self-upgrade [version]` ───────────────────────────
+
+
+def test_cli_self_upgrade_resolves_latest_from_pypi_when_version_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The version-resolution contract, updated (#292): an omitted version is NO
+    LONGER a usage error — it resolves the latest release from PyPI and upgrades
+    to it, so the unattended dotfiles trigger can call a bare ``hive
+    self-upgrade``. An explicit version still wins (next test)."""
     from hive import server
 
-    with pytest.raises(SystemExit) as excinfo:
-        server._run_self_upgrade([])
-    assert excinfo.value.code == 2
+    seen: dict[str, object] = {}
+    monkeypatch.setattr("hive._runtime.latest_version", lambda: "1.42.1")
+
+    def _fake(version: str) -> str:
+        seen["version"] = version
+        return "1.41.9"
+
+    monkeypatch.setattr("hive._runtime.self_upgrade", _fake)
+
+    assert server._run_self_upgrade([]) == 0
+    assert seen["version"] == "1.42.1"  # resolved-latest flowed into the upgrade
+
+
+def test_cli_self_upgrade_with_explicit_version_never_touches_pypi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pinned ``hive self-upgrade 1.41.6`` stays deterministic and network-free:
+    ``latest_version()`` must not be called when the caller already named a
+    version (auto-latest is strictly the omitted-arg path)."""
+    from hive import server
+
+    def _must_not_resolve() -> str:
+        raise AssertionError("explicit version must not hit PyPI")
+
+    monkeypatch.setattr("hive._runtime.latest_version", _must_not_resolve)
+    monkeypatch.setattr("hive._runtime.self_upgrade", lambda version: "1.41.5")
+
+    assert server._run_self_upgrade(["1.41.6"]) == 0
 
 
 def test_cli_self_upgrade_dispatches_the_version_to_the_orchestrator(


### PR DESCRIPTION
## What

`hive self-upgrade` now accepts an **optional** version. Omitted, it resolves the newest `hive-vault` release from PyPI's JSON API (`info.version`), so the unattended dotfiles upgrade trigger can fire a bare `hive self-upgrade`. An explicit `hive self-upgrade <version>` stays deterministic and network-free.

## Why

Continues #292 (HIVE-267 / ADR-015 mechanism A3). PR #294 shipped the explicit `<version>` contract and deliberately deferred auto-latest to the unattended trigger; this is that follow-up. Without it, the trigger would have to resolve the latest version itself.

## How

- `_runtime.latest_version(package="hive-vault")` — the module's single network seam (mocked in unit tests; real PyPI exercised only by the trigger). Bounded by a 10s timeout. Every failure — timeout, network/HTTP error, unexpected payload — raises an actionable WHY/FIX `RuntimeError` naming the explicit-version escape hatch, never a bare httpx traceback nor an empty version that would repoint `current` at nothing.
- `_run_self_upgrade` makes `version` `nargs="?"`; omitted → `latest_version()`. An explicit version never touches PyPI.
- Catches the `httpx.TimeoutException` umbrella per the load-bearing rule in `AGENTS.md` (a slow PyPI surfaces as `ReadTimeout`).

## Verification

- `make check` green: **794 passed, 19 skipped**; `ruff` + `ruff format --check` + `mypy --strict` clean.
- 5 new tests: `latest_version` happy / timeout / bad-payload, plus CLI omitted-resolves-latest vs explicit-never-touches-PyPI.
- Real read-only check: `_runtime.latest_version()` → `1.42.1` against live PyPI; `hive self-upgrade -h` shows the optional `[version]`.

## Out of scope (remaining #292 work)

- **dotfiles (cross-repo):** swap the `uv tool install --upgrade` trigger for `hive self-upgrade`.
- **real-hardware Windows** non-admin re-validation.

Spec: `specs/HIVE-267-upgrade-swap/`.