### PR TITLE
fix(service): never register the daemon against a binary that cannot start

### DIFF
--- a/specs/HIVE-328-runtime-launcher/proposal.md
+++ b/specs/HIVE-328-runtime-launcher/proposal.md
@@ -1,0 +1,65 @@
+---
+id: "HIVE-328-runtime-launcher"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-08-07"
+issue: "hive#328"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HIVE-328: Runtime launcher + honest exec resolution
+
+<!-- from issue #328: self-upgrade builds the A3 layout but installs no PATH launcher; _resolve_exec() trusts a dead trampoline -->
+
+## Why
+
+A3 (HIVE-267 / ADR-015) made hive own its install layout: `self_upgrade` builds `versions/<v>` and flips a `current` junction. But `specs/HIVE-267-upgrade-swap/tasks.md:28` promised "hive owns the layout … **+ own launcher**", and the launcher was never implemented — so after a successful upgrade `current` points at a working venv that no shell can find. Independently, `_service._resolve_exec()` did a bare `shutil.which("hive")`, which cannot tell a healthy console script from an orphaned uv trampoline: on the maintainer's Windows box `which` returns `~/.local/bin/hive.exe`, and running it yields `error: uv trampoline failed to canonicalize script path`. `hive service install` would therefore have registered a supervised daemon against a binary that can never start. Together these are why dotfiles#791 (AI-028) PR2 cannot proceed.
+
+## What
+
+1. `_resolve_exec()` resolves in an order that reflects ownership: the A3 `current` layout first (it follows upgrades, so the registered command survives a version swap unrewritten), then a `hive` on PATH **but only once verified to actually start**, then `<python> -m hive.server`. A present-but-broken binary falls through instead of being selected.
+2. `self_upgrade` (and a first install) installs a launcher on PATH that resolves **through `current`**, so an upgrade needs no launcher rewrite.
+
+Part 1 ships in PR1. **Part 2 is blocked on an unresolved design decision** — see below.
+
+## Out of scope
+
+- The dotfiles-side migration of the three install sites — dotfiles#791 (AI-028). This spec is its upstream dependency, not its implementation.
+- Repairing an already-orphaned trampoline. Detection/repair is dotfiles#574 (`dotf doctor --fix`); this spec stops hive from *trusting* one.
+- macOS / launchd.
+
+## Risks / open questions
+
+**BLOCKING for PR2 — which directory owns the launcher?** `~/.local/bin` is already on PATH on the affected machine (no admin, no shell restart — the constraints A3 was chosen under), but uv put the trampoline there, so hive writing into it means hive and uv both claim the directory. Worse on Windows: `PATHEXT` resolves `.COM;.EXE;.BAT;.CMD`, so a `hive.cmd` hive writes **loses to a leftover `hive.exe` sitting beside it** — meaning the launcher work is inseparable from disposing of another tool's artifact.
+
+Two candidate designs, neither obviously right:
+
+- **(A) Joint ownership of `~/.local/bin`.** hive writes its shim there and must detect-and-remove a stale trampoline. Already on PATH, so it works with no admin and no restart. Cost: hive races `uv tool install hive-vault` forever, and deleting a file uv created is a different class of act from installing hive's own.
+- **(B) hive owns `%LOCALAPPDATA%\hive\bin`.** No collision with uv. Cost: a PATH mutation step (User-scope env var on Windows), which does not affect already-running shells — so a fresh install is not usable until the user opens a new shell.
+
+Decide by asking which one `hive service install` can make work **without admin and without a shell restart**, since that is the constraint that selected A3 in the first place. A defensible middle path: write to `~/.local/bin` but only *replace* a `hive*` entry that fails the `_executes` probe, never a healthy one — repair rather than seizure.
+
+Non-blocking, decided:
+
+- **`sys.executable` fallback under A3.** Once hive runs *from* `versions/<v>`, `sys.executable` is that pinned venv's python, so `-m hive.server` resolves the pinned version rather than following `current`. Accepted: the fallback is a last resort reached only when there is no layout and nothing runnable on PATH, and in that situation "the interpreter that is running" is the only thing guaranteed to work. Correctness of the *supervisor-follows-the-junction* property is carried by branch 1, which is preferred whenever a layout exists.
+- **Probe cost.** `_executes` spawns `<command> --version` with a bounded 10 s timeout, on the install path only — not per request.
+
+## Acceptance criteria
+
+- [x] **AC1** — `_resolve_exec()` prefers the A3 layout over an arbitrary PATH hit, and returns the path **through `current`**, not the concrete `versions/<v>` dir.
+- [x] **AC2** — A PATH hit that cannot start is not selected; resolution falls through to the module invocation.
+- [x] **AC3** — A healthy PATH hit is still selected when no layout exists (no regression for uv-tool installs).
+- [x] **AC4** — With neither a layout nor a PATH hit, `<python> -m hive.server` is returned.
+- [x] **AC5** — The probe answers `False` on any subprocess failure and never propagates (AGENTS.md broad-`Exception` rule; Windows raises `OSError` variants here, not `CalledProcessError`).
+- [x] **AC6** — A `current` junction pointing at a half-built version (no launcher inside) does not win.
+- [ ] **AC7** *(PR2, blocked)* — After `hive self-upgrade` on a machine with no prior install, `hive --version` works from a fresh shell.
+- [ ] **AC8** *(PR2, blocked)* — An upgrade repoints `current` and requires no launcher rewrite; launcher installation is idempotent.
+
+## References
+
+- Bitácora board: [hive#328](https://github.com/mlorentedev/hive/issues/328)
+- Predecessor: `specs/HIVE-267-upgrade-swap/` — `tasks.md:28` is where the launcher was promised
+- ADR: `docs/adr/adr-015-windows-daemon-supervision-upgrade.md` (`proposed`; its AC-3 is what PR2 closes)
+- Downstream consumer: [dotfiles#791](https://github.com/mlorentedev/dotfiles/issues/791) (AI-028) — PR2 there is gated on PR2 here
+- Adjacent: [dotfiles#574](https://github.com/mlorentedev/dotfiles/issues/574) (`dotf doctor --fix` repairs an orphaned trampoline), [hive#176](https://github.com/mlorentedev/hive/issues/176)

--- a/specs/HIVE-328-runtime-launcher/tasks.md
+++ b/specs/HIVE-328-runtime-launcher/tasks.md
@@ -1,0 +1,57 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-07"
+---
+
+# Tasks - HIVE-328-runtime-launcher
+
+> TDD order. One task = one focused commit. Tick as you go.
+>
+> **Split into two PRs.** PR1 (exec resolution) has no design ambiguity and ships first — it is the half that stops `hive service install` registering a daemon against a dead binary. PR2 (the launcher) is **blocked on the directory-ownership decision** in `proposal.md` and must not start until that is settled.
+
+## Setup
+
+- [x] Branch created from master: `fix/resolve-exec-verifies-the-binary`
+- [x] Gating issue open: hive#328
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions" — **one BLOCKING question remains** (launcher directory), scoped to PR2
+
+## Implementation
+
+### PR1 — honest exec resolution (AC1-AC6) — no design ambiguity, ships first
+
+- [x] [P] [AC1] Write failing test: the A3 layout beats an arbitrary PATH hit, and the returned path goes **through `current`**, not `versions/<v>`.
+- [x] [P] [AC2] Write failing test: a PATH hit that cannot start falls through to the module invocation.
+- [x] [P] [AC3] Write failing test: a healthy PATH hit is still selected when no layout exists.
+- [x] [P] [AC4] Write failing test: neither layout nor PATH hit yields `<python> -m hive.server`.
+- [x] [P] [AC5] Write failing test: the probe answers `False` on a raised `OSError` and never propagates.
+- [x] [P] [AC6] Write failing test: a `current` pointing at a version dir with no launcher inside does not win.
+- [x] [AC1] Add `_current_layout_exec()` — reads `_runtime.current_link() / {Scripts,bin} / hive[.exe]`, returns `None` when absent.
+- [x] [AC2] [AC5] Add `_executes(command)` — bounded `<command> --version` probe, broad `Exception` -> `False`, `_subprocess_run_kwargs()` so no console window flashes on Windows.
+- [x] [AC1-AC4] Rewrite `_resolve_exec()` as layout -> verified PATH hit -> module invocation.
+- [x] Test fixture uses `_runtime._make_junction`, not `Path.symlink_to`: a Windows symlink needs `SeCreateSymbolicLinkPrivilege` (WinError 1314) while a junction does not — which is precisely why A3 uses `mklink /J`. Reusing the production seam keeps the fixture honest cross-OS.
+- [x] `make check` equivalent green: ruff, ruff format --check, mypy --strict, pytest.
+
+### PR2 — the PATH launcher (AC7, AC8) — BLOCKED
+
+- [ ] **GATE: decide the launcher directory** (`proposal.md` -> Risks). `~/.local/bin` (already on PATH, no admin, no restart, but shared with uv and losing to a leftover `hive.exe` under PATHEXT) vs `%LOCALAPPDATA%\hive\bin` (hive-owned, but needs a PATH mutation that does not reach running shells). Middle path to evaluate: write to `~/.local/bin` but only replace a `hive*` entry that FAILS the `_executes` probe — repair, never seizure.
+- [ ] [AC7] Install a launcher resolving through `current` as part of `self_upgrade` and first install.
+- [ ] [AC8] Idempotent re-install; an upgrade repoints the junction and rewrites nothing.
+- [ ] [AC8] Never clobber a healthy non-hive binary of the same name.
+- [ ] Then flip ADR-015 -> `accepted` (its AC-3) and unblock dotfiles#791 PR2.
+
+## Closing
+
+- [x] Every PR1 acceptance criterion is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` — deferred to PR2, when the criteria set is complete
+- [x] Type checks pass
+- [x] Lint passes
+- [x] No unrelated changes in the diff (no scope creep)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+`features.json` is authored when PR2 lands and the criteria set is complete. PR1's six criteria each map 1:1 onto a named test in `tests/test_service.py`, verifiable with a single command.
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state.

--- a/specs/HIVE-328-runtime-launcher/verification.md
+++ b/specs/HIVE-328-runtime-launcher/verification.md
@@ -1,0 +1,70 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-07"
+---
+
+# Verification - HIVE-328-runtime-launcher
+
+## Evidence
+
+- [x] AC1 (layout beats PATH, resolves through `current`) -> `test_resolve_exec_prefers_the_a3_layout_over_an_arbitrary_path_hit`
+- [x] AC2 (dead PATH hit falls through) -> `test_resolve_exec_rejects_a_path_hit_that_cannot_start`
+- [x] AC3 (healthy PATH hit still wins with no layout) -> `test_resolve_exec_accepts_a_path_hit_that_starts`
+- [x] AC4 (module-invocation fallback) -> `test_resolve_exec_falls_back_to_module_invocation`
+- [x] AC5 (probe never propagates) -> `test_executes_treats_any_probe_failure_as_not_runnable`
+- [x] AC6 (half-built layout does not win) -> `test_resolve_exec_ignores_a_layout_whose_launcher_is_missing`
+- [ ] AC7, AC8 -> PR2, blocked on the launcher-directory decision
+
+## The failure this closes, observed on real hardware (2026-08-07)
+
+Not hypothetical. On the maintainer's Windows box, at the time of writing:
+
+```
+$ python -c "import shutil; print(shutil.which('hive'))"
+C:\Users\mlorente\.local\bin\hive.exe
+
+$ hive --version
+error: uv trampoline failed to canonicalize script path
+```
+
+The old `_resolve_exec()` returned that first path unconditionally, so `hive service install` would have registered a supervised daemon whose task action is a binary that cannot start — and Task Scheduler would have reported the registration as successful. The new resolution runs the same `--version` probe and falls through.
+
+## Test status
+
+```
+$ .venv/Scripts/python.exe -m pytest tests/test_service.py -q
+22 passed
+
+$ .venv/Scripts/python.exe -m ruff check src/ tests/
+All checks passed!
+
+$ .venv/Scripts/python.exe -m ruff format --check src/ tests/
+68 files already formatted
+
+$ .venv/Scripts/python.exe -m mypy --strict src/
+Success: no issues found in 29 source files
+```
+
+Full-suite run and the cross-OS matrix are carried by CI on the PR (local Python here is 3.14, outside the supported 3.12/3.13 floor, so CI is the authority for the whole-suite result).
+
+- No regressions: the five existing `test_service.py` cases that monkeypatch `_resolve_exec` are untouched and green; `_resolve_exec` had **zero direct coverage** before this change, which is how the defect survived.
+
+## Decisions made during implementation
+
+- **Split PR1 from PR2.** The exec-resolution half has no design ambiguity and closes the live hole; the launcher half turns on an unresolved directory-ownership question. Landing a half-implemented launcher would have been a worse artifact than a written-up decision.
+- **Verify by execution, not by existence.** `shutil.which` answers "is there a file on PATH", which is not the question the supervisor needs answered. The probe costs one bounded subprocess on the install path only.
+- **Fixture reuses `_runtime._make_junction`.** The first draft used `Path.symlink_to` and failed with `WinError 1314` — a Windows symlink needs a privilege a junction does not. That is the same fact that made A3 pick `mklink /J`, so the test now exercises the production seam instead of a parallel one that only works on POSIX or elevated Windows.
+- **Accepted the `sys.executable` fallback's version-pinning wrinkle.** Under A3 it resolves the pinned venv rather than following `current`; it is a last resort reached only when no layout and nothing runnable exist, where the running interpreter is the only guaranteed-working answer. Recorded in `proposal.md` rather than silently.
+
+## Promotion candidates
+
+- [ ] Lesson for the repo's `docs/lessons.md`? **yes, on PR2 completion** — "a `which` hit proves a file exists on PATH, not that it runs; when a supervisor is being pointed at something, existence is the wrong predicate". Held until the spec closes so it is written once, whole.
+- [ ] ADR-worthy decision? not for PR1. The **launcher-directory** decision in PR2 likely is — it settles who owns `~/.local/bin` between hive and uv, which outlives this spec.
+- [ ] New pattern candidate for `00_meta/patterns/`? no — single-project mechanics.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HIVE-328-runtime-launcher/` -> `specs/archive/HIVE-328-runtime-launcher/`
+- [ ] Bitácora board ticket moved to Done / closed with PR link (ADR-018) — **only after PR2**; PR1 alone does not close #328
+- [ ] Promotions above executed (if any)

--- a/src/hive/_service.py
+++ b/src/hive/_service.py
@@ -28,12 +28,17 @@ import tempfile
 from pathlib import Path
 from xml.sax.saxutils import escape
 
+from hive._helpers import _subprocess_run_kwargs
 from hive.config import settings
 
 _log = logging.getLogger(__name__)
 
 SYSTEMD_UNIT_FILENAME = "hive.service"
 WINDOWS_TASK_NAME = "HiveVaultDaemon"
+
+# Bounded so a wedged launcher cannot hang `hive service install`; a healthy
+# `--version` returns in milliseconds.
+_PROBE_TIMEOUT_S = 10.0
 
 
 # ── platform + path helpers (all overridable in tests) ───────────────────
@@ -59,14 +64,61 @@ def systemd_unit_path() -> Path:
     return _config_root() / "systemd" / "user" / SYSTEMD_UNIT_FILENAME
 
 
+def _current_layout_exec() -> str | None:
+    """The launcher inside the A3 versioned layout, or ``None`` when absent.
+
+    Resolving through the ``current`` junction rather than a concrete version
+    dir is the property A3 exists for (HIVE-267): an upgrade repoints the
+    junction and the registered command keeps working, unrewritten.
+    """
+    from hive import _runtime
+
+    subdir, name = ("Scripts", "hive.exe") if sys.platform == "win32" else ("bin", "hive")
+    launcher = _runtime.current_link() / subdir / name
+    return str(launcher) if launcher.exists() else None
+
+
+def _executes(command: str) -> bool:
+    """Whether *command* actually starts.
+
+    ``shutil.which`` only proves a file sits on PATH. An orphaned uv trampoline
+    is present but dead (``failed to canonicalize script path``), and a
+    present-but-broken binary is indistinguishable from a healthy one at the
+    ``which`` level — registering it hands the supervisor a command that can
+    never start (#328, observed in dotfiles#791).
+
+    Broad ``Exception`` per AGENTS.md: on Windows a broken launcher surfaces as
+    ``OSError`` variants, not ``CalledProcessError``. A probe that cannot answer
+    means "not runnable", never a raised exception into the install path.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603
+            [command, "--version"],
+            check=False,
+            capture_output=True,
+            timeout=_PROBE_TIMEOUT_S,
+            **_subprocess_run_kwargs(),
+        )
+    except Exception:  # noqa: BLE001 — any failure to probe means "do not use it"
+        return False
+    return proc.returncode == 0
+
+
 def _resolve_exec() -> str:
     """Absolute command the supervisor runs (the unit/task appends ``serve``).
 
-    Prefers the installed ``hive`` console script; falls back to
-    ``<python> -m hive.server`` when it is not on PATH.
+    Resolution order, most-owned first:
+
+    1. the A3 versioned layout, when hive owns one — it follows upgrades;
+    2. a ``hive`` on PATH, but only once verified to start;
+    3. ``<python> -m hive.server``, which works because this interpreter has
+       hive importable by construction.
     """
+    layout = _current_layout_exec()
+    if layout:
+        return layout
     found = shutil.which("hive")
-    if found:
+    if found and _executes(found):
         return found
     return f"{sys.executable} -m hive.server"
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -340,3 +340,133 @@ def test_run_is_quiet_on_success(
     rc = svc._run(["schtasks", "/Query"])
     assert rc == 0
     assert capsys.readouterr().err == ""
+
+
+# ── _resolve_exec: what the supervisor is actually registered against (#328) ──
+
+
+def _seed_layout(root: Path, version: str = "1.43.0", *, with_launcher: bool = True) -> Path:
+    """Build a minimal A3 layout under *root* and return the launcher path.
+
+    Uses `_runtime._make_junction` rather than `Path.symlink_to`: on Windows a
+    symlink needs SeCreateSymbolicLinkPrivilege (WinError 1314) while a junction
+    does not, which is the whole reason A3 uses `mklink /J`. Reusing the
+    production seam keeps the fixture honest on both OSes.
+    """
+    import sys
+
+    from hive import _runtime
+
+    target = root / "versions" / version
+    bindir = target / ("Scripts" if sys.platform == "win32" else "bin")
+    bindir.mkdir(parents=True)
+    launcher = bindir / ("hive.exe" if sys.platform == "win32" else "hive")
+    if with_launcher:
+        launcher.write_text("", encoding="utf-8")
+    _runtime._make_junction(root / "current", target)
+    return launcher
+
+
+def test_resolve_exec_prefers_the_a3_layout_over_an_arbitrary_path_hit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The versioned layout is the install hive owns; a stray PATH hit is not.
+    Resolving through `current` also means an upgrade repoints the junction and
+    the registered command keeps working without being rewritten (#328)."""
+    import hive._service as svc
+
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    _seed_layout(tmp_path)
+    monkeypatch.setattr(svc.shutil, "which", lambda _: "/somewhere/else/hive")
+
+    resolved = svc._resolve_exec()
+
+    # Through `current`, NOT the concrete versions/<v> dir: that indirection is
+    # what lets an upgrade repoint the junction without rewriting the unit/task.
+    assert str(tmp_path / "current") in resolved
+    assert "versions" not in resolved
+    assert "somewhere/else" not in resolved
+
+
+def test_resolve_exec_rejects_a_path_hit_that_cannot_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An orphaned uv trampoline is present-but-dead: `which` finds it, running it
+    fails. Registering it would give the supervisor a command that can never
+    start — the #791 failure. It must fall through, not be selected."""
+    import hive._service as svc
+
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path / "absent"))
+    dead = tmp_path / "hive.exe"
+    dead.write_text("", encoding="utf-8")
+    monkeypatch.setattr(svc.shutil, "which", lambda _: str(dead))
+    monkeypatch.setattr(svc, "_executes", lambda _: False)
+
+    resolved = svc._resolve_exec()
+
+    assert str(dead) not in resolved
+    assert "-m hive.server" in resolved
+
+
+def test_resolve_exec_accepts_a_path_hit_that_starts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A healthy console script on PATH stays the answer when there is no layout."""
+    import hive._service as svc
+
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path / "absent"))
+    good = tmp_path / "hive"
+    good.write_text("", encoding="utf-8")
+    monkeypatch.setattr(svc.shutil, "which", lambda _: str(good))
+    monkeypatch.setattr(svc, "_executes", lambda _: True)
+
+    assert svc._resolve_exec() == str(good)
+
+
+def test_resolve_exec_falls_back_to_module_invocation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No layout and nothing on PATH: the module invocation always works because
+    the interpreter running this code has hive importable."""
+    import hive._service as svc
+
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path / "absent"))
+    monkeypatch.setattr(svc.shutil, "which", lambda _: None)
+
+    assert "-m hive.server" in svc._resolve_exec()
+
+
+def test_executes_treats_any_probe_failure_as_not_runnable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AGENTS.md load-bearing rule: subprocess invocations catch broad Exception —
+    on Windows a broken launcher raises OSError variants, not CalledProcessError.
+    The probe must answer False, never propagate."""
+    import hive._service as svc
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise OSError("the process cannot be accessed")
+
+    monkeypatch.setattr(svc.subprocess, "run", _boom)
+
+    assert svc._executes(str(tmp_path / "hive")) is False
+
+
+def test_resolve_exec_ignores_a_layout_whose_launcher_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A `current` junction pointing at a half-built version must not win — the
+    layout is only preferable when it actually contains a launcher."""
+    import hive._service as svc
+
+    monkeypatch.setenv("HIVE_RUNTIME_ROOT", str(tmp_path))
+    _seed_layout(tmp_path, with_launcher=False)
+    monkeypatch.setattr(svc.shutil, "which", lambda _: None)
+
+    assert "-m hive.server" in svc._resolve_exec()


