### PR TITLE
fix(deps): bound fastmcp to >=3.3.1,<4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,20 @@ classifiers = [
     "Topic :: Text Processing :: Markup :: Markdown",
 ]
 dependencies = [
-    "fastmcp>=2.0.0",
+    # The >=2.0.0 floor was unsatisfiable: src/hive/_client.py imports
+    # fastmcp.server.providers.proxy.FastMCPProxy, which exists only from
+    # 3.x on (2.x exposed it as fastmcp.server.proxy), and _diagnostics.py
+    # needs fastmcp.server.middleware, absent in 2.0.0. A resolver that
+    # honoured the old floor produced an install that could not import.
+    # Note fastmcp 3.x is a metadata-only meta-package: it pins
+    # fastmcp-slim[client,server]==<same version>, and all code ships in
+    # fastmcp-slim under the shared `fastmcp/` namespace. A partial or
+    # skewed upgrade across that split leaves importable-looking installs
+    # missing real submodules — see #319.
+    # Cap at <4 so a deliberate review happens before adopting any new
+    # major release. Bump the lower bound when verifying a newer release.
+    # 3.3.1 and 3.4.6 audited 2026-08-06: full suite green on both.
+    "fastmcp>=3.3.1,<4",
     "filelock>=3.13",
     "httpx>=0.27.0",
     # Pinned because src/hive/_compat.py monkey-patches private

--- a/uv.lock
+++ b/uv.lock
@@ -550,7 +550,7 @@ semantic = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.0.0" },
+    { name = "fastmcp", specifier = ">=3.3.1,<4" },
     { name = "filelock", specifier = ">=3.13" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.27,<2.0" },


### PR DESCRIPTION
## Problem

`pyproject.toml` declared `fastmcp>=2.0.0`. That floor was unsatisfiable in practice — hive cannot run on any 2.x release:

| Import | Where | 2.0.0 | 2.14.1 | 3.3.1+ |
|---|---|:--:|:--:|:--:|
| `fastmcp.server.providers.proxy` | `_client.py:185` | no | no | yes |
| `fastmcp.server.middleware` | `_diagnostics.py:25` | no | yes | yes |
| `fastmcp.server.auth.providers.jwt` | `_daemon.py:102` | no | yes | yes |

`FastMCPProxy` lived at `fastmcp.server.proxy` in 2.x and moved to `fastmcp.server.providers.proxy` in 3.x, so any resolution honouring the old floor produced an install that raised `ImportError` on startup.

## Change

`fastmcp>=3.3.1,<4`, with the reasoning recorded inline — mirroring the treatment already applied to `mcp>=1.27,<2.0` in the same block.

The floor is the lowest version actually verified rather than the lowest that might work, per the discipline the `mcp` pin comment already states ("bump the lower bound when verifying a newer release").

## Context for the upper bound (#319)

From 3.x, `fastmcp` on PyPI is a **metadata-only meta-package** — its 3.4.6 wheel contains 4 files, none of them code. It pins `fastmcp-slim[client,server]==<same version>`, and all code ships in `fastmcp-slim` under the shared `fastmcp/` namespace.

That split is relevant to #319, which reports `ModuleNotFoundError: No module named 'fastmcp.server.tasks.routing'`. The issue attributes it to a removed module, but `fastmcp/server/tasks/routing.py` is present in **every** `fastmcp-slim` wheel from 3.3.1 through 3.4.6, and a clean `hive-vault==1.43.0` + fastmcp 3.4.6 venv imports `hive.server` without error. The reported error is what a partial or version-skewed install across that namespace split looks like.

This PR does not close #319 — it removes a real dependency-declaration defect and bounds future exposure. Diagnosis of the reporter's machine is still open there.

## Verification

Full suite green against both ends of the new range:

- fastmcp 3.3.1 — 811 passed, 2 skipped, 84% coverage
- fastmcp 3.4.6 — 811 passed, 2 skipped, 84% coverage

`ruff check` and `mypy --strict` clean.

Refs #319


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported FastMCP version range.
  * Prevented installation with unsupported older versions and untested future major versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->