### PR TITLE
test: stop letting an empirical classifier gate merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,18 @@ jobs:
       - name: Test cross-worker lock
         run: uv run pytest tests/test_cross_worker_lock.py -m cross_worker -v
 
-      - name: Test cancellation race
-        run: uv run pytest tests/test_compat_shim.py::test_classify_cancellation_race -v
+      # The classifier is excluded from the default run by the `diagnostic`
+      # marker, so this step must select it explicitly — a nodeid alone is still
+      # filtered by addopts and would collect nothing (pytest exit 5).
+      #
+      # continue-on-error, deliberately: this test reports how cancellation races
+      # distribute, and its own docstring says it is not a pass/fail correctness
+      # test. Its output is worth having on every run; its failure is not worth
+      # blocking a merge, because a red here means the 20-iteration harness did
+      # not fit the runner's timing, not that the shim regressed.
+      - name: Test cancellation race (diagnostic, non-blocking)
+        continue-on-error: true
+        run: uv run pytest tests/test_compat_shim.py::test_classify_cancellation_race -m diagnostic -v
 
   docker:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ test-one: ## Run a single test file or expression (e.g. `make test-one ARGS="tes
 smoke: ## Run e2e smoke tests (needs Ollama + API key)
 	uv run pytest -m smoke -v
 
+diagnostic: ## Run empirical classifiers (report distributions; never gate a merge)
+	uv run pytest -m diagnostic -v
+
 check: lint typecheck test ## Lint + typecheck + test
 
 build: check ## Check + build package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,5 +116,6 @@ asyncio_mode = "auto"
 markers = [
     "smoke: end-to-end tests against real Ollama/OpenRouter (skip in CI)",
     "cross_worker: multi-process integration tests and benchmarks (excluded from default run; the HIVE-116 lock tests also require a fake-git PATH fixture)",
+    "diagnostic: empirical classifiers that report a distribution rather than assert a contract (excluded from default run; they must never gate a merge)",
 ]
-addopts = "-m 'not smoke and not cross_worker'"
+addopts = "-m 'not smoke and not cross_worker and not diagnostic'"

--- a/tests/test_compat_shim.py
+++ b/tests/test_compat_shim.py
@@ -154,6 +154,7 @@ def _classify(messages: list[dict[str, object]]) -> tuple[str, str]:
     reason="Re-enabled on all platforms as part of HIVE-116 PR-3 cross-OS CI lane",
 )
 @pytest.mark.asyncio
+@pytest.mark.diagnostic
 async def test_classify_cancellation_race(tmp_path: Path) -> None:
     """Drive cancellation race N times against a real hive subprocess; report scenario distribution.
 


### PR DESCRIPTION
Closes #388. Unblocks the release PR #386, whose only failure is this test.

## What happened

#386 is `master` plus a version bump, and it went red:

```
FAILED tests/test_compat_shim.py::test_classify_cancellation_race - ConnectionResetError: Connection lost
= 1 failed, 903 passed, 2 skipped, 63 deselected in 228.51s =
```

`check (3.13)` red, `check (3.12)` green, same commit.

## Why this is not a flake to retry

The test's own docstring:

> *This is **NOT a pass/fail correctness test** — it is an empirical classifier whose output dictates the Fase C design in HIVE-104. The assertion at the end only verifies all iterations were accounted for.*

It spawns a real hive subprocess and drives 20 cancellation races over JSON-RPC stdio. `ConnectionResetError: Connection lost` is the child closing the pipe mid-run under load — not a regression in the shim. **If `_compat.py` were broken this test would still pass**, because counting iterations is all it asserts. A diagnostic instrument was deciding merges.

Measured locally on `master`: passes, at **~41 s per run** — a real slice of a 228 s suite spent on something that asserts no contract.

## The fix

A `diagnostic` marker, excluded from the default run alongside `smoke` and `cross_worker`, plus a `make diagnostic` target so it stays runnable on demand.

**Why a new marker rather than an existing one:** `cross_worker` still runs in CI and still gates, so it would not have de-gated anything; `smoke` is described as *"against real Ollama/OpenRouter"*, providers #384 is in the middle of removing, and this test needs neither. Reusing either would have made a marker mean two things.

## Verified in both directions

```
default run:        3/4 tests collected (1 deselected)
-m diagnostic:      1/969 tests collected (968 deselected)
make check:         903 passed, 2 skipped, 64 deselected, exit 0
```

64 deselected against 63 before — the one extra is this test, leaving the gate. A marker asserted in only one direction would not have shown that.

## On merging #386

Merge this first, then #386 goes green on its own. Re-running #386's job would also produce a green, and that is the point worth stating: **a green retry proves the run fitted in the time budget, not that the shim works.**