### PR TITLE
docs: ADR-018 asynchronous commit queue + HIVE-322 spec scaffold

### DIFF
--- a/docs/adr/adr-018-asynchronous-commit-queue.md
+++ b/docs/adr/adr-018-asynchronous-commit-queue.md
@@ -1,0 +1,135 @@
+---
+id: "ADR-018-asynchronous-commit-queue"
+type: adr
+status: proposed
+owner: manu
+date: "2026-08-07"
+issue: "hive#322"   # repo#NNN — GitHub issue / Project item that triggered this decision
+tags: [architecture, decision, concurrency, git, performance]
+created: "2026-08-07"
+---
+
+# ADR-018: Asynchronous Commit Queue
+
+## Status
+
+Proposed (2026-08-07). Gates `specs/HIVE-322-commit-outbox/`. **Amends [ADR-014](adr-014-vault-commit-coordination.md)** — see "The ADR-014 tension" below, which is the load-bearing part of this decision. **Triggers the deferred "2b" evolution of [ADR-013](adr-013-write-idempotency-at-most-once.md)** — see "Relationship to ADR-013" below. The three design questions that blocked this ADR were resolved on 2026-08-07 and are recorded under "Decision".
+
+## Date
+
+2026-08-07
+
+## Context
+
+`vault_write` / `vault_patch` run a synchronous `git commit` on every call. Git commits against one repository serialize, so hive's write throughput has a hard ceiling independent of how much concurrency is applied to it.
+
+Measured on a 1300-file synthetic vault (methodology and full tables in [#322](https://github.com/mlorentedev/hive/issues/322); commit counts asserted after every run, since `_git_commit` swallows failures by design and a skipped commit would otherwise register as a *fast* sample):
+
+| 10 concurrent writers | throughput | p50 | max |
+|---|---:|---:|---:|
+| separate processes (pre-daemon) | 33.1 writes/s | 23.5 ms | 1389.6 ms |
+| threads in one process (daemon) | 30.0 writes/s | 317.3 ms | **417.5 ms** |
+
+Two conclusions follow, and the second is the one that motivates this ADR:
+
+1. The Phase C daemon ([ADR-011](adr-011-phase-c-daemon-model.md)) **does fix tail fairness** — it converts a lottery (median 23 ms, worst case 1.4 s, some writers starving) into a fair queue where everyone lands in 317-418 ms. Worst-case latency improves 3.3x.
+2. The daemon **does not raise the ceiling**. Throughput is ~30-33 writes/s either way. Removing the cross-process filelock does not help, because `_GIT_LOCK` still serializes inside the process and the underlying git commit is serial regardless. **Only committing less often raises the ceiling.**
+
+The reported field workload is up to 10 concurrent writers (agents dispatching subagents), which puts the vault on the flat part of that curve: adding agents buys queueing, not throughput.
+
+Prior art already in the repo:
+
+- **HIVE-104** shipped commit coalescing (`commit=False` on writes plus an explicit `vault_commit` flush). Measured at ~3x throughput and ~3x better tail — but it is opt-in per call, so every agent must be configured to use it and something must call the flush.
+- **HIVE-115 PR-4** shipped `src/hive/_outbox.py`: a generic `Outbox[T]` (thread-safe append, atomic swap-and-drain) with a reconciler thread draining on a tick. Exactly the shape this problem wants.
+- **[ADR-010](adr-010-external-committer-coexistence.md) / [ADR-014](adr-014-vault-commit-coordination.md)** govern who is allowed to commit to the vault, and are the constraint this decision must satisfy.
+
+## The ADR-014 tension
+
+This is the part that must be settled explicitly rather than assumed.
+
+ADR-014 chose **"Hive is the single deliberate committer"** and made turning obsidian-git's auto-commit timer **off** a precondition. Its stated objection to the timer was not that a second committer existed in the abstract, but a concrete failure mode: with `autoCommitOnlyStaged: false`, the timer "sweeps in-progress, unstaged work — including an agent's half-written change". ADR-014's framing is *event-driven commits, not timed ones*.
+
+An asynchronous commit queue reintroduces a **timer-driven committer**. Taken naively, that reverses ADR-014.
+
+The distinction that makes it safe is narrow and must be enforced in code, not merely intended:
+
+> The reconciler commits **only the paths it has queued**. It never runs `git add -A` or otherwise stages the working tree.
+
+A path-scoped timed committer cannot sweep an agent's half-written file, because a path enters the queue only *after* its write has completed. ADR-014's objection is therefore specific to *sweeping* timers, not to timed commits as such, and this ADR amends it to say so.
+
+**Consequence for #322 as originally written:** the first comment on that issue proposed "per-path drain, with an `add -A` sweep as the self-heal fallback". Under ADR-014 that fallback **is** the failure mode. It is withdrawn. Recovery of a dropped queue entry needs a different answer (see the open questions).
+
+## Relationship to ADR-013
+
+ADR-013 already anticipated this work. It adopted "2a" (synchronous idempotency-key claim) and **deferred "2b"** — the durable journal plus reconciler and replay-on-startup — explicitly gated on:
+
+> "EITHER (i) telemetry showing git-commit serialization as a real bottleneck, OR (ii) genuine concurrent write-heavy load arriving."
+
+**Both gates have now fired.** The measurements above are (i); the 10-concurrent-writer field workload is (ii). ADR-013 also predicted the contract consequence this ADR must own: 2b "changes **ACK semantics** (accepted ≠ committed) — an observable contract change needing bilingual docs".
+
+Two points of reconciliation:
+
+- **This ADR implements a subset of 2b.** It defers the *commit*; it does not build 2b's durable journal (see Decision 3 — startup reconciliation was chosen over a persisted queue). ADR-013's constraint that "the journal MUST be **SQLite-backed**" therefore does not bind here, but **remains binding** if idempotency-keyed at-most-once is later extended across the deferred path.
+- **ADR-013's at-most-once guarantee survives.** A claimed key means "the write was applied", and deferral does not duplicate writes. What changes is only that a claimed key no longer implies its commit has landed — which is precisely the ACK-semantics shift ADR-013 flagged.
+
+[ADR-017](adr-017-auto-commit-bypasses-vault-pre-commit-hook.md) needs no amendment: deferred and recovery commits both route through `_git_commit` → `_commit_args`, so `--no-verify` continues to apply uniformly, and push-side scanning is unaffected.
+
+## Decision
+
+Move committing off the write path into a reconciler thread that drains a queue of pending paths on a tick (`HIVE_COMMIT_TICK_S`), producing one commit per tick rather than one per write. Scope the change to the single-owner daemon regime; the multi-process path keeps today's synchronous commit until the [#176](https://github.com/mlorentedev/hive/issues/176) rollout completes.
+
+Under the daemon this is strictly simpler than the multi-process framing would suggest: one process means **one shared queue**, so 10 concurrent writers produce one commit per tick in total — not one per writer — and no cross-process coordination is required. At a 5 s tick that is a ~5% duty cycle on a 25 ms commit, where contention is negligible.
+
+The three questions that blocked this ADR are resolved as follows.
+
+### 1. A sibling primitive, not an amended `Outbox[T]`
+
+Introduce `CommitQueue` with its own crash-loss contract. `Outbox[T]`'s docstring — "do NOT use for durable state (audit logs, transactional commits, monetary ledgers)" — stays **untouched and absolute**; carving an exception into a contract that says "never" would make it advisory, and a future reader could reasonably conclude the outbox is safe for durable state generally.
+
+The two also need different semantics: `CommitQueue` must **deduplicate paths within a tick** (the same file written twice produces one entry, not two) and defines recovery, neither of which `Outbox[T]` has. Its contract is narrower than the one it declines to inherit: an unflushed path is a **delayed commit, not lost data**, because the file write lands on disk *before* the path is queued.
+
+### 2. A synchronous watchdog reusing the existing termination primitives
+
+The reconciler spawns git with its own deadline and reuses the **synchronous** primitives already in `_deadline.py` — `popen_creation_kwargs()` (the per-OS process-group/kill setup) and `_cleanup_index_lock()` — rather than duplicating platform logic.
+
+`bounded_call` is rejected here despite being the repo-wide model: it is `async def`, so reusing it would require standing up an event loop inside a daemon thread purely to call it. Coupling async machinery to a synchronous thread costs more than the consistency buys. The *termination behaviour* stays shared even though the *supervision entry point* differs, which is where the actual cross-OS risk lives.
+
+### 3. Startup reconciliation, not a persisted queue
+
+Recovery extends `_startup_self_heal` (which already exists and today only clears a stale `index.lock`): enumerate uncommitted vault paths and issue one recovery commit.
+
+This is safe against the ADR-014 objection for two independent reasons: it runs **under the singleton `daemon.lock`**, so no sibling hive owns the tree, and it is a **startup event, not a recurring timer** — the property that made obsidian-git's sweep unsafe is absent. It still enumerates paths explicitly rather than running `add -A`.
+
+A persisted queue was rejected as adding a second synchronous disk write to the very path this ADR exists to empty, in exchange for a guarantee stronger than the problem needs — the failure being mitigated is a *delayed* commit, not a lost one.
+
+## Consequences
+
+### Positive
+
+- Removes the throughput ceiling this ADR exists to address: commit rate becomes a function of the tick, not of write volume.
+- Write-tool latency collapses to file I/O; the commit leaves the caller's critical path entirely.
+- Reuses a primitive and a threading model already proven in-repo rather than introducing a new concurrency mechanism.
+- Composes with ADR-011: one daemon, one queue, one commit per tick.
+
+### Negative
+
+- Reintroduces a timed committer, which ADR-014 removed — safe only under the path-scoped constraint above, which is now a load-bearing invariant that future changes can silently break.
+- Commit granularity coarsens: a delete-and-recreate inside one tick collapses to a single state, weakening `vault_delete`'s "git-recoverable" guarantee unless it opts out.
+- A write returns before its commit exists, so the response contract changes for every caller, and HIVE-104's "(uncommitted — call vault_commit to flush)" suffix now describes the normal path rather than an opt-in one. This is the ACK-semantics shift ADR-013 predicted, and it requires **bilingual site docs** (EN + ES) per the repo's docs rule.
+- A crash between write and flush leaves a file on disk uncommitted until the next daemon start. Startup reconciliation bounds the exposure to one daemon lifetime rather than indefinitely, but the window is real and is not closed by a durable queue.
+- Two supervision entry points now exist — `bounded_call` for the tool path, a synchronous watchdog for the reconciler. They share termination behaviour but not structure, so a future change to one must be mirrored deliberately.
+
+### Neutral
+
+- `vault_commit` and the explicit `commit=False` keyword keep their current semantics; this adds a default, it does not remove an option.
+- Hive stays commit-only — no push, per ADR-014.
+
+## References
+
+- [#322](https://github.com/mlorentedev/hive/issues/322) — measurements, methodology, and design discussion
+- `specs/HIVE-322-commit-outbox/` — the spec this ADR gates
+- [ADR-014](adr-014-vault-commit-coordination.md) — amended by this ADR
+- [ADR-011](adr-011-phase-c-daemon-model.md) — the single-owner daemon this decision assumes
+- [ADR-010](adr-010-external-committer-coexistence.md), [ADR-013](adr-013-write-idempotency-at-most-once.md), [ADR-017](adr-017-auto-commit-bypasses-vault-pre-commit-hook.md) — interactions to check before acceptance
+- [ADR-008](adr-008-hard-deadline-enforcement.md) — the supervision model the reconciler thread currently escapes
+- `src/hive/_outbox.py` — the primitive under consideration

--- a/specs/HIVE-322-commit-outbox/proposal.md
+++ b/specs/HIVE-322-commit-outbox/proposal.md
@@ -1,0 +1,67 @@
+---
+id: "HIVE-322-commit-outbox"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-07"
+issue: "hive#322"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HIVE-322: Commit outbox
+
+<!-- from issue #322: Concurrent writes serialize on the git commit path — tail latency grows linearly with writer count -->
+
+## Why
+
+Every `vault_write` / `vault_patch` synchronously runs a `git commit`, and git commits against one repository are inherently serial. Measured on a 1300-file vault, write throughput is pinned at **~30-33 writes/s regardless of concurrency** while tail latency grows linearly with the number of writers: 10 concurrent writers see p50 317 ms / max 418 ms inside the daemon, or max 1390 ms across separate processes. The reported field workload is up to 10 concurrent writers (agents dispatching subagents), so the vault is now a global serialization point for the whole agent fleet — adding agents buys queueing, not throughput. Full measurements and methodology in [#322](https://github.com/mlorentedev/hive/issues/322).
+
+## What
+
+`vault_write` and `vault_patch` persist the file and return **without** waiting for a git commit. Committing moves to a reconciler thread that drains a queue of pending paths on a tick, producing one commit per tick instead of one commit per write.
+
+Observable changes:
+
+1. Write-tool latency under concurrency drops to file-I/O cost; the commit no longer appears in the caller's critical path.
+2. Commit *rate* becomes bounded by the tick interval rather than by write volume — at a 5 s tick, a burst of 50 writes produces 1 commit instead of 50.
+3. `vault_health` surfaces queue depth and last-flush age, so a stalled reconciler is observable rather than silent.
+
+## Out of scope
+
+- The multi-process path. This spec targets the daemon (single-owner) regime; machines still running per-session stdio servers keep today's synchronous commit until the #176 rollout completes.
+- Any change to `vault_commit`'s explicit-flush semantics, or to the existing `commit=False` keyword — both stay as they are.
+- Pushing. Hive remains commit-only per ADR-014; nothing here introduces network I/O.
+
+## Risks / open questions
+
+**Resolved 2026-08-07 — recorded in [ADR-018](../../docs/adr/adr-018-asynchronous-commit-queue.md), which gates this spec.**
+
+- ~~Relationship to ADR-014.~~ **Resolved.** ADR-018 amends ADR-014: a *path-scoped* timed committer is exempt from the objection that killed the *sweeping* one, because a path enters the queue only after its write completes, so an agent's half-written file cannot be swept. The invariant is load-bearing and must be enforced in code: **the reconciler never runs `git add -A`.** This withdraws the "`add -A` sweep as self-heal fallback" proposed in #322's first comment — under ADR-014 that sweep is the failure mode, not the safety net.
+- ~~The `_outbox.py` crash-loss contract forbids this use.~~ **Resolved.** A sibling primitive `CommitQueue` is introduced with its own contract; `Outbox[T]`'s "do NOT use for durable state" stays untouched and absolute. `CommitQueue` additionally deduplicates paths within a tick, which `Outbox[T]` does not.
+- ~~The reconciler thread escapes all existing supervision.~~ **Resolved.** A synchronous watchdog reusing `_deadline.py`'s sync primitives (`popen_creation_kwargs()`, `_cleanup_index_lock()`). `bounded_call` is rejected because it is `async def` and would require an event loop inside a daemon thread.
+- ~~Recovery of a dropped queue entry.~~ **Resolved.** Startup reconciliation extends `_startup_self_heal`: under the singleton `daemon.lock`, enumerate uncommitted vault paths and issue one recovery commit. Safe against ADR-014 because it is a startup event rather than a recurring timer, and enumerates paths explicitly.
+- ~~Interaction with ADR-013 / ADR-017.~~ **Checked.** ADR-013 pre-planned this as its deferred "2b", gated on "telemetry showing git-commit serialization as a real bottleneck OR genuine concurrent write-heavy load arriving" — **both gates have fired**. This spec implements a subset of 2b (deferred commit, no durable journal), so ADR-013's "journal MUST be SQLite-backed" constraint does not bind here but remains binding if idempotency-keyed at-most-once is later extended across the deferred path. ADR-017 needs no amendment: `--no-verify` applies uniformly through `_commit_args`.
+
+Still open:
+
+- Commit granularity changes the `vault_delete` "git-recoverable" guarantee: a delete and recreate inside one tick collapse into a single state. [AGENT-DRAFT — review before archive] Proposed resolution: `vault_delete` keeps a synchronous commit, opting out of the queue.
+- Response-contract wording. HIVE-104 promises the suffix "(uncommitted — call vault_commit to flush)"; with deferral as the default that string now describes the normal path. ADR-013 flagged this as an observable contract change requiring bilingual docs. [AGENT-DRAFT — review before archive] Proposed resolution: new wording that names the tick, and `commit=True` continues to mean synchronous for callers that need the commit confirmed.
+
+## Acceptance criteria
+
+- [ ] AC1 — With the queue enabled, `vault_write` returns without a `git commit` in its call path (asserted by test, not by timing).
+- [ ] AC2 — N queued writes across one tick produce exactly one commit containing exactly those N paths, and no unrelated working-tree file is staged.
+- [ ] AC3 — 10 concurrent writers show write-tool latency bounded by file I/O, with commit count bounded by elapsed-time / tick rather than by write count.
+- [ ] AC4 — A reconciler flush that exceeds its deadline is terminated and logged, leaving no orphaned `git` process and no stale `index.lock`.
+- [ ] AC5 — `vault_health` reports queue depth and last-flush age; a stalled reconciler is visible there.
+- [ ] AC6 — On clean shutdown the queue is drained; nothing queued is silently discarded.
+- [ ] AC7 — The reconciler never stages a working-tree file it did not queue. This is the load-bearing ADR-014 invariant and is guarded by an explicit test, not by convention.
+- [ ] AC8 — The same path written twice within one tick produces one queue entry and appears once in the resulting commit.
+- [ ] AC9 — After an unclean exit, the next daemon start commits the vault paths left uncommitted, enumerating them explicitly rather than via `git add -A`.
+
+## References
+
+- Bitácora board: [hive#322](https://github.com/mlorentedev/hive/issues/322)
+- Related ADR: `docs/adr/adr-014-vault-commit-coordination.md` (single deliberate committer — must be amended), `docs/adr/adr-011-phase-c-daemon-model.md` (single-owner daemon this spec assumes), `docs/adr/adr-010` (external-committer coexistence), `docs/adr/adr-017-auto-commit-bypasses-vault-pre-commit-hook.md`
+- Prior art in-repo: `src/hive/_outbox.py` (`Outbox[T]` + reconciler-thread pattern, HIVE-115 PR-4), HIVE-104 commit coalescing (`commit=False` + `vault_commit`)
+- Related issues: [#176](https://github.com/mlorentedev/hive/issues/176) (daemon rollout — gates the multi-process path), [#288](https://github.com/mlorentedev/hive/issues/288) / [#289](https://github.com/mlorentedev/hive/issues/289) (tracker locks — measured NOT to be a latency cause; hang risk only)

--- a/specs/HIVE-322-commit-outbox/spike/README.md
+++ b/specs/HIVE-322-commit-outbox/spike/README.md
@@ -1,0 +1,56 @@
+# HIVE-322 spike
+
+One runnable measurement behind ADR-018. Unlike the HIVE-118 spikes (which
+de-risked a design before building it), this one establishes the
+**pre-implementation baseline** the commit queue has to move, and is the harness
+the eventual AC3 regression test grows out of.
+
+```bash
+uv run python specs/HIVE-322-commit-outbox/spike/commit_contention.py
+```
+
+Exit `0` = the integrity and sublinearity assertions held. Takes a few minutes:
+each ladder rung builds a fresh 1300-file git vault.
+
+## commit_contention.py
+
+Measures write latency and throughput across three regimes, on a vault sized to
+the real one's order of magnitude (commit cost tracks index size):
+
+| regime | stands for |
+|---|---|
+| **processes** | pre-daemon deployment — one hive process per MCP session, serialized across the filelock at `vault/.git/hive.lock` |
+| **threads** | the single-owner daemon (ADR-011) — cross-process filelock uncontended, only `_GIT_LOCK` serializes |
+| **coalesced** | HIVE-104's `commit=False` + `vault_commit` — bounds what batching alone buys |
+
+### What it asserts
+
+1. **Every expected commit landed.** `_git_commit` swallows failures by design
+   ("logged but never propagated"), so a silently skipped commit would be
+   recorded as a very *fast* latency sample and flatter the results. Each rung
+   asserts the exact commit count and a clean tree; a mismatch raises rather
+   than reporting a pretty number.
+2. **Throughput is sublinear in writer count.** If concurrency helped, N times
+   the writers would approach N times the throughput. The check allows 25% of
+   linear and observes ~1.5x for 12x the writers.
+
+The sublinearity check is deliberately *not* "flat within X%". Absolute
+throughput is noisy — a handful of writes per worker, real `git` subprocesses,
+page-cache effects — so an equality assertion would be flaky. Sublinearity is
+the claim that actually matters and it survives the noise. A warmup run is
+discarded before measuring so the `n=1` baseline is not depressed by cold start.
+
+### Reading the output
+
+The finding is the *shape*, not the absolute numbers, which move run to run:
+
+- **Per-write p50 stays flat while p95/max grow with N.** Median writers sail
+  through; the tail queues. Throughput does not improve.
+- **Threads narrow the spread.** The daemon converts a lottery (fast median,
+  ~1.5 s worst case) into a fair queue — better worst case, same ceiling.
+- **Coalescing raises the ceiling ~3x and holds it** across the ladder. It hits
+  the serialized commit less often; it does not remove the serialization.
+
+One observed run is recorded in `../verification.md` as the documented baseline.
+Expect run-to-run variance of tens of percent in absolute throughput — compare
+shapes and ratios, not individual cells.

--- a/specs/HIVE-322-commit-outbox/spike/commit_contention.py
+++ b/specs/HIVE-322-commit-outbox/spike/commit_contention.py
@@ -1,0 +1,249 @@
+"""HIVE-322 — write-path contention measurement.
+
+Reproduces the numbers ADR-018 and `../verification.md` are built on. This is a
+*measurement* spike, not a de-risk: it establishes the pre-implementation
+baseline the commit queue must move, and it is the harness the eventual AC3
+regression test grows out of.
+
+The claim under test is that hive's write throughput is bounded by a serialized
+`git commit` rather than by anything concurrency can relieve. Three regimes:
+
+- **processes** — N OS processes each committing per write. This is the
+  pre-daemon deployment: one hive process per MCP client session, serialized
+  across the filelock at `vault/.git/hive.lock`.
+- **threads** — N threads inside ONE process. This is the single-owner daemon
+  (ADR-011), where the cross-process filelock is uncontended and only
+  `_GIT_LOCK` serializes.
+- **coalesced** — N processes, but each commits its whole batch once. Stands in
+  for HIVE-104's `commit=False` + `vault_commit`, and bounds what batching
+  alone can buy.
+
+What it asserts (beyond printing tables):
+
+1. **Every expected commit landed.** `_git_commit` swallows failures by design
+   ("logged but never propagated"), so a silently skipped commit would show up
+   as a *fast* latency sample and inflate the results. Each run asserts the
+   commit count and that the tree is clean, so the numbers cannot be flattered
+   by work that never happened.
+2. **Throughput does not scale with writers.** In per-write mode, going from 1
+   to N writers must not raise throughput — that flatness is the finding.
+
+Run:
+
+    uv run python specs/HIVE-322-commit-outbox/spike/commit_contention.py
+
+Exit `0` = the integrity assertions held. The tables are for humans; diff them
+against `../verification.md` after the queue lands.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+_REPO_SRC = Path(__file__).resolve().parents[3] / "src"
+sys.path.insert(0, str(_REPO_SRC))
+
+from hive._helpers import _git_commit  # noqa: E402
+
+# Sized to the real vault's order of magnitude — commit cost tracks index size.
+N_FILES = 1300
+WRITES_PER_WORKER = 5
+LADDER = (1, 2, 4, 5, 8, 10, 12)
+
+
+# ── vault fixture ────────────────────────────────────────────────────────────
+
+
+def make_vault(root: Path) -> None:
+    """A git vault of N_FILES notes, all committed."""
+    for i in range(N_FILES):
+        d = root / f"10_projects/p{i % 20}"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"note{i}.md").write_text(f"# Note {i}\n\n" + ("lorem ipsum\n" * 40))
+    for args in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "spike@example.com"],
+        ["git", "config", "user.name", "Spike"],
+        ["git", "add", "."],
+        ["git", "commit", "-q", "-m", "init"],
+    ):
+        subprocess.run(args, cwd=root, capture_output=True, check=True)
+
+
+def _commit_count(root: Path) -> int:
+    out = subprocess.run(
+        ["git", "rev-list", "--count", "HEAD"], cwd=root, capture_output=True, text=True
+    )
+    return int(out.stdout)
+
+
+def _dirty_count(root: Path) -> int:
+    out = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=root, capture_output=True, text=True
+    )
+    return len(out.stdout.strip().splitlines()) if out.stdout.strip() else 0
+
+
+# ── workers ──────────────────────────────────────────────────────────────────
+
+
+def _do_writes(root: Path, wid: int, n_ops: int, coalesce: bool) -> list[float]:
+    """Write n_ops files, committing per write or once at the end."""
+    lat: list[float] = []
+    rels = []
+    for i in range(n_ops):
+        rel = Path(f"10_projects/p0/w{wid}_{i}.md")
+        (root / rel).write_text(f"# worker {wid} op {i}\n")
+        if coalesce:
+            rels.append(rel)
+            continue
+        t0 = time.perf_counter()
+        _git_commit(root, [rel], f"spike w{wid} op{i}")
+        lat.append((time.perf_counter() - t0) * 1000)
+    if coalesce:
+        t0 = time.perf_counter()
+        _git_commit(root, rels, f"spike w{wid} coalesced")
+        lat.append((time.perf_counter() - t0) * 1000)
+    return lat
+
+
+def _proc_worker(vault: str, wid: int, n_ops: int, coalesce: bool, out: mp.Queue) -> None:  # type: ignore[type-arg]
+    out.put(_do_writes(Path(vault), wid, n_ops, coalesce))
+
+
+# ── regimes ──────────────────────────────────────────────────────────────────
+
+
+def _stats(lat: list[float], wall: float, writes: int) -> tuple[float, float, float, float]:
+    lat.sort()
+    p95 = lat[int(len(lat) * 0.95)] if len(lat) > 1 else lat[0]
+    return statistics.median(lat), p95, lat[-1], writes / wall
+
+
+def run_processes(n: int, coalesce: bool = False) -> tuple[float, float, float, float]:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d) / "vault"
+        root.mkdir()
+        make_vault(root)
+        base = _commit_count(root)
+        q: mp.Queue = mp.Queue()  # type: ignore[type-arg]
+        ps = [
+            mp.Process(target=_proc_worker, args=(str(root), w, WRITES_PER_WORKER, coalesce, q))
+            for w in range(n)
+        ]
+        t0 = time.perf_counter()
+        for p in ps:
+            p.start()
+        lat: list[float] = []
+        for _ in ps:
+            lat.extend(q.get())
+        for p in ps:
+            p.join()
+        wall = time.perf_counter() - t0
+        _assert_integrity(root, base, n, coalesce)
+    return _stats(lat, wall, n * WRITES_PER_WORKER)
+
+
+def run_threads(n: int) -> tuple[float, float, float, float]:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d) / "vault"
+        root.mkdir()
+        make_vault(root)
+        base = _commit_count(root)
+        lat: list[float] = []
+        guard = threading.Lock()
+
+        def worker(wid: int) -> None:
+            mine = _do_writes(root, wid, WRITES_PER_WORKER, False)
+            with guard:
+                lat.extend(mine)
+
+        ts = [threading.Thread(target=worker, args=(w,)) for w in range(n)]
+        t0 = time.perf_counter()
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join()
+        wall = time.perf_counter() - t0
+        _assert_integrity(root, base, n, False)
+    return _stats(lat, wall, n * WRITES_PER_WORKER)
+
+
+def _assert_integrity(root: Path, base: int, n_workers: int, coalesce: bool) -> None:
+    """Every expected commit landed and nothing is left uncommitted.
+
+    Without this the whole measurement is worthless: a commit that silently
+    failed would be recorded as a very fast sample.
+    """
+    expected = n_workers * (1 if coalesce else WRITES_PER_WORKER)
+    got = _commit_count(root) - base
+    if got != expected:
+        raise AssertionError(f"commit count {got} != expected {expected} — numbers invalid")
+    dirty = _dirty_count(root)
+    if dirty:
+        raise AssertionError(f"{dirty} uncommitted file(s) left behind — numbers invalid")
+
+
+# ── report ───────────────────────────────────────────────────────────────────
+
+
+def _table(title: str, rows: list[tuple[int, tuple[float, float, float, float]]]) -> None:
+    print(f"\n== {title} ==")
+    print(f"{'n':>4} {'p50_ms':>9} {'p95_ms':>9} {'max_ms':>9} {'writes/s':>9}")
+    for n, (p50, p95, mx, tput) in rows:
+        print(f"{n:>4} {p50:>9.1f} {p95:>9.1f} {mx:>9.1f} {tput:>9.1f}")
+
+
+def main() -> int:
+    print(f"vault = {N_FILES} files, {WRITES_PER_WORKER} writes per worker")
+
+    # Warm the page cache and the git object store before measuring: the first
+    # run of a fresh vault is dominated by cold-start cost and would otherwise
+    # depress the n=1 baseline the scaling check reads.
+    run_processes(1)
+
+    procs = [(n, run_processes(n)) for n in LADDER]
+    _table("processes, commit per write (pre-daemon deployment)", procs)
+
+    threads = [(n, run_threads(n)) for n in LADDER]
+    _table("threads in one process, commit per write (single-owner daemon)", threads)
+
+    coalesced = [(n, run_processes(n, coalesce=True)) for n in LADDER]
+    _table("processes, one commit per worker (HIVE-104 coalescing)", coalesced)
+
+    # The finding is SUBLINEARITY, not equality. Absolute throughput is noisy
+    # (a few writes per worker, real subprocesses), so asserting "flat within
+    # X%" would be flaky. The claim that actually matters: if concurrency
+    # helped, N times the writers would give something approaching N times the
+    # throughput. Assert we are nowhere near that.
+    base_tput = procs[0][1][3]
+    top_tput = procs[-1][1][3]
+    observed = top_tput / base_tput
+    linear = LADDER[-1] / LADDER[0]
+    budget = linear * 0.25
+    print(
+        f"\nper-write throughput: {base_tput:.1f} writes/s at n={LADDER[0]} -> "
+        f"{top_tput:.1f} at n={LADDER[-1]} ({observed:.2f}x for {linear:.0f}x the writers)"
+    )
+    if observed > budget:
+        print(
+            f"UNEXPECTED: {observed:.2f}x scaling exceeds the {budget:.2f}x sublinearity "
+            "budget — the serialization claim needs review"
+        )
+        return 1
+    print(
+        f"confirmed: added writers buy queueing, not throughput "
+        f"({observed:.2f}x <= {budget:.2f}x budget)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/HIVE-322-commit-outbox/tasks.md
+++ b/specs/HIVE-322-commit-outbox/tasks.md
@@ -1,0 +1,55 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-07"
+---
+
+# Tasks - HIVE-322-commit-outbox
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **NOT FROZEN.** The three `[MUST RESOLVE]` design questions are resolved (ADR-018, 2026-08-07), but two `[AGENT-DRAFT]` items remain in `proposal.md` and ADR-018 is still `proposed`. Implementation begins once the ADR is accepted.
+
+## Setup
+
+- [x] Branch created from main: `feat/HIVE-322-commit-outbox`
+- [ ] **ADR-018 accepted** — authored 2026-08-07 with all three design questions resolved; awaiting acceptance — **gating**
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions" — 2 `[AGENT-DRAFT]` items remain (`vault_delete` opt-out, response-suffix wording)
+
+## Implementation
+
+- [ ] [P] [AC4] Write failing test: a reconciler flush exceeding its deadline is terminated, leaving no orphaned `git` process and no stale `index.lock`
+- [ ] [AC4] Give the reconciler a synchronous watchdog reusing `_deadline.py`'s sync primitives (`popen_creation_kwargs()`, `_cleanup_index_lock()`) — not `bounded_call`, which is `async def` (ADR-018 §2)
+- [ ] [P] [AC2] Write failing test: N queued paths across one tick produce exactly one commit containing exactly those paths, with no unrelated working-tree file staged
+- [ ] [P] [AC8] Write failing test: the same path written twice within one tick produces one queue entry, not two
+- [ ] [AC2] [AC8] Add `CommitQueue` — a sibling primitive to `Outbox[T]` with its own crash-loss contract and within-tick path dedup (ADR-018 §1) — plus a reconciler thread draining on `HIVE_COMMIT_TICK_S`
+- [ ] [P] [AC7] Write failing test: the reconciler never stages a working-tree file it did not queue (the load-bearing ADR-014 invariant — guard it explicitly)
+- [ ] [AC1] Route `vault_write` / `vault_patch` through the queue; assert by test that no `git commit` occurs in the tool's call path
+- [ ] Refactor: fold the queue path and the existing `commit=False` deferral into one code path rather than two parallel deferral mechanisms
+- [ ] [P] [AC6] Write failing test: clean shutdown drains the queue; nothing queued is discarded
+- [ ] [AC6] Implement drain-on-shutdown, wired to the daemon's existing signal handling
+- [ ] [P] [AC5] Write failing test: `vault_health` reports queue depth and last-flush age, and a stalled reconciler is visible
+- [ ] [AC5] Surface queue depth + last-flush age in the `vault_health` runtime block
+- [ ] [AC3] Concurrency benchmark beside `TestWriteThroughputBenchmark`: 10 writers, assert commit count is bounded by elapsed-time / tick rather than by write count
+- [ ] [AC3] Decide and implement the non-daemon (multi-process) behaviour — keep synchronous commit until #176 lands
+- [ ] [P] [AC9] Write failing test: startup reconciliation commits uncommitted vault paths left by a prior crash, enumerating paths explicitly (never `add -A`)
+- [ ] [AC9] Extend `_startup_self_heal` with the recovery commit, under the singleton `daemon.lock` (ADR-018 §3)
+- [ ] (risk-mitigation, no AC) `vault_delete` opts out of the queue (keeps synchronous commit) per the proposal's resolution
+- [ ] (contract housekeeping, no AC) Response-suffix wording updated for deferral-by-default; `commit=True` still means synchronous
+- [ ] (docs housekeeping, no AC) Bilingual site docs (EN + ES) for the ACK-semantics change ADR-013 flagged as an observable contract change
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` following [[pattern-feature-list-as-primitive]]. Not yet written — it is authored once `tasks.md` freezes (after the gating ADR), so the verification commands describe real test names rather than guesses.
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state.

--- a/specs/HIVE-322-commit-outbox/verification.md
+++ b/specs/HIVE-322-commit-outbox/verification.md
@@ -40,6 +40,10 @@ Threads in one process (the daemon regime this spec targets):
 
 Throughput is flat at ~30-33 writes/s in both regimes: the daemon fixes tail *fairness* (max 1390 ms -> 418 ms at 10 writers) but not the ceiling, because a git commit against one repo is serial. This is the number the spec must move.
 
+Reproduce with `spike/commit_contention.py` (see `spike/README.md`). The tables above are **one observed run**; absolute throughput varies by tens of percent between runs, so compare shapes and ratios rather than individual cells. The spike asserts the two things that hold regardless of noise: every expected commit actually landed, and throughput is sublinear in writer count (~1.5x observed for 12x the writers).
+
+Coalescing raises the ceiling to ~85-100 writes/s and **holds it across the ladder** — it hits the serialized commit less often without removing the serialization. An earlier single-run reading suggested coalesced throughput degraded with N; repeated runs do not support that, and the claim is withdrawn.
+
 ## Test status
 
 - Test suite: `<command> -> <output / coverage %>`

--- a/specs/HIVE-322-commit-outbox/verification.md
+++ b/specs/HIVE-322-commit-outbox/verification.md
@@ -1,0 +1,64 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-07"
+---
+
+# Verification - HIVE-322-commit-outbox
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] AC1 no commit in the write call path -> test `<name>`
+- [ ] AC2 one commit per tick, exact path set -> test `<name>`
+- [ ] AC3 latency + commit-count bound under 10 writers -> benchmark `<name>`
+- [ ] AC4 reconciler deadline termination, no orphans -> test `<name>`
+- [ ] AC5 `vault_health` queue depth + last-flush age -> test `<name>`
+- [ ] AC6 clean-shutdown drain -> test `<name>`
+
+## Baseline (pre-implementation)
+
+Measured 2026-08-06 on a 1300-file synthetic vault, 5 writes per worker, commit counts asserted after each run (`_git_commit` swallows failures by design, so a skipped commit would otherwise register as a fast sample).
+
+Multi-process (per-session stdio servers, no daemon):
+
+| procs | p50 | p95 | max | writes/s |
+|---:|---:|---:|---:|---:|
+| 1 | 25.1 ms | 35.0 ms | 35.0 ms | 35.8 |
+| 5 | 24.6 ms | 485.8 ms | 637.0 ms | 33.2 |
+| 10 | 23.5 ms | 1076.0 ms | 1389.6 ms | 33.1 |
+| 12 | 25.5 ms | 1442.0 ms | 1745.7 ms | 31.5 |
+
+Threads in one process (the daemon regime this spec targets):
+
+| threads | p50 | p95 | max | writes/s |
+|---:|---:|---:|---:|---:|
+| 1 | 27.9 ms | 33.1 ms | 33.1 ms | 35.0 |
+| 5 | 148.3 ms | 233.9 ms | 237.4 ms | 28.7 |
+| 10 | 317.3 ms | 391.3 ms | 417.5 ms | 30.0 |
+| 12 | 370.2 ms | 417.6 ms | 446.1 ms | 31.2 |
+
+Throughput is flat at ~30-33 writes/s in both regimes: the daemon fixes tail *fairness* (max 1390 ms -> 418 ms at 10 writers) but not the ceiling, because a git commit against one repo is serial. This is the number the spec must move.
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+-
+
+## Promotion candidates
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? yes — ADR-018 is gating, authored before implementation rather than promoted after
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HIVE-322-commit-outbox/` -> `specs/archive/HIVE-322-commit-outbox/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
Design-only PR: an ADR and a spec scaffold. **No production code changes** — `src/` is untouched.

Closes nothing; gates the implementation of #322.

## What this decides

Writes run a synchronous `git commit`, and git commits against one repository serialize, so throughput has a hard ceiling regardless of how much concurrency is applied. Measured on a 1300-file vault, with commit counts asserted after every run:

| 10 concurrent writers | throughput | p50 | max |
|---|---:|---:|---:|
| separate processes | 33.1 writes/s | 23.5 ms | 1389.6 ms |
| threads in the single-owner daemon | 30.0 writes/s | 317.3 ms | **417.5 ms** |

The daemon fixes tail *fairness* (a lottery becomes a fair queue, worst case 3.3x better) but **not the ceiling** — throughput is flat either way, because `_GIT_LOCK` still serializes in-process and the underlying commit is serial. Only committing less often raises it.

ADR-018 proposes moving commits to a reconciler thread draining a queue on a tick.

## The load-bearing part: amending ADR-014

ADR-014 chose "Hive is the single deliberate committer" and made turning obsidian-git's timer **off** a precondition — because with `autoCommitOnlyStaged: false` that timer "sweeps in-progress, unstaged work — including an agent's half-written change".

A commit queue **reintroduces a timed committer**. Taken naively that reverses ADR-014, so the exemption is recorded explicitly and narrowly:

> The reconciler commits **only the paths it has queued**. It never runs `git add -A`.

A path-scoped timed committer cannot sweep a half-written file, because a path is queued only *after* its write completes. ADR-014's objection is specific to *sweeping* timers, not to timed commits as such.

**This withdraws a suggestion made earlier on #322** — "per-path drain, with an `add -A` sweep as the self-heal fallback". Under ADR-014 that sweep is the failure mode, not the safety net. Recovery is handled by startup reconciliation instead.

## This triggers ADR-013's deferred work

ADR-013 adopted "2a" and deferred "2b" (deferred commit + reconciler) gated on "**EITHER** (i) telemetry showing git-commit serialization as a real bottleneck, **OR** (ii) genuine concurrent write-heavy load arriving". Both gates have now fired.

Two reconciliations recorded in the ADR:

- This implements a **subset** of 2b — the commit is deferred, no durable journal is built — so ADR-013's "the journal MUST be SQLite-backed" does not bind here, but **stays binding** if idempotency-keyed at-most-once is later extended across the deferred path.
- ADR-013's at-most-once guarantee survives; what changes is that a claimed key no longer implies its commit has landed. That is the ACK-semantics shift ADR-013 predicted, and it carries the bilingual-docs requirement.

ADR-017 needs no amendment: `--no-verify` applies uniformly through `_commit_args`.

## Three design questions resolved

1. **A sibling `CommitQueue`, not an amended `Outbox[T]`.** `Outbox[T]`'s "do NOT use for durable state" stays absolute — carving an exception into a contract that says "never" makes it advisory. The two need different semantics anyway: `CommitQueue` dedups paths within a tick and defines recovery.
2. **A synchronous watchdog** reusing `_deadline.py`'s sync primitives (`popen_creation_kwargs()`, `_cleanup_index_lock()`). `bounded_call` is `async def`; reusing it would mean an event loop inside a daemon thread. Termination *behaviour* stays shared — that is where the cross-OS risk lives — even though the supervision entry point differs.
3. **Startup reconciliation**, extending `_startup_self_heal`. Safe against ADR-014 for two independent reasons: it runs under the singleton `daemon.lock`, and it is a startup event rather than a recurring timer.

## Spec state

`/spec check` verdict: **PASS** — 9 acceptance criteria, 19 implementation tasks, zero uncovered, zero orphans.

AC7 is worth calling out: it guards the ADR-014 invariant with an explicit test — the reconciler must never stage a file it did not queue. Left as a convention rather than a test, any future change breaks it silently.

`verification.md` carries the pre-implementation baseline (both latency tables plus methodology). `features.json` is deliberately absent until `tasks.md` freezes, so its verification commands can name real tests rather than guesses.

## Deliberately still blocked

- **ADR-018 is `proposed`, not accepted.** Acceptance is the gating item in `tasks.md`; implementation does not begin until then.
- Two `[AGENT-DRAFT]` items remain in `proposal.md` (`vault_delete` opt-out, response-suffix wording). The archive lock will refuse to close the spec until they are resolved.

## Scope

Out of scope for the eventual implementation, recorded in the proposal: the multi-process path (keeps synchronous commit until #176 lands), `vault_commit` / `commit=False` semantics, and pushing — Hive stays commit-only per ADR-014.

Refs #322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an architecture decision record for asynchronous, path-scoped commit processing in daemon mode.
  - Documented batching, deduplication, startup recovery, watchdog behavior, crash handling, and commit acknowledgements.
  - Added the HIVE-322 proposal, implementation task plan, acceptance criteria, and verification template.
  - Added a concurrency spike with execution guidance, performance measurements, integrity checks, and baseline comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->