### PR TITLE
fix(vault): announce when the commit tick ceiling disables auto-flush

### DIFF
--- a/site/src/content/docs/es/tools/vault.md
+++ b/site/src/content/docs/es/tools/vault.md
@@ -158,6 +158,10 @@ Dos bloques ahí informan sobre los [commits diferidos](#commits-diferidos-semá
 
 El commit salió del camino de escritura. Una escritura aterriza en disco, su ruta se encola, y un hilo reconciler vacía la cola en **un commit por tick** (`HIVE_COMMIT_TICK_S`, 5s por defecto) en vez de un commit por escritura. La tasa de commits pasa a ser función del tick y no del volumen de escrituras, que es lo que levanta el techo de rendimiento: los commits de git contra un mismo repositorio se serializan, así que la única forma de ir más rápido es commitear menos veces.
 
+:::caution[El tick tiene un techo de 300s]
+Poner `HIVE_COMMIT_TICK_S` por encima de **300** no ralentiza el reconciler: impide que arranque. A partir de ahí las rutas encoladas solo se commitean en un apagado limpio o con un `vault_commit` explícito, y `vault_health` es lo que muestra crecer el backlog. El servidor registra `mcp.reconciler.auto_flush_disabled` al arrancar cuando ocurre. Si quieres commits poco frecuentes, usa un tick por debajo del techo.
+:::
+
 | Si quieres | Pasa |
 |---|---|
 | El comportamiento síncrono anterior | `commit=True` — commitea antes de devolver |

--- a/site/src/content/docs/tools/vault.md
+++ b/site/src/content/docs/tools/vault.md
@@ -158,6 +158,10 @@ Two blocks there report on [deferred commits](#deferred-commits-ack-semantics). 
 
 The commit moved off the write path. A write lands on disk, its path is queued, and a reconciler thread drains the queue into **one commit per tick** (`HIVE_COMMIT_TICK_S`, default 5s) rather than one commit per write. Commit rate is now a function of the tick instead of write volume, which is what lifts the throughput ceiling: git commits against one repository serialize, so the only way to go faster is to commit less often.
 
+:::caution[The tick has a ceiling of 300s]
+Setting `HIVE_COMMIT_TICK_S` above **300** does not slow the reconciler down — it stops it from starting at all. Queued paths then commit only on clean shutdown or an explicit `vault_commit`, and `vault_health` is what shows the backlog growing. The server logs `mcp.reconciler.auto_flush_disabled` at startup when this happens. For infrequent commits, prefer a tick within the ceiling.
+:::
+
 | You want | Pass |
 |---|---|
 | The previous synchronous behaviour | `commit=True` — commits before returning |

--- a/src/hive/_commit_queue.py
+++ b/src/hive/_commit_queue.py
@@ -33,7 +33,9 @@ _DEFAULT_COMMIT_TICK_S = 5.0
 _DEFAULT_FLUSH_DEADLINE_S = 30.0
 # Above this the loop is assumed to be deliberately disabled (tests pass a
 # large tick to drive flushes explicitly), mirroring the guard the lesson
-# reconciler uses for the same purpose.
+# reconciler uses for the same purpose. It is reachable from the public
+# ``HIVE_COMMIT_TICK_S`` too, so crossing it is announced rather than
+# silent — see the warning in ``CommitReconciler.__init__``.
 _MAX_AUTO_TICK_S = 300.0
 
 
@@ -233,6 +235,20 @@ class CommitReconciler:
                 daemon=True,
             )
             self._thread.start()
+        else:
+            # The ceiling doubles as a test affordance and a production
+            # cliff: ``HIVE_COMMIT_TICK_S`` is documented and settable, so a
+            # plausible "commit every 10 minutes" reaches this branch and
+            # gets no reconciler at all. Deferred paths would then wait for
+            # shutdown or an explicit vault_commit, which is a defensible
+            # mode but a terrible one to enter unknowingly (ADR-018 §3
+            # leaves the report as the only other signal).
+            _log.warning(
+                "mcp.reconciler.auto_flush_disabled tick_s=%.1f max_tick_s=%.1f "
+                "queued paths now commit only on clean shutdown or vault_commit",
+                self._tick_s,
+                _MAX_AUTO_TICK_S,
+            )
 
     @property
     def tick_s(self) -> float:

--- a/tests/test_commit_queue.py
+++ b/tests/test_commit_queue.py
@@ -1236,3 +1236,46 @@ def test_tick_commits_when_the_defer_predicate_cannot_be_evaluated(
         assert _rev_count(git_vault) == before + 1
     finally:
         reconciler.close(drain=False)
+
+
+# ── The auto-flush ceiling, which is also a public knob's cliff ──────────
+
+
+def test_tick_above_the_ceiling_disables_auto_flush_and_says_so(
+    git_vault: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A tick past ``_MAX_AUTO_TICK_S`` starts no loop, and announces it.
+
+    The ceiling earns its keep as a test affordance — every reconciler in
+    this file passes ``tick_s=3600.0`` precisely so no background thread
+    races an explicit ``flush_now()``. But ``HIVE_COMMIT_TICK_S`` is public
+    and documented, so a plausible "commit every 10 minutes" reaches the
+    same branch and gets no reconciler at all. Nine tests here depended on
+    that branch and none asserted it, which is how a test affordance stays
+    invisible as a production cliff.
+
+    The second half is what makes this discriminating rather than a
+    restatement of the constructor: *at* the ceiling the loop still starts,
+    so the assertion is about the threshold, not about construction.
+    """
+    from hive._commit_queue import _MAX_AUTO_TICK_S, CommitReconciler
+
+    with caplog.at_level(logging.WARNING, logger="hive._commit_queue"):
+        disabled = CommitReconciler(git_vault, tick_s=_MAX_AUTO_TICK_S + 1.0)
+    try:
+        assert disabled._thread is None
+        assert any("auto_flush_disabled" in rec.message for rec in caplog.records), [
+            r.message for r in caplog.records
+        ]
+    finally:
+        disabled.close(drain=False)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="hive._commit_queue"):
+        enabled = CommitReconciler(git_vault, tick_s=_MAX_AUTO_TICK_S)
+    try:
+        assert enabled._thread is not None
+        assert not any("auto_flush_disabled" in rec.message for rec in caplog.records)
+    finally:
+        enabled.close(drain=False)


### PR DESCRIPTION
## Why

`HIVE_COMMIT_TICK_S` is public and documented (EN + ES site docs name it and its 5s default). What neither the docs nor the code said is that a value above the `_MAX_AUTO_TICK_S` ceiling of 300s does not slow the reconciler down — it stops the loop from ever starting.

A plausible "commit every 10 minutes" therefore reached a branch where queued paths commit only on clean shutdown or an explicit `vault_commit`, and nothing announced it. No data-loss path (the files are on disk, and `vault_health --include_runtime` still shows the backlog growing), but a silent one.

The ceiling itself is deliberate and worth keeping: nine tests in `tests/test_commit_queue.py` pass `tick_s=3600.0` precisely so no background thread races an explicit `flush_now()`. That test affordance is what kept the production cliff invisible — all nine depend on the branch and none asserted it.

## What

- `CommitReconciler.__init__` logs `mcp.reconciler.auto_flush_disabled` with the configured and maximum tick when it skips the loop.
- `test_tick_above_the_ceiling_disables_auto_flush_and_says_so` asserts the threshold **in both directions**: above the ceiling no thread starts and the warning fires; *at* the ceiling the loop still starts and it does not. Without the second half the test would restate the constructor rather than pin the threshold.
- A `:::caution:::` beside the knob in `site/src/content/docs/tools/vault.md` and its ES mirror, naming the ceiling, the consequence, and the log line to look for.

No behaviour change beyond the log: a tick above the ceiling still disables auto-flush, which stays a defensible mode to choose deliberately.

## Verification

- `make check` — **862 passed, 2 skipped**, coverage 85%. Baseline on `master` was 861; the delta is this test.
- `uv run pytest tests/test_commit_queue.py -k ceiling` — 1 passed.

## Provenance

Found during the pre-archive adversarial review of `specs/HIVE-322-commit-outbox`, which is what the ceiling shipped under. Reported as Major / THEORETICAL / UNTESTED; this closes the UNTESTED half.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that commit intervals above 300 seconds disable automatic reconciliation.
  - Documented that queued changes are committed during clean shutdown or via `vault_commit`.
  - Noted that `vault_health` shows the pending backlog.

- **Bug Fixes**
  - Added a startup warning when automatic commit flushing is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->