### PR DESCRIPTION
PR1 of #328. **Does not close it** — PR2 (the PATH launcher) is blocked on a design decision written up in `specs/HIVE-328-runtime-launcher/proposal.md`.

## The bug

`_service._resolve_exec()` returned `shutil.which("hive")` unconditionally. That answers *"is there a file named hive on PATH"*, which is not the question a supervisor needs answered — an orphaned uv trampoline is **present but dead**, and indistinguishable from a healthy console script at the `which` level.

On the maintainer's Windows box, right now:

```
$ python -c "import shutil; print(shutil.which('hive'))"
C:\Users\mlorente\.local\bin\hive.exe

$ hive --version
error: uv trampoline failed to canonicalize script path
```

So `hive service install` would have registered a supervised daemon whose task action can never start — and Task Scheduler would have reported the registration as successful. This is the upstream half of the outage diagnosed in [dotfiles#791](https://github.com/mlorentedev/dotfiles/issues/791), where four mechanisms went silently inert together.

## The fix

Resolution is now ownership-ordered:

| # | Candidate | Why it ranks here |
|---|---|---|
| 1 | The A3 layout, **through the `current` junction** | It follows upgrades — repointing the junction keeps the registered command valid without rewriting the unit/task. That indirection is the property A3 exists for (#267). |
| 2 | A `hive` on PATH | Only once a bounded `--version` probe shows it actually starts. |
| 3 | `<python> -m hive.server` | Always works: the interpreter running this code has hive importable by construction. |

The probe catches broad `Exception` per the AGENTS.md load-bearing rule — on Windows a broken launcher surfaces as `OSError` variants, never `CalledProcessError` — and a probe that cannot answer means "do not use it", never an exception raised into the install path. Bounded at 10 s so a wedged launcher cannot hang the install; it runs on the install path only.

## Tests

Six added. **`_resolve_exec` had zero direct coverage before this** — all five existing references monkeypatch it (`test_service.py:115,137,154,180,204`), which is how the defect survived.

```
test_resolve_exec_prefers_the_a3_layout_over_an_arbitrary_path_hit
test_resolve_exec_rejects_a_path_hit_that_cannot_start
test_resolve_exec_accepts_a_path_hit_that_starts
test_resolve_exec_falls_back_to_module_invocation
test_executes_treats_any_probe_failure_as_not_runnable
test_resolve_exec_ignores_a_layout_whose_launcher_is_missing
```

AC1 asserts the returned path goes through `current` and **not** the concrete `versions/<v>` dir — the first draft asserted the resolved target and would have passed while silently losing the upgrade-follows-junction property.

The layout fixture uses `_runtime._make_junction`, not `Path.symlink_to`: a Windows symlink needs `SeCreateSymbolicLinkPrivilege` (WinError 1314) while a junction does not — the same fact that made A3 pick `mklink /J`. Reusing the production seam keeps the fixture honest on both OSes rather than green only on POSIX.

```
pytest tests/test_service.py   22 passed
ruff check                     All checks passed!
ruff format --check            68 files already formatted
mypy --strict                  Success: no issues found in 29 source files
```

Local Python here is 3.14, outside the supported 3.12/3.13 floor, so **CI is the authority for the full-suite result.**

## What is still blocked

`self_upgrade` builds `versions/<v>` and flips `current`, then stops — nothing installs a launcher on PATH, despite `specs/HIVE-267-upgrade-swap/tasks.md:28` promising "hive owns the layout … + own launcher". PR2 turns on **which directory owns that launcher**:

- **`~/.local/bin`** — already on PATH (no admin, no shell restart: the constraints that selected A3). But uv put the trampoline there, so hive and uv would both claim it, and on Windows `PATHEXT` resolves `.EXE` before `.CMD`, so a `hive.cmd` hive writes **loses to a leftover `hive.exe` beside it**. The launcher work is therefore inseparable from disposing of another tool's artifact.
- **`%LOCALAPPDATA%\hive\bin`** — hive-owned, no collision. But it needs a PATH mutation that does not reach already-running shells, so a fresh install is unusable until the user opens a new one.

A middle path worth evaluating: write to `~/.local/bin` but only replace a `hive*` entry that **fails** the `_executes` probe added here — repair, never seizure.

That decision likely deserves an ADR of its own, since it settles who owns `~/.local/bin` between hive and uv, and it outlives this spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved runtime startup by prioritizing the versioned runtime launcher.
  - Added validation for launchers discovered on the system PATH, including startup checks and timeout handling.
  - Added a reliable fallback that starts the service through the active Python interpreter.

- **Bug Fixes**
  - Prevents unusable, failing, or non-runnable launchers from blocking startup.

- **Documentation**
  - Added specifications, implementation tasks, verification results, acceptance criteria, and follow-up notes for runtime launcher support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->