### PR TITLE
fix(vault): apply review feedback on the tick-ceiling warning

### DIFF
--- a/site/src/content/docs/es/tools/vault.md
+++ b/site/src/content/docs/es/tools/vault.md
@@ -161,7 +161,7 @@ Dos bloques ahí informan sobre los [commits diferidos](#commits-diferidos-semá
 El commit salió del camino de escritura. Una escritura aterriza en disco, su ruta se encola, y un hilo reconciler vacía la cola en **un commit por tick** (`HIVE_COMMIT_TICK_S`, 5s por defecto) en vez de un commit por escritura. La tasa de commits pasa a ser función del tick y no del volumen de escrituras, que es lo que levanta el techo de rendimiento: los commits de git contra un mismo repositorio se serializan, así que la única forma de ir más rápido es commitear menos veces.
 
 :::caution[El tick tiene un techo de 300s]
-Poner `HIVE_COMMIT_TICK_S` por encima de **300** no ralentiza el reconciler: impide que arranque. A partir de ahí las rutas encoladas solo se commitean en un apagado limpio o con un `vault_commit` explícito, y `vault_health` es lo que muestra crecer el backlog. El servidor registra `mcp.reconciler.auto_flush_disabled` al arrancar cuando ocurre. Si quieres commits poco frecuentes, usa un tick por debajo del techo.
+Poner `HIVE_COMMIT_TICK_S` por encima de **300** no ralentiza el reconciler: impide que arranque. Lo que se detiene es la reconciliación *automática*: las rutas encoladas siguen llegando a git mediante un apagado limpio, un `vault_commit` explícito o un [committer externo](/es/guides/obsidian-git-integration/), pero ya nada ocurre por temporizador, y `vault_health` es lo que muestra crecer el backlog. El servidor registra `mcp.reconciler.auto_flush_disabled` al arrancar cuando ocurre. Si quieres commits poco frecuentes, usa un tick de **hasta 300 segundos inclusive** — exactamente 300 sigue arrancando.
 :::
 
 | Si quieres | Pasa |

--- a/site/src/content/docs/tools/vault.md
+++ b/site/src/content/docs/tools/vault.md
@@ -161,7 +161,7 @@ Two blocks there report on [deferred commits](#deferred-commits-ack-semantics). 
 The commit moved off the write path. A write lands on disk, its path is queued, and a reconciler thread drains the queue into **one commit per tick** (`HIVE_COMMIT_TICK_S`, default 5s) rather than one commit per write. Commit rate is now a function of the tick instead of write volume, which is what lifts the throughput ceiling: git commits against one repository serialize, so the only way to go faster is to commit less often.
 
 :::caution[The tick has a ceiling of 300s]
-Setting `HIVE_COMMIT_TICK_S` above **300** does not slow the reconciler down — it stops it from starting at all. Queued paths then commit only on clean shutdown or an explicit `vault_commit`, and `vault_health` is what shows the backlog growing. The server logs `mcp.reconciler.auto_flush_disabled` at startup when this happens. For infrequent commits, prefer a tick within the ceiling.
+Setting `HIVE_COMMIT_TICK_S` above **300** does not slow the reconciler down — it stops it from starting at all. What stops is *automatic* reconciliation: queued paths still reach git through a clean shutdown, an explicit `vault_commit`, or an [external committer](/guides/obsidian-git-integration/), but nothing happens on a timer any more, and `vault_health` is what shows the backlog growing. The server logs `mcp.reconciler.auto_flush_disabled` at startup when this happens. For infrequent commits, use a tick of **up to 300 seconds inclusive** — exactly 300 still runs.
 :::
 
 | You want | Pass |

--- a/src/hive/_commit_queue.py
+++ b/src/hive/_commit_queue.py
@@ -239,13 +239,18 @@ class CommitReconciler:
             # The ceiling doubles as a test affordance and a production
             # cliff: ``HIVE_COMMIT_TICK_S`` is documented and settable, so a
             # plausible "commit every 10 minutes" reaches this branch and
-            # gets no reconciler at all. Deferred paths would then wait for
-            # shutdown or an explicit vault_commit, which is a defensible
-            # mode but a terrible one to enter unknowingly (ADR-018 §3
-            # leaves the report as the only other signal).
+            # gets no reconciler at all. What stops is *automatic*
+            # reconciliation: deferred paths still reach git through a clean
+            # shutdown, an explicit vault_commit, or an external committer
+            # (ADR-010). A defensible mode to choose, a terrible one to enter
+            # unknowingly — ADR-018 §3 leaves the report as the only signal.
+            # %r, not %.1f: the threshold is exclusive, so a tick of 300.04
+            # lands here and would render as "tick_s=300.0 max_tick_s=300.0"
+            # — a warning that reads as though the ceiling was not crossed.
             _log.warning(
-                "mcp.reconciler.auto_flush_disabled tick_s=%.1f max_tick_s=%.1f "
-                "queued paths now commit only on clean shutdown or vault_commit",
+                "mcp.reconciler.auto_flush_disabled tick_s=%r max_tick_s=%r "
+                "no automatic reconciliation; queued paths reach git only via "
+                "clean shutdown, an explicit vault_commit, or an external committer",
                 self._tick_s,
                 _MAX_AUTO_TICK_S,
             )

--- a/tests/test_commit_queue.py
+++ b/tests/test_commit_queue.py
@@ -1262,12 +1262,21 @@ def test_tick_above_the_ceiling_disables_auto_flush_and_says_so(
     from hive._commit_queue import _MAX_AUTO_TICK_S, CommitReconciler
 
     with caplog.at_level(logging.WARNING, logger="hive._commit_queue"):
-        disabled = CommitReconciler(git_vault, tick_s=_MAX_AUTO_TICK_S + 1.0)
+        # Just past the ceiling rather than comfortably past it: with `%.1f`
+        # this value rendered as "tick_s=300.0 max_tick_s=300.0", a warning
+        # that reads as though the ceiling had not been crossed. A `+1.0`
+        # probe cannot see that, which is why the margin is 0.04.
+        disabled = CommitReconciler(git_vault, tick_s=_MAX_AUTO_TICK_S + 0.04)
     try:
         assert disabled._thread is None
-        assert any("auto_flush_disabled" in rec.message for rec in caplog.records), [
-            r.message for r in caplog.records
+        warnings = [
+            rec.getMessage() for rec in caplog.records if "auto_flush_disabled" in rec.message
         ]
+        assert warnings, [r.message for r in caplog.records]
+        # The rendered values, not just the event name: a lossy format would
+        # report the configured tick as equal to the ceiling it exceeded.
+        assert "tick_s=300.04" in warnings[0], warnings[0]
+        assert "max_tick_s=300.0" in warnings[0], warnings[0]
     finally:
         disabled.close(drain=False)
 


### PR DESCRIPTION
Follow-up to #355, which merged before these could be pushed onto it. Three review findings, all valid, all applied.

## 1. The warning misreported the value that triggered it

`%.1f` rendered a tick of `300.04` as `tick_s=300.0 max_tick_s=300.0` — a warning that reads as though the ceiling had **not** been crossed. That is the same defect #355 exists to fix, committed inside the fix. Now `%r`.

## 2. The test could not have caught that

A `+1.0` margin is comfortable enough that the rounding never shows. It now probes at `+0.04` and asserts the rendered strings, not just the event name:

```python
assert "tick_s=300.04" in warnings[0]
assert "max_tick_s=300.0" in warnings[0]
```

This is the lesson `docs/lessons.md` already records for benchmark loads that drift away from their own discrimination threshold — a probe far from the boundary stops testing the boundary.

## 3. "only on clean shutdown or vault_commit" omitted the external committer

Above the ceiling what stops is *automatic* reconciliation. Queued paths still reach git through a clean shutdown, an explicit `vault_commit`, or obsidian-git (ADR-010). Corrected in the code comment, the log line, and both doc languages.

## 4. The wording excluded a tick the guard admits

The comparison is `tick_s <= _MAX_AUTO_TICK_S`, so exactly 300 still starts the loop. "prefer a tick within the ceiling" / "por debajo del techo" read as excluding it. Both languages now say **up to 300 seconds inclusive**, and note that exactly 300 runs.

## Verification

- `make check` — **862 passed**, 2 skipped, coverage 85%.
- `cd site && npm run build` — 31 pages, clean, both languages.

## Note on the reviews

Worth flagging for the other open PRs: CodeRabbit hit its review limit on #356, #358, #359 and #360, so the green check there means "could not review", not "reviewed and found nothing". Only #355 received an actual review — these four findings came from it.