### PR TITLE
feat!: make the delegate worker NaN-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Hive is an MCP server (stdio transport, FastMCP framework) with three responsibi
 
 1. **Vault tools** — query, search, list, write, patch markdown files in an Obsidian vault. All writes auto-commit to git (best-effort; git failure never crashes the server) and validate YAML frontmatter.
 2. **Session tools** — `session_briefing` assembles tasks + lessons + git log + health in one call so an AI client gets ~50 lines of context instead of ~800.
-3. **Worker tools** — `delegate_task` and `capture_lesson` route work down a cost ladder: Ollama (local, free) → OpenRouter free tier → OpenRouter paid (gated by $1/mo SQLite budget) → reject.
+3. **Worker tools** — `delegate_task` and `capture_lesson` each make one attempt against one OpenAI-compatible worker (NaN). No internal fallback: the caller owns the chain, and failures are classified as *pool unavailable* vs *task failed* so the caller can tell a retryable one from a real one.
 
 The package layout follows a deliberate split: `server.py` is a thin registration layer only. Each `_vault_*.py` / `_workers.py` module owns one tool family and registers its tools onto the FastMCP instance via a `register_*(mcp, ctx)` function. State lives in `ServerContext` (a dataclass in `_context.py`) and is passed to every handler — there is no module-level mutable state.
 
@@ -32,7 +32,7 @@ The package layout follows a deliberate split: `server.py` is a thin registratio
 | `src/hive/_compat.py` | MCP cancellation shim — see "Compat shim" below |
 | `src/hive/config.py` | `HiveSettings` (pydantic-settings, `HIVE_*` env vars) |
 | `src/hive/budget.py` | SQLite budget tracker ($1/mo default cap, WAL mode) |
-| `src/hive/clients.py` | Async HTTP clients (Ollama + OpenRouter, httpx) |
+| `src/hive/clients.py` | Async HTTP client for any OpenAI-compatible `/v1` API (httpx) |
 | `src/hive/relevance.py` | EMA-based section relevance scoring |
 | `src/hive/frontmatter.py` | YAML frontmatter parse/validate/generate |
 | `site/` | Astro + Starlight bilingual (EN/ES) docs site |
@@ -50,12 +50,21 @@ Two corrections worth carrying, because the stale versions of both are still quo
 
 ### Worker routing order
 
-`delegate_task` tries clients in this order, falling through on failure or unavailability:
+`delegate_task` makes **one** attempt against **one** worker — a single OpenAI-compatible provider
+(NaN), configured by `HIVE_WORKER_BASE_URL` / `HIVE_WORKER_API_KEY` / `HIVE_WORKER_MODEL`, each
+falling back to its `HIVE_EMBED_*` counterpart when unset. `NAN_API_KEY` is accepted as the
+launcher-side alias for the key.
 
-1. **Ollama** `qwen2.5-coder:7b` (local) — free, primary
-2. **OpenRouter** `qwen/qwen3-coder:free` — free tier fallback
-3. **OpenRouter** paid (`qwen/qwen3-coder`) — only if caller passes `max_cost_per_request > 0` AND `BudgetTracker` allows it
-4. **Reject** — surface the error to the client; Claude handles fallback
+There is deliberately **no internal fallback chain**. Choosing among pools belongs to the caller
+that owns a routing map; a backend that falls back on its own is a second routing authority, and its
+answer can no longer be attributed to a model. Failures are classified rather than collapsed — *pool
+unavailable* (unreachable, 429, auth) is distinct from *task failed* (the provider answered and the
+answer is unusable), because a caller may retry the first elsewhere and must not retry the second.
+
+Ollama and OpenRouter were removed in **4.0.0**; their model aliases (`auto`, `ollama`,
+`openrouter-free`, `openrouter`) are rejected with a message naming the replacement rather than
+silently ignored. There is no spend cap: the provider is a flat subscription, so the binding
+constraint is concurrency, not cost.
 
 ## MCP tool schema rules (load-bearing)
 
@@ -76,7 +85,7 @@ make lint       # ruff check src/ tests/
 make typecheck  # mypy --strict src/
 make test       # pytest with coverage (smoke tests auto-excluded via addopts)
 make test-one   # run a single test: make test-one ARGS="tests/test_server.py -k vault_query"
-make smoke      # pytest -m smoke (needs running Ollama + OPENROUTER_API_KEY)
+make smoke      # pytest -m smoke (needs a reachable worker + HIVE_WORKER_API_KEY)
 make check      # lint + typecheck + test — run this before every PR
 make build      # check + uv build
 make run        # uv run python -m hive.server (local MCP server over stdio)
@@ -96,7 +105,7 @@ uv run pytest tests/test_server.py -k "vault_query"               # by keyword
 uv run pytest -m smoke -k worker_status                           # smoke subset
 ```
 
-Smoke tests are marked `@pytest.mark.smoke` and excluded by default (`addopts = "-m 'not smoke'"` in `pyproject.toml`); they require a live Ollama at `OLLAMA_ENDPOINT` and an `OPENROUTER_API_KEY`.
+Smoke tests are marked `@pytest.mark.smoke` and excluded by default; they require a reachable worker endpoint (`HIVE_WORKER_BASE_URL`) and its credential (`HIVE_WORKER_API_KEY`, or `NAN_API_KEY` as the launcher injects it). The skip condition **probes** the endpoint rather than checking that the variables are set — a configured-but-unreachable worker looking healthy is the defect #384 exists to fix.
 
 ## Configuration
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test: ## Run unit + integration tests
 test-one: ## Run a single test file or expression (e.g. `make test-one ARGS="tests/test_server.py -k vault_query"`)
 	uv run pytest $(ARGS)
 
-smoke: ## Run e2e smoke tests (needs Ollama + API key)
+smoke: ## Run e2e smoke tests (needs a reachable worker + HIVE_WORKER_API_KEY)
 	uv run pytest -m smoke -v
 
 check: lint typecheck test ## Lint + typecheck + test

--- a/specs/HIVE-384-nan-worker-and-delegate-verb/proposal.md
+++ b/specs/HIVE-384-nan-worker-and-delegate-verb/proposal.md
@@ -149,6 +149,29 @@ Things this PR explicitly does NOT include. Forces a sharp boundary and prevents
   config file. hive's side of this is narrow but real: it must not log the
   value, must not echo it into the crash artifact — ADR-011 §4 already requires *"no secrets/API
   keys"* there — and must be verifiable by consequence (the daemon answers) rather than by printing.
+- **[FOUND IN CODE 2026-08-23] The worker has three call sites and two tools, not one.** Besides
+  `delegate_task`'s inference path, `_try_worker` is called by **`capture_lesson`** and by
+  `delegate_task`'s own vault-summarization path. `capture_lesson`'s MCP *surface* does not change,
+  so it stays outside the declared §5 amendment — but its provider re-routes with everything else,
+  and it is a consumer whose behaviour changes. Named here so "update every in-repo caller" has a
+  known denominator rather than being discovered mid-PR.
+- **[FOUND IN CODE 2026-08-23] `delegate_task` returns a formatted string, so the error
+  classification cannot ride on an exception type.** Typed exceptions do not cross the JSON-RPC
+  boundary between the verb and the daemon, and the current `_try_worker` collapses *every* failure
+  into `(None, "some string")` — catching `(ConnectionError, RuntimeError)` and then broad
+  `Exception` into the same shape. That collapsing is exactly what exit `3` vs exit `1` forbids.
+  **The classification must travel as data in the result** (`status: ok | task_failed |
+  pool_unavailable | timeout`), with the verb mapping result → exit code client-side. This replaces
+  `_try_worker`'s error handling rather than wrapping it.
+- **[FOUND IN CODE 2026-08-23] `delegate_task` needs an additive `timeout_s` parameter**, because the
+  daemon is where `bounded_call` runs, so the deadline has to travel in the request. Additive, but a
+  surface change nonetheless: folded into the declared §5 amendment above.
+- **[CORRECTION 2026-08-23] `budget.py` shrinks; it does not disappear**, and neither does its test
+  file. `record_request` is *usage telemetry* — tokens and latency, which the reshaped
+  `worker_status` and `usage.db` both want — while `can_spend` / `month_spent` / `month_remaining` /
+  `month_stats` are the *spend cap* being removed. `cost_usd` becomes moot on a flat subscription.
+  `tasks.md`'s "delete `test_budget.py` with its subject" is too coarse: trim it to the surviving
+  behaviour instead.
 - **[OPEN] Where the verb's own smoke test can run.** It needs the worker credential present, so it belongs
   behind the existing `smoke` marker (excluded by default) rather than in `make check`. What is not
   yet decided is whether CI gets a credential or the smoke stays developer-only; the second is the

--- a/specs/HIVE-384-nan-worker-and-delegate-verb/tasks.md
+++ b/specs/HIVE-384-nan-worker-and-delegate-verb/tasks.md
@@ -9,6 +9,19 @@ created: "2026-08-23"
 >
 > **Inline markers**: `[P]` — no dependency on another unchecked task, safe to run in parallel. `[AC<n>]` — helps satisfy acceptance criterion #`<n>` from `proposal.md`.
 
+## PR sequence
+
+The work does not fit one atomic PR and splits on the seam this file already organises around.
+Declared here so no PR silently absorbs the next:
+
+| PR | Lands | Criteria |
+|---|---|---|
+| **1** | the provider layer: `HIVE_WORKER_*` settings with the `HIVE_EMBED_*` fallback and the `NAN_API_KEY` alias, Ollama and OpenRouter removed, the three `_try_worker` call sites re-routed, `budget.py` trimmed, `worker_status` reshaped, and the stale surfaces (`AGENTS.md`, `Makefile`, tests) | AC5, AC6, AC7 |
+| **2** | the verb: `hive delegate`, the result-carried status classification, `delegate_task`'s `timeout_s` and `model` migration, exit-code mapping, daemon routing and the degraded flag | AC1, AC2, AC3, AC4 |
+
+Both land before the release; release-please accumulates them into one `4.0.0`. **PR 1 carries the
+`feat!`** — it is where the providers and the MCP parameters actually disappear.
+
 ## Setup
 
 - [ ] Worktree + branch off `master`: `feat/nan-worker-and-delegate-verb`
@@ -78,8 +91,12 @@ created: "2026-08-23"
 - [ ] [AC6] `AGENTS.md`: replace the "Ollama … free, primary" provider list with the NaN-only reality
 - [ ] [AC6] `Makefile`: the `smoke` target's help text reads *"needs Ollama + API key"* — it becomes
       NaN and `HIVE_WORKER_API_KEY`. A help string is documentation a human acts on
-- [ ] [AC6] `tests/test_budget.py` covers the spend cap being removed; delete it with its subject
-      rather than leaving a test asserting a contract that no longer exists
+- [ ] [AC6] Trim `budget.py` to its surviving half rather than deleting it: `record_request` stays
+      (usage telemetry — tokens and latency, which the reshaped `worker_status` and `usage.db` both
+      read), while `can_spend` / `month_spent` / `month_remaining` / `month_stats` go with the spend
+      cap. `cost_usd` becomes moot on a flat subscription
+- [ ] [AC6] Trim `tests/test_budget.py` to the surviving behaviour — not a wholesale delete, which
+      would drop coverage of telemetry that is staying
 - [ ] [AC5] Re-point the `@pytest.mark.smoke` tests at NaN and `HIVE_WORKER_API_KEY`; they stay
       excluded from `make check` by the existing `-m 'not smoke'`
 - [ ] [AC5] Reshape `worker_status` to report reachability and the resolved model — the shape the

--- a/src/hive/_context.py
+++ b/src/hive/_context.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from hive._lesson_reinforcement import LessonReinforcementTracker
     from hive._lock_eviction import LockEvictionTracker
     from hive.budget import BudgetTracker
-    from hive.clients import OllamaClient, OpenRouterClient
+    from hive.clients import OpenAICompatibleClient
     from hive.relevance import RelevanceTracker
     from hive.usage import UsageTracker
 
@@ -27,15 +27,18 @@ class ServerContext:
     scopes: dict[str, str]
     tracker: UsageTracker
     budget: BudgetTracker
-    ollama: OllamaClient
-    openrouter: OpenRouterClient | None
+    # HIVE-384: one worker client, OpenAI-compatible, pointed at NaN.
+    # ``None`` means the worker is unconfigured — the same meaning
+    # ``embed_base_url == ""`` carries for the semantic backend. Callers must
+    # branch on it rather than assume a client exists: the previous shape had a
+    # non-optional Ollama client that was always present and never reachable,
+    # which is how the worker served zero models without anyone noticing.
+    worker: OpenAICompatibleClient | None
     relevance: RelevanceTracker
     lessons: LessonReinforcementTracker
     lock_eviction: LockEvictionTracker
     idempotency: IdempotencyStore
     stale_days: int
-    openrouter_budget: float
-    openrouter_paid_model: str
     tool_timeout: float
     # HIVE-211: optional semantic backend for vault_ask (empty = disabled).
     embed_base_url: str = ""

--- a/src/hive/_vault_health.py
+++ b/src/hive/_vault_health.py
@@ -58,20 +58,16 @@ def identity_block_text(ctx: ServerContext) -> str:
     booleans only — never API keys), started_at. Stable across calls
     since started_at is captured at server construction.
     """
-    # Ollama backend: report the cached availability probe. Unprobed →
-    # False (we cannot claim presence we haven't verified). OpenRouter:
-    # presence boolean derived from whether the client was constructed
-    # (which requires an api_key) — the key itself is never embedded.
-    ollama_present = bool(
-        getattr(ctx.ollama, "_availability_cached", None),
-    )
-    openrouter_present = ctx.openrouter is not None
+    # HIVE-384: one worker backend. The boolean says the client was
+    # CONSTRUCTED, which requires a configured base_url — it does not claim the
+    # endpoint answers. That distinction is the whole reason this issue exists:
+    # the previous shape reported an Ollama client that always existed and never
+    # reached a model, so "configured" read as "working" for an unknown length
+    # of time. The key itself is never embedded here.
     backends = (
-        '{"ollama": '
-        + ("true" if ollama_present else "false")
-        + ', "openrouter": '
-        + ("true" if openrouter_present else "false")
-        + "}"
+        '{"worker": '
+        + ("true" if ctx.worker is not None else "false")
+        + ', "worker_reachable": "unprobed"}'
     )
     return "\n".join(
         [
@@ -125,7 +121,7 @@ def runtime_block_text(ctx: ServerContext, mcp: FastMCP) -> str:
     uptime_s = max(0.0, time.monotonic() - ctx.started_at_monotonic)
     tools = _registered_tool_names(mcp)
     period = datetime.now(UTC).strftime("%Y-%m")
-    stats = ctx.budget.month_stats(ctx.openrouter_budget)
+    usage = ctx.budget.month_usage()
 
     # HIVE-115 telemetry. Each computation is defensive: a psutil error
     # or stat failure must NEVER prevent vault_health from returning.
@@ -211,9 +207,9 @@ def runtime_block_text(ctx: ServerContext, mcp: FastMCP) -> str:
         "- uncommitted:",
         f"  - count: {count_text}",
         f"  - oldest_age_s: {oldest_age_text}",
-        "- openrouter_budget:",
-        f"  - spent_usd: {float(stats['spent']):.4f}",
-        f"  - cap_usd: {ctx.openrouter_budget}",
+        "- worker_usage:",
+        f"  - request_count: {usage['request_count']}",
+        f"  - total_tokens: {usage['total_tokens']}",
         f"  - period: {period}",
         "",
     ]

--- a/src/hive/_workers.py
+++ b/src/hive/_workers.py
@@ -292,14 +292,21 @@ def _capture_lesson_lookup(
     )
 
 
+# HIVE-384: model ids the 4.0.0 removal retired. Rejected with a message that
+# names the replacement, never silently ignored — a dead alias that is quietly
+# accepted surfaces later as a confusing inference failure instead of a clear
+# validation error, which is the difference between a break a caller can fix and
+# one they have to debug.
+_RETIRED_MODEL_ALIASES = frozenset({"auto", "ollama", "openrouter-free", "openrouter"})
+
+
 def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
     """Register worker tools on the MCP server."""
 
     def _record(resp: ClientResponse) -> None:
-        """Record a successful response in the budget tracker."""
+        """Record a successful response as usage telemetry (tokens, latency)."""
         ctx.budget.record_request(
             model=resp.model,
-            cost_usd=resp.cost_usd,
             tokens=resp.tokens,
             latency_ms=resp.latency_ms,
             task_type="delegate",
@@ -308,49 +315,53 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
     async def _try_worker(
         prompt: str,
         max_tokens: int,
-        provider: str = "ollama",
         context: str = "",
         model: str = "",
-    ) -> tuple[ClientResponse | None, str]:
-        """Try to generate via a worker provider.
+    ) -> tuple[ClientResponse | None, str, str]:
+        """Run one inference against the worker. One shot, no fallback.
 
-        Returns (response, "") on success or (None, error_detail) on failure.
+        Returns ``(response, status, detail)`` where ``status`` is one of
+        ``"ok"``, ``"pool_unavailable"`` or ``"task_failed"``.
+
+        **The classification travels as data, deliberately** (HIVE-384). The
+        previous version returned ``(None, "some string")`` for every failure,
+        catching ``(ConnectionError, RuntimeError)`` and then broad ``Exception``
+        into one shape. A caller cannot tell *the provider was unreachable* from
+        *the provider answered and the answer failed*, and those must stay
+        distinguishable: a dispatcher advances its fallback chain on the first
+        and must not on the second, because collapsing them turns a bad answer
+        into a silent retry against a different model. Exception types also do
+        not survive the JSON-RPC boundary between the daemon and its clients, so
+        the distinction has to be a value, not a type.
+
+        The fallback chain itself lives in the caller, not here: a second
+        routing authority inside a backend is exactly what the routing registry
+        exists to prevent.
         """
+        if ctx.worker is None:
+            return None, "pool_unavailable", "worker not configured"
         try:
-            if provider == "ollama":
-                resp = await ctx.ollama.generate(
-                    prompt,
-                    context=context,
-                    max_tokens=max_tokens,
-                )
-            elif ctx.openrouter is None:
-                return None, "OpenRouter not configured"
-            elif model:
-                resp = await ctx.openrouter.generate(
-                    prompt,
-                    context=context,
-                    model=model,
-                    max_tokens=max_tokens,
-                )
-            else:
-                resp = await ctx.openrouter.generate(
-                    prompt,
-                    context=context,
-                    max_tokens=max_tokens,
-                )
-            _record(resp)
-            return resp, ""
-        except (ConnectionError, RuntimeError) as exc:
-            label = f"OpenRouter ({model})" if model else provider.capitalize()
-            return None, f"{label}: {exc}"
-        except Exception as exc:
-            label = f"OpenRouter ({model})" if model else provider.capitalize()
-            _log.warning(
-                "_try_worker unexpected error for %s: %r",
-                label,
-                exc,
+            resp = await ctx.worker.generate(
+                prompt,
+                context=context,
+                model=model or ctx.worker.model,
+                max_tokens=max_tokens,
             )
-            return None, f"{label}: unexpected error ({type(exc).__name__})"
+            _record(resp)
+            return resp, "ok", ""
+        except ConnectionError as exc:
+            # Unreachable, refused, rate-limited, auth rejected — the pool did
+            # not serve the request. Retrying elsewhere is legitimate.
+            return None, "pool_unavailable", f"worker unreachable: {exc}"
+        except RuntimeError as exc:
+            # The provider answered and the answer is unusable. Retrying the
+            # same task on another model would hide a real failure.
+            return None, "task_failed", f"worker error: {exc}"
+        except Exception as exc:
+            _log.warning("_try_worker unexpected error: %r", exc)
+            # Unknown failures classify as task_failed, never as unavailable:
+            # the fail-closed direction is the one that does NOT retry.
+            return None, "task_failed", f"unexpected error ({type(exc).__name__})"
 
     @mcp.tool(annotations=_WRITE)
     async def capture_lesson(
@@ -427,31 +438,18 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                         text=safe_text,
                     )
 
-                    errors: list[str] = []
+                    # HIVE-384: capture_lesson is the worker's second consumer.
+                    # Its MCP surface is unchanged; only which provider answers
+                    # is, so the two-tier ladder collapses to the same single
+                    # shot delegate_task now makes.
                     resp: ClientResponse | None = None
-
-                    if await ctx.ollama.is_available():
-                        resp, err = await _try_worker(prompt, 2000, "ollama")
-                        if resp is None:
-                            errors.append(err)
-                    else:
-                        errors.append("Ollama: offline")
+                    resp, _status, detail = await _try_worker(prompt, 2000)
 
                     if resp is None:
-                        resp, err = await _try_worker(
-                            prompt,
-                            2000,
-                            "openrouter",
-                        )
-                        if resp is None:
-                            errors.append(err)
-
-                    if resp is None:
-                        reasons = "; ".join(errors) if errors else "no workers configured"
                         return track(
                             ctx,
                             "capture_lesson",
-                            f"All workers unavailable [{reasons}]. "
+                            f"Worker unavailable [{detail}]. "
                             "Cannot extract lessons without a worker model.",
                             project,
                         )
@@ -621,9 +619,8 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
     async def delegate_task(
         prompt: str = "",
         context: str = "",
-        model: str = "auto",
+        model: str = "",
         max_tokens: int = 2000,
-        max_cost_per_request: float = 0.0,
         project: str = "",
         section: str = "context",
         path: str = "",
@@ -638,9 +635,10 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
         Args:
             prompt: The task description or code to process.
             context: Optional system context for the model.
-            model: 'auto', 'ollama', 'openrouter-free', 'openrouter' (paid), or model ID.
+            model: Concrete model id. Empty uses the configured worker model.
+                The 4.0.0 removal retired 'auto', 'ollama', 'openrouter-free'
+                and 'openrouter'; passing one is rejected rather than ignored.
             max_tokens: Maximum tokens in the response.
-            max_cost_per_request: Max USD. 0 = free models only.
             project: Project slug for vault summarization mode.
             section: Shortcut name for summarization. Ignored if path is set.
             path: Relative path to a .md file. Overrides section.
@@ -691,28 +689,11 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                         f"and action items.\n\n{body}"
                     )
                     summary_ctx = f"Document metadata: {meta}" if meta else ""
-                    summary_resp: ClientResponse | None = None
-                    summary_errors: list[str] = []
-                    if await ctx.ollama.is_available():
-                        summary_resp, err = await _try_worker(
-                            summary_prompt,
-                            max_tokens,
-                            "ollama",
-                            summary_ctx,
-                        )
-                        if err:
-                            summary_errors.append(err)
-                    else:
-                        summary_errors.append("Ollama: offline")
-                    if summary_resp is None:
-                        summary_resp, err = await _try_worker(
-                            summary_prompt,
-                            max_tokens,
-                            "openrouter",
-                            summary_ctx,
-                        )
-                        if err:
-                            summary_errors.append(err)
+                    summary_resp, _status, summary_detail = await _try_worker(
+                        summary_prompt,
+                        max_tokens,
+                        summary_ctx,
+                    )
                     if summary_resp is not None:
                         return track(
                             ctx,
@@ -720,17 +701,19 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                             f"{header}{_format_response(summary_resp)}",
                             project,
                         )
-                    # Workers unavailable — return raw content with notice
-                    reasons = (
-                        "; ".join(summary_errors) if summary_errors else "no workers configured"
-                    )
+
+                    # Worker unavailable — degrade to raw content with a notice.
+                    # The raw file is still useful, so this stays a graceful
+                    # degradation rather than an error; the notice exists so the
+                    # caller knows it received the document rather than a summary.
                     _log.warning(
                         "delegate_task summarize fallback for %s: %s",
                         project,
-                        reasons,
+                        summary_detail,
                     )
                     fallback_notice = (
-                        f"**Note:** Summarization failed ({reasons}). Returning raw content.\n\n"
+                        f"**Note:** Summarization failed ({summary_detail}). "
+                        "Returning raw content.\n\n"
                     )
                     return track(
                         ctx,
@@ -743,82 +726,33 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                     return track(ctx, "delegate_task", "Either prompt or project is required.")
 
                 # ── Worker delegation ──
+                #
+                # HIVE-384: one worker, one shot. The tiered ladder that stood
+                # here (Ollama → OpenRouter free → OpenRouter paid → reject)
+                # went with its providers, and the shape went with it on
+                # purpose: choosing among pools is the dispatcher's job, and a
+                # backend that picks its own fallback is a second routing
+                # authority whose answer nobody can attribute.
                 _tn = "delegate_task"
 
-                # Explicit routing
-                if model == "ollama":
-                    resp, err = await _try_worker(prompt, max_tokens, "ollama", context)
-                    if resp:
-                        return track(ctx, _tn, _format_response(resp))
-                    return track(ctx, _tn, f"{err}. {_REJECT_MSG}")
-                if model == "openrouter-free":
-                    resp, err = await _try_worker(prompt, max_tokens, "openrouter", context)
-                    if resp:
-                        return track(ctx, _tn, _format_response(resp))
-                    return track(ctx, _tn, f"{err}. {_REJECT_MSG}")
-                if model == "openrouter":
-                    if not ctx.budget.can_spend(ctx.openrouter_budget, max_cost_per_request):
-                        return track(ctx, _tn, f"Monthly budget exhausted. {_REJECT_MSG}")
-                    resp, err = await _try_worker(
-                        prompt,
-                        max_tokens,
-                        "openrouter",
-                        context,
-                        model=ctx.openrouter_paid_model,
+                if model in _RETIRED_MODEL_ALIASES:
+                    return track(
+                        ctx,
+                        _tn,
+                        f"'{model}' was removed in 4.0.0 — the worker now runs a "
+                        "single OpenAI-compatible provider. Pass a concrete model "
+                        "id, or omit `model` to use the configured default.",
                     )
-                    if resp:
-                        return track(ctx, _tn, _format_response(resp))
-                    return track(ctx, _tn, f"{err}. {_REJECT_MSG}")
-                if model != "auto":
-                    resp, err = await _try_worker(
-                        prompt,
-                        max_tokens,
-                        "openrouter",
-                        context,
-                        model=model,
-                    )
-                    if resp:
-                        return track(ctx, _tn, _format_response(resp))
-                    return track(ctx, _tn, f"{err}. {_REJECT_MSG}")
 
-                # Auto routing: Ollama → OpenRouter free → OpenRouter paid → reject
-                errors: list[str] = []
-
-                # Tier 1: Ollama
-                if await ctx.ollama.is_available():
-                    resp, err = await _try_worker(prompt, max_tokens, "ollama", context)
-                    if resp is not None:
-                        return track(ctx, _tn, _format_response(resp))
-                    errors.append(err)
-                else:
-                    errors.append("Ollama: offline")
-
-                # Tier 2: OpenRouter free
-                resp, err = await _try_worker(prompt, max_tokens, "openrouter", context)
+                resp, status, detail = await _try_worker(
+                    prompt,
+                    max_tokens,
+                    context,
+                    model=model,
+                )
                 if resp is not None:
                     return track(ctx, _tn, _format_response(resp))
-                errors.append(err)
-
-                # Tier 3: OpenRouter paid (only if max_cost > 0 and budget allows)
-                if (
-                    max_cost_per_request > 0
-                    and ctx.openrouter is not None
-                    and ctx.budget.can_spend(ctx.openrouter_budget, max_cost_per_request)
-                ):
-                    resp, err = await _try_worker(
-                        prompt,
-                        max_tokens,
-                        "openrouter",
-                        context,
-                        model=ctx.openrouter_paid_model,
-                    )
-                    if resp is not None:
-                        return track(ctx, _tn, _format_response(resp))
-                    errors.append(err)
-
-                # All tiers exhausted
-                reasons = "; ".join(errors)
-                return track(ctx, _tn, f"All workers unavailable. [{reasons}]. {_REJECT_MSG}")
+                return track(ctx, _tn, f"{detail}. {_REJECT_MSG}")
         except TimeoutError:
             return track(
                 ctx,
@@ -829,66 +763,75 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
 
     @mcp.tool(annotations=_READ_ONLY)
     async def worker_status(include_models: bool = True) -> str:
-        """Show worker health: budget, connectivity, available models, and usage stats.
+        """Show worker health: configuration, reachability, model, and usage.
+
+        HIVE-384 reshaped this tool, and the reshape is the point rather than a
+        side effect. The old output led with a dollar budget and reported two
+        providers by *configuration*: it said "Ollama: offline / OpenRouter: no
+        API key" for an unknown length of time while every caller treated the
+        worker as a working capability. A status surface that cannot distinguish
+        "configured" from "answers" is how a dead backend stays invisible.
+
+        So reachability is **probed, not inferred**, and reported separately
+        from configuration. The dollar figures are gone: on a flat subscription
+        they would read zero forever, and a gauge that always says the same
+        thing looks like a working gauge.
 
         Args:
-            include_models: Include available model list from all providers. Default True.
+            include_models: Probe the provider for its model list. Default True.
+                Set False to report configuration without a network call.
         """
         try:
             async with tool_span("worker_status", ctx.tool_timeout):
-                stats = ctx.budget.month_stats(ctx.openrouter_budget)
-                ollama_up = await ctx.ollama.is_available()
+                usage = ctx.budget.month_usage()
+                configured = ctx.worker is not None
 
                 lines = [
                     "# Worker Status",
                     "",
-                    "## Budget",
-                    f"- Spent this month: ${stats['spent']:.2f}",
-                    f"- Remaining: ${stats['remaining']:.2f} / ${ctx.openrouter_budget:.1f}",
-                    f"- Requests: {stats['request_count']}",
+                    "## Provider",
+                    f"- Configured: {'yes' if configured else 'no — set HIVE_WORKER_BASE_URL'}",
+                ]
+                if configured and ctx.worker is not None:
+                    lines.append(f"- Model: {ctx.worker.model or '(none configured)'}")
+
+                # Reachability is a probe. "Configured" is not a claim that the
+                # endpoint answers, and the two must never be printed as one.
+                if configured and include_models and ctx.worker is not None:
+                    try:
+                        models = await ctx.worker.list_models()
+                        lines.append(f"- Reachable: yes ({len(models)} models)")
+                    except (ConnectionError, RuntimeError, TimeoutError) as exc:
+                        models = []
+                        lines.append(f"- Reachable: NO — {exc}")
+                else:
+                    models = []
+                    lines.append("- Reachable: unprobed")
+
+                lines += [
                     "",
-                    "## Connectivity",
-                    f"- Ollama: {'online' if ollama_up else 'offline / unavailable'}",
-                    f"- OpenRouter: {'configured' if ctx.openrouter is not None else 'no API key'}",
+                    "## Usage this month",
+                    f"- Requests: {usage['request_count']}",
+                    f"- Tokens: {usage['total_tokens']}",
                     "",
                 ]
 
-                if stats["by_model"]:
-                    lines.append("## Top Models")
-                    for model_name, model_stats in stats["by_model"].items():
-                        cost = f"${model_stats['total_cost']:.4f}"
-                        lat = f"{model_stats['avg_latency_ms']}ms"
+                if usage["by_model"]:
+                    lines.append("## By model")
+                    for model_name, model_stats in usage["by_model"].items():
                         lines.append(
-                            f"- **{model_name}**: "
-                            f"{model_stats['count']} requests, "
-                            f"{cost}, avg {lat}",
+                            f"- **{model_name}**: {model_stats['count']} requests, "
+                            f"{model_stats['tokens']} tokens, "
+                            f"avg {model_stats['avg_latency_ms']}ms",
                         )
                     lines.append("")
 
-                if include_models:
+                if include_models and models:
                     lines.append("## Available Models")
+                    for m in models:
+                        lines.append(f"- **{m.id}** — {m.name}, ctx: {m.context_length}")
                     lines.append("")
-                    ollama_status = "online" if ollama_up else "offline / unavailable"
-                    lines.append(f"### Ollama ({ollama_status})")
-                    if ollama_up:
-                        lines.append(f"- **{ctx.ollama.model}** — local, free, no token limit")
-                    lines.append("")
-                    lines.append("### OpenRouter")
-                    if ctx.openrouter is not None:
-                        try:
-                            models = await ctx.openrouter.list_models()
-                            for m in models:
-                                cost = (
-                                    "free" if m.is_free else f"${m.cost_per_million_input:.2f}/M in"
-                                )
-                                lines.append(
-                                    f"- **{m.id}** — {m.name}, ctx: {m.context_length}, {cost}",
-                                )
-                        except (ConnectionError, RuntimeError, TimeoutError) as exc:
-                            lines.append(f"- Error fetching models: {exc}")
-                    else:
-                        lines.append("- No API key configured")
 
-                return "\n".join(lines)
+                return track(ctx, "worker_status", "\n".join(lines))
         except TimeoutError:
             return "Worker status timed out. Workers may be unreachable."

--- a/src/hive/budget.py
+++ b/src/hive/budget.py
@@ -1,4 +1,29 @@
-"""BudgetTracker — SQLite-backed monthly budget tracking for worker requests."""
+"""BudgetTracker — SQLite-backed usage telemetry for worker requests.
+
+HIVE-384 trimmed this module rather than deleting it, and the split is worth
+stating because the two halves look alike and only one was retired.
+
+**Retired: the spend cap.** ``can_spend`` / ``month_spent`` / ``month_remaining``
+existed to keep a pay-per-token provider inside a monthly dollar budget. The
+worker now runs on a flat subscription, where marginal cost is zero and the
+binding constraint is *concurrency*, not spend. A dollar cap there is not a
+weakened guard — it is a guard measuring the wrong quantity, and one that would
+have to be reintroduced by any future paid provider rather than inherited.
+
+**Kept: usage telemetry.** ``record_request`` and the per-month aggregate remain,
+because tokens and latency are what ``worker_status``, ``/status`` and
+``usage.db`` actually read. Deleting them along with the cap would have removed
+observability that nothing asked to remove.
+
+``cost_usd`` survives in the schema but not in the API: dropping the column would
+be a destructive migration of a database users already hold, for a field that now
+records ``0.0``. It is left in place, unread.
+
+**The class name is now a misnomer and is knowingly left alone.** It tracks usage,
+not a budget. Renaming it touches 83 call sites across ten files, which would bury
+this change's substance in mechanical churn on a PR a reviewer has to read closely.
+Tracked separately rather than smuggled in here.
+"""
 
 from __future__ import annotations
 
@@ -10,7 +35,7 @@ _MONTH_CLAUSE = "WHERE month = strftime('%Y-%m', 'now')"
 
 
 class BudgetTracker(_SqliteTracker):
-    """Track worker request costs against a monthly budget cap."""
+    """Track worker request volume, tokens and latency by month."""
 
     _SCHEMA = """\
 CREATE TABLE IF NOT EXISTS requests (
@@ -28,12 +53,17 @@ CREATE TABLE IF NOT EXISTS requests (
     def record_request(
         self,
         model: str,
-        cost_usd: float,
         tokens: int,
         latency_ms: int,
         task_type: str = "general",
+        cost_usd: float = 0.0,
     ) -> None:
-        """Insert a completed request into the tracking table."""
+        """Insert a completed request into the tracking table.
+
+        ``cost_usd`` keeps its column so an existing ``worker.db`` opens
+        unchanged, but it defaults to zero and no longer has a caller: on a flat
+        subscription there is no per-request cost to record.
+        """
         with self._lock:
             self._conn.execute(
                 "INSERT INTO requests (model, cost_usd, tokens, latency_ms, task_type) "
@@ -42,52 +72,35 @@ CREATE TABLE IF NOT EXISTS requests (
             )
             self._conn.commit()
 
-    def _month_spent(self) -> float:
-        """Internal — caller MUST hold self._lock."""
-        row = self._conn.execute(
-            f"SELECT COALESCE(SUM(cost_usd), 0.0) FROM requests {_MONTH_CLAUSE}"
-        ).fetchone()
-        return float(row[0]) if row else 0.0
+    def month_usage(self) -> dict[str, Any]:
+        """Aggregate usage for the current month.
 
-    def month_spent(self) -> float:
-        """Total USD spent in the current month."""
+        Reports volume rather than spend: request count, total tokens, and a
+        per-model breakdown with average latency. This is the shape ``/status``
+        and ``worker_status`` consume now that a dollar figure would always
+        read zero.
+        """
         with self._lock:
-            return self._month_spent()
-
-    def month_remaining(self, budget: float) -> float:
-        """How much budget remains this month."""
-        with self._lock:
-            return budget - self._month_spent()
-
-    def can_spend(self, budget: float, amount: float) -> bool:
-        """Check if spending `amount` would stay within budget."""
-        with self._lock:
-            return (budget - self._month_spent()) >= amount
-
-    def month_stats(self, budget: float) -> dict[str, Any]:
-        """Aggregate stats for the current month."""
-        with self._lock:
-            spent = self._month_spent()
-            count_row = self._conn.execute(
-                f"SELECT COUNT(*) FROM requests {_MONTH_CLAUSE}"
+            totals = self._conn.execute(
+                f"SELECT COUNT(*), COALESCE(SUM(tokens), 0) FROM requests {_MONTH_CLAUSE}"
             ).fetchone()
-            request_count = count_row[0] if count_row else 0
+            request_count = totals[0] if totals else 0
+            total_tokens = int(totals[1]) if totals else 0
 
             by_model: dict[str, dict[str, Any]] = {}
             rows = self._conn.execute(
-                "SELECT model, COUNT(*), SUM(cost_usd), AVG(latency_ms) "
+                "SELECT model, COUNT(*), COALESCE(SUM(tokens), 0), AVG(latency_ms) "
                 f"FROM requests {_MONTH_CLAUSE} GROUP BY model"
             ).fetchall()
-            for model, cnt, total_cost, avg_latency in rows:
+            for model, cnt, tokens, avg_latency in rows:
                 by_model[model] = {
                     "count": cnt,
-                    "total_cost": total_cost,
-                    "avg_latency_ms": int(avg_latency),
+                    "tokens": int(tokens),
+                    "avg_latency_ms": int(avg_latency or 0),
                 }
 
         return {
-            "spent": spent,
-            "remaining": budget - spent,
             "request_count": request_count,
+            "total_tokens": total_tokens,
             "by_model": by_model,
         }

--- a/src/hive/clients.py
+++ b/src/hive/clients.py
@@ -47,119 +47,6 @@ class ModelInfo:
     is_free: bool
 
 
-class OllamaClient:
-    """Async client for Ollama's /api/chat endpoint."""
-
-    def __init__(self, endpoint: str, model: str, timeout: float = 120.0) -> None:
-        self._endpoint = endpoint.rstrip("/")
-        self._model = model
-        self._http = httpx.AsyncClient(base_url=self._endpoint, timeout=timeout)
-        # is_available probe uses a much shorter connect timeout so an
-        # unreachable homelab fails in ~1s rather than burning the full
-        # generate timeout; the read timeout still matches generate
-        # because the / endpoint should respond instantly.
-        self._probe_http = httpx.AsyncClient(
-            base_url=self._endpoint,
-            timeout=httpx.Timeout(
-                connect=_AVAILABILITY_CONNECT_TIMEOUT_S,
-                read=_AVAILABILITY_CONNECT_TIMEOUT_S,
-                write=_AVAILABILITY_CONNECT_TIMEOUT_S,
-                pool=_AVAILABILITY_CONNECT_TIMEOUT_S,
-            ),
-        )
-        self._availability_cached: bool | None = None
-        self._availability_cached_at: float = 0.0
-
-    @property
-    def model(self) -> str:
-        """The configured model name."""
-        return self._model
-
-    async def aclose(self) -> None:
-        """Close the underlying HTTP clients."""
-        await self._http.aclose()
-        await self._probe_http.aclose()
-
-    async def generate(
-        self, prompt: str, context: str = "", max_tokens: int = 2000
-    ) -> ClientResponse:
-        """Send a chat completion to Ollama and return a unified response."""
-        messages: list[dict[str, str]] = []
-        if context:
-            messages.append({"role": "system", "content": context})
-        messages.append({"role": "user", "content": prompt})
-
-        try:
-            start = time.monotonic()
-            resp = await self._http.post(
-                "/api/chat",
-                json={
-                    "model": self._model,
-                    "messages": messages,
-                    "stream": False,
-                    "options": {"num_predict": max_tokens},
-                },
-            )
-            elapsed_ms = int((time.monotonic() - start) * 1000)
-        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
-            msg = f"Ollama unavailable at {self._endpoint}: {exc}"
-            raise ConnectionError(msg) from exc
-        except httpx.TimeoutException as exc:
-            msg = f"Ollama request timed out at {self._endpoint}: {exc}"
-            raise ConnectionError(msg) from exc
-
-        if resp.status_code >= 400:
-            msg = f"Ollama error ({resp.status_code}): {resp.text[:200]}"
-            raise RuntimeError(msg)
-
-        try:
-            data = resp.json()
-        except ValueError as exc:
-            msg = f"Ollama returned non-JSON response: {exc}"
-            raise RuntimeError(msg) from exc
-        # Ollama returns total_duration in nanoseconds
-        total_ns = data.get("total_duration", 0)
-        latency = int(total_ns / 1_000_000) if total_ns else elapsed_ms
-
-        try:
-            text = data["message"]["content"]
-        except (KeyError, TypeError) as exc:
-            msg = f"Ollama response missing expected fields: {exc}"
-            raise RuntimeError(msg) from exc
-
-        return ClientResponse(
-            text=text,
-            model=self._model,
-            tokens=data.get("eval_count", 0),
-            cost_usd=0.0,
-            latency_ms=latency,
-        )
-
-    async def is_available(self) -> bool:
-        """Check if Ollama is reachable.
-
-        Result is cached for ``_AVAILABILITY_CACHE_TTL_S`` seconds to
-        avoid storming the endpoint when multiple tool calls (or
-        multiple hive subprocesses) all probe within the same window.
-        Uses a short connect timeout so an outage answers in ~1s
-        instead of consuming the generate-timeout budget.
-        """
-        now = time.monotonic()
-        if (
-            self._availability_cached is not None
-            and now - self._availability_cached_at < _AVAILABILITY_CACHE_TTL_S
-        ):
-            return self._availability_cached
-        try:
-            resp = await self._probe_http.get("/")
-            available = resp.status_code == 200
-        except (httpx.ConnectError, httpx.TimeoutException):
-            available = False
-        self._availability_cached = available
-        self._availability_cached_at = now
-        return available
-
-
 class OpenAICompatibleClient:
     """Async client for any OpenAI-compatible ``/v1`` API (OpenRouter, NaN, Ollama).
 
@@ -189,6 +76,11 @@ class OpenAICompatibleClient:
         if title:
             headers["X-OpenRouter-Title"] = title
         self._http: httpx.AsyncClient = httpx.AsyncClient(timeout=timeout, headers=headers)
+
+    @property
+    def model(self) -> str:
+        """The default model id this client was configured with."""
+        return self._default_model
 
     async def aclose(self) -> None:
         """Close the underlying HTTP client."""
@@ -336,21 +228,3 @@ class OpenAICompatibleClient:
                 )
             )
         return models
-
-
-class OpenRouterClient(OpenAICompatibleClient):
-    """OpenRouter client — a thin, backward-compatible OpenAI-compatible subclass.
-
-    Preserves the original constructor signature and the ``X-OpenRouter-Title``
-    header so existing callers and tests are unaffected.
-    """
-
-    def __init__(self, api_key: str, default_model: str, timeout: float = 120.0) -> None:
-        super().__init__(
-            base_url="https://openrouter.ai/api/v1",
-            api_key=api_key,
-            default_model=default_model,
-            timeout=timeout,
-            provider_name="OpenRouter",
-            title="hive-worker",
-        )

--- a/src/hive/config.py
+++ b/src/hive/config.py
@@ -3,7 +3,7 @@
 import re
 from pathlib import Path
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # A leading drive letter (``C:``) marks a Windows absolute path; checked
@@ -18,11 +18,24 @@ class HiveSettings(BaseSettings):
         default=Path.home() / "Projects" / "knowledge",
         validation_alias=AliasChoices("HIVE_VAULT_PATH", "VAULT_PATH"),
     )
-    ollama_endpoint: str = "http://localhost:11434"
-    ollama_model: str = "qwen2.5-coder:7b"
-    openrouter_api_key: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("HIVE_OPENROUTER_API_KEY", "OPENROUTER_API_KEY"),
+    # HIVE-384: the worker's own provider, OpenAI-compatible. Ollama and
+    # OpenRouter were removed rather than deprecated — Ollama was not running
+    # and OpenRouter was retired upstream in August 2026, so the worker reached
+    # zero models and nothing noticed.
+    #
+    # Empty base_url = worker disabled, exactly as embed_base_url means for the
+    # semantic backend. Never a guessed default: a worker that silently points
+    # somewhere is worse than one that says it is unconfigured.
+    worker_base_url: str = ""
+    worker_model: str = ""
+    # NAN_API_KEY is the launcher-side name of this credential: the consuming
+    # `dotf secrets run` resolves it from a registry that calls it that. Without
+    # the alias the launcher would inject one name and hive would read another,
+    # and authentication would fail for a reason no error message explains.
+    # Same AliasChoices pattern vault_path uses.
+    worker_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("HIVE_WORKER_API_KEY", "NAN_API_KEY"),
     )
     vault_scopes: dict[str, str] = Field(
         # ``agents`` is intentionally LAST: auto-scan (plain project name)
@@ -36,9 +49,6 @@ class HiveSettings(BaseSettings):
             "agents": "80_agents",
         },
     )
-    openrouter_budget: float = 1.0
-    openrouter_model: str = "qwen/qwen3-coder:free"
-    openrouter_paid_model: str = "qwen/qwen3-coder"
     # HIVE-211: optional semantic backend for vault_ask. Empty base_url =
     # disabled (the default) — no index, no embed-on-write, zero overhead.
     # OpenAI-compatible; default config points at NaN, Ollama is the local
@@ -91,6 +101,28 @@ class HiveSettings(BaseSettings):
     # killed them. Secret scanning now lives push-side/CI on the vault, so
     # skipping the hook here is safe. Override with HIVE_GIT_COMMIT_NO_VERIFY.
     git_commit_no_verify: bool = True
+
+    @model_validator(mode="after")
+    def _worker_falls_back_to_embed(self) -> "HiveSettings":
+        """Resolve unset ``worker_*`` from the ``embed_*`` values (HIVE-384).
+
+        The worker is not an embedder, so it earns honest names — but in the
+        default deployment both point at the same NaN endpoint, and requiring
+        both to be configured would mean a machine that works today stops
+        working on upgrade. So the fallback is per field, not all-or-nothing:
+        a deployment can override the model alone and inherit the endpoint.
+
+        Fallback fills only what is *empty*; an explicit ``worker_*`` always
+        wins. Both unset stays empty, which reads as "worker disabled" rather
+        than as a guess.
+        """
+        if not self.worker_base_url:
+            self.worker_base_url = self.embed_base_url
+        if not self.worker_api_key:
+            self.worker_api_key = self.embed_api_key
+        if not self.worker_model:
+            self.worker_model = self.embed_model
+        return self
 
     @field_validator("vault_scopes")
     @classmethod

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -52,27 +52,34 @@ from hive._vault_read import list_projects_text, register_vault_read  # noqa: E4
 from hive._vault_write import register_vault_write  # noqa: E402
 from hive._workers import register_workers  # noqa: E402
 from hive.budget import BudgetTracker  # noqa: E402
-from hive.clients import OllamaClient, OpenRouterClient  # noqa: E402
+from hive.clients import OpenAICompatibleClient  # noqa: E402
 from hive.config import settings  # noqa: E402
 from hive.relevance import RelevanceTracker  # noqa: E402
 from hive.usage import UsageTracker  # noqa: E402
 
 
 def _status_payload(ctx: ServerContext) -> dict[str, Any]:
-    """Assemble the /status JSON: live metrics + budget + version + uptime.
+    """Assemble the /status JSON: live metrics + worker usage + version + uptime.
 
     Live metrics come from the in-memory core (no DB read on the hot path);
-    the budget snapshot is an on-demand read, acceptable here since /status is
+    the usage snapshot is an on-demand read, acceptable here since /status is
     an operator query, not the request hot path.
+
+    HIVE-384 replaced the ``budget`` block with ``worker_usage``. The old block
+    reported dollars spent and remaining against a monthly cap, which on a flat
+    subscription would read ``0.0`` and ``the whole budget`` forever — an
+    operator surface that always says the same thing is worse than one that says
+    nothing, because it looks like a working gauge. Volume and latency are what
+    an operator can act on now.
     """
-    stats = ctx.budget.month_stats(ctx.openrouter_budget)
+    usage = ctx.budget.month_usage()
     uptime_s = max(0, int(time.monotonic() - ctx.started_at_monotonic))
     return {
         "version": _hive_version(),
         "uptime_s": uptime_s,
-        "budget": {
-            "spent": round(float(stats["spent"]), 4),
-            "remaining": round(float(stats["remaining"]), 4),
+        "worker_usage": {
+            "request_count": usage["request_count"],
+            "total_tokens": usage["total_tokens"],
         },
         **METRICS.snapshot(),
     }
@@ -106,8 +113,7 @@ def create_server(
     vault_path: Path | None = None,
     usage_tracker: UsageTracker | None = None,
     budget_tracker: BudgetTracker | None = None,
-    ollama_client: OllamaClient | None = None,
-    openrouter_client: OpenRouterClient | None = None,
+    worker_client: OpenAICompatibleClient | None = None,
     vault_scopes: dict[str, str] | None = None,
     relevance_tracker: RelevanceTracker | None = None,
     lesson_tracker: LessonReinforcementTracker | None = None,
@@ -139,19 +145,18 @@ def create_server(
     scopes = vault_scopes or _default_scopes()
     tracker = usage_tracker or UsageTracker()
     budget = budget_tracker or BudgetTracker(db_path=settings.db_path)
-    ollama = ollama_client or OllamaClient(
-        endpoint=settings.ollama_endpoint,
-        model=settings.ollama_model,
-        timeout=settings.http_timeout,
-    )
-    openrouter: OpenRouterClient | None = None
-    if openrouter_client is not None:
-        openrouter = openrouter_client
-    elif settings.openrouter_api_key:
-        openrouter = OpenRouterClient(
-            api_key=settings.openrouter_api_key,
-            default_model=settings.openrouter_model,
+    # HIVE-384: one worker, built only when it is actually configured. An
+    # unconfigured worker is ``None``, never a client pointed at a default that
+    # happens to be unreachable — that shape is what let the worker report
+    # "available models: none" for an unknown length of time.
+    worker: OpenAICompatibleClient | None = worker_client
+    if worker is None and settings.worker_base_url:
+        worker = OpenAICompatibleClient(
+            base_url=settings.worker_base_url,
+            api_key=settings.worker_api_key,
+            default_model=settings.worker_model,
             timeout=settings.http_timeout,
+            provider_name="NaN",
         )
     relevance = relevance_tracker or RelevanceTracker(
         db_path=settings.relevance_db_path,
@@ -181,15 +186,12 @@ def create_server(
         scopes=scopes,
         tracker=tracker,
         budget=budget,
-        ollama=ollama,
-        openrouter=openrouter,
+        worker=worker,
         relevance=relevance,
         lessons=lessons,
         lock_eviction=lock_eviction,
         idempotency=idempotency,
         stale_days=settings.stale_threshold_days,
-        openrouter_budget=settings.openrouter_budget,
-        openrouter_paid_model=settings.openrouter_paid_model,
         tool_timeout=settings.tool_timeout,
         embed_base_url=(embed_base_url if embed_base_url is not None else settings.embed_base_url),
         embed_model=embed_model if embed_model is not None else settings.embed_model,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from hive.budget import BudgetTracker
-from hive.clients import OllamaClient, OpenRouterClient
+from hive.clients import OpenAICompatibleClient
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -185,15 +185,14 @@ def budget() -> Generator[BudgetTracker, None, None]:
 
 
 @pytest.fixture
-def ollama() -> OllamaClient:
-    """Ollama client for worker tests (methods are mocked per-test)."""
-    return OllamaClient(endpoint="http://localhost:11434", model="qwen2.5-coder:7b")
-
-
-@pytest.fixture
-def openrouter() -> OpenRouterClient:
-    """OpenRouter client for worker tests (methods are mocked per-test)."""
-    return OpenRouterClient(api_key="sk-test", default_model="qwen/qwen3-coder:free")
+def worker() -> OpenAICompatibleClient:
+    """Worker client for worker tests (methods are mocked per-test)."""
+    return OpenAICompatibleClient(
+        base_url="https://api.nan.example/v1",
+        api_key="test-key",
+        default_model="deepseek-v4-flash",
+        provider_name="NaN",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,7 +185,7 @@ def budget() -> Generator[BudgetTracker, None, None]:
 
 
 @pytest.fixture
-def worker() -> OpenAICompatibleClient:
+def worker_client() -> OpenAICompatibleClient:
     """Worker client for worker tests (methods are mocked per-test)."""
     return OpenAICompatibleClient(
         base_url="https://api.nan.example/v1",

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,4 +1,16 @@
-"""Tests for BudgetTracker — SQLite-backed budget tracking."""
+"""Tests for BudgetTracker — SQLite-backed worker usage telemetry.
+
+HIVE-384 retired the spend cap and kept the telemetry, so this file was trimmed
+rather than deleted. What went: ``TestBudgetGuards`` in full, and the cost
+assertions inside the record/aggregate tests — they covered ``can_spend`` /
+``month_remaining`` / ``month_spent``, which exist to keep a pay-per-token
+provider inside a dollar budget and have no subject on a flat subscription.
+
+What deliberately stayed: recording, the month-scoped aggregate, WAL mode, file
+DB creation and thread safety. None of those belong to the cap, and deleting the
+module wholesale would have dropped concurrency coverage of a tracker that is
+still written on every worker call.
+"""
 
 from __future__ import annotations
 
@@ -15,97 +27,64 @@ def tracker() -> BudgetTracker:
     return BudgetTracker(db_path=":memory:")
 
 
-class TestRecordAndSpent:
-    """Recording requests and querying monthly spend."""
+class TestRecordAndAggregate:
+    """Recording requests and querying the monthly aggregate."""
 
     def test_record_single_request(self, tracker: BudgetTracker) -> None:
         tracker.record_request(
-            model="qwen/qwen3-coder:free",
-            cost_usd=0.0,
+            model="deepseek-v4-flash",
             tokens=100,
             latency_ms=500,
             task_type="code_review",
         )
-        assert tracker.month_spent() == 0.0
+        usage = tracker.month_usage()
+        assert usage["request_count"] == 1
+        assert usage["total_tokens"] == 100
 
-    def test_record_multiple_requests_sums_cost(self, tracker: BudgetTracker) -> None:
-        tracker.record_request(
-            "model-a", cost_usd=0.10, tokens=200, latency_ms=300, task_type="general"
-        )
-        tracker.record_request(
-            "model-b", cost_usd=0.25, tokens=500, latency_ms=600, task_type="general"
-        )
-        assert tracker.month_spent() == pytest.approx(0.35)
+    def test_record_multiple_requests_sums_tokens(self, tracker: BudgetTracker) -> None:
+        tracker.record_request("model-a", tokens=200, latency_ms=300)
+        tracker.record_request("model-b", tokens=500, latency_ms=600)
+        usage = tracker.month_usage()
+        assert usage["request_count"] == 2
+        assert usage["total_tokens"] == 700
 
-    def test_empty_db_returns_zero_spent(self, tracker: BudgetTracker) -> None:
-        assert tracker.month_spent() == 0.0
-
-
-class TestBudgetGuards:
-    """Budget cap enforcement."""
-
-    def test_month_remaining_with_no_spend(self, tracker: BudgetTracker) -> None:
-        assert tracker.month_remaining(budget=5.0) == 5.0
-
-    def test_month_remaining_after_spend(self, tracker: BudgetTracker) -> None:
-        tracker.record_request("m", cost_usd=1.50, tokens=100, latency_ms=100, task_type="general")
-        assert tracker.month_remaining(budget=5.0) == pytest.approx(3.50)
-
-    def test_can_spend_within_budget(self, tracker: BudgetTracker) -> None:
-        assert tracker.can_spend(budget=5.0, amount=1.0) is True
-
-    def test_can_spend_exceeds_budget(self, tracker: BudgetTracker) -> None:
-        tracker.record_request("m", cost_usd=4.50, tokens=100, latency_ms=100, task_type="general")
-        assert tracker.can_spend(budget=5.0, amount=1.0) is False
-
-    def test_can_spend_exact_boundary(self, tracker: BudgetTracker) -> None:
-        tracker.record_request("m", cost_usd=4.00, tokens=100, latency_ms=100, task_type="general")
-        assert tracker.can_spend(budget=5.0, amount=1.0) is True
+    def test_empty_db_returns_zero(self, tracker: BudgetTracker) -> None:
+        usage = tracker.month_usage()
+        assert usage["request_count"] == 0
+        assert usage["total_tokens"] == 0
+        assert usage["by_model"] == {}
 
 
-class TestMonthStats:
-    """Monthly statistics aggregation."""
+class TestMonthUsage:
+    """Monthly usage aggregation."""
 
-    def test_empty_stats(self, tracker: BudgetTracker) -> None:
-        stats = tracker.month_stats(budget=5.0)
-        assert stats["spent"] == 0.0
-        assert stats["remaining"] == 5.0
-        assert stats["request_count"] == 0
-        assert stats["by_model"] == {}
+    def test_usage_with_requests(self, tracker: BudgetTracker) -> None:
+        tracker.record_request("model-a", tokens=200, latency_ms=300, task_type="code")
+        tracker.record_request("model-a", tokens=300, latency_ms=500, task_type="code")
+        tracker.record_request("model-b", tokens=100, latency_ms=200)
 
-    def test_stats_with_requests(self, tracker: BudgetTracker) -> None:
-        tracker.record_request(
-            "model-a", cost_usd=0.10, tokens=200, latency_ms=300, task_type="code"
-        )
-        tracker.record_request(
-            "model-a", cost_usd=0.15, tokens=300, latency_ms=500, task_type="code"
-        )
-        tracker.record_request(
-            "model-b", cost_usd=0.00, tokens=100, latency_ms=200, task_type="general"
-        )
+        usage = tracker.month_usage()
+        assert usage["request_count"] == 3
+        assert usage["total_tokens"] == 600
+        assert usage["by_model"]["model-a"]["count"] == 2
+        assert usage["by_model"]["model-a"]["tokens"] == 500
+        assert usage["by_model"]["model-a"]["avg_latency_ms"] == 400
+        assert usage["by_model"]["model-b"]["count"] == 1
 
-        stats = tracker.month_stats(budget=5.0)
-        assert stats["spent"] == pytest.approx(0.25)
-        assert stats["remaining"] == pytest.approx(4.75)
-        assert stats["request_count"] == 3
-        assert stats["by_model"]["model-a"]["count"] == 2
-        assert stats["by_model"]["model-a"]["total_cost"] == pytest.approx(0.25)
-        assert stats["by_model"]["model-a"]["avg_latency_ms"] == 400
-        assert stats["by_model"]["model-b"]["count"] == 1
-
-    def test_stats_only_current_month(self, tracker: BudgetTracker) -> None:
-        """Requests from other months should not appear in stats."""
-        tracker.record_request("m", cost_usd=1.00, tokens=100, latency_ms=100, task_type="general")
+    def test_usage_only_current_month(self, tracker: BudgetTracker) -> None:
+        """Requests from other months must not appear in the aggregate."""
+        tracker.record_request("m", tokens=100, latency_ms=100)
         # Manually insert a row with a different month
         tracker._conn.execute(
             "INSERT INTO requests (month, model, cost_usd, tokens, latency_ms, task_type) "
-            "VALUES ('2020-01', 'old-model', 99.0, 100, 100, 'general')"
+            "VALUES ('2020-01', 'old-model', 99.0, 4242, 100, 'general')"
         )
         tracker._conn.commit()
 
-        stats = tracker.month_stats(budget=5.0)
-        assert stats["spent"] == pytest.approx(1.00)
-        assert stats["request_count"] == 1
+        usage = tracker.month_usage()
+        assert usage["request_count"] == 1
+        assert usage["total_tokens"] == 100
+        assert "old-model" not in usage["by_model"]
 
 
 class TestWALMode:
@@ -134,12 +113,12 @@ class TestFileDB:
 
         db_file = Path(str(tmp_path)) / "sub" / "dir" / "test.db"
         tracker = BudgetTracker(db_path=str(db_file))
-        tracker.record_request("m", cost_usd=0.5, tokens=10, latency_ms=50, task_type="test")
+        tracker.record_request("m", tokens=10, latency_ms=50, task_type="test")
         assert db_file.exists()
 
         # Verify data persists across instances
         tracker2 = BudgetTracker(db_path=str(db_file))
-        assert tracker2.month_spent() == pytest.approx(0.5)
+        assert tracker2.month_usage()["total_tokens"] == 10
 
 
 class TestThreadSafety:
@@ -159,7 +138,6 @@ class TestThreadSafety:
                 for i in range(n_ops):
                     tracker.record_request(
                         f"model-{i}",
-                        cost_usd=0.01,
                         tokens=10,
                         latency_ms=10,
                         task_type="test",
@@ -174,7 +152,7 @@ class TestThreadSafety:
             t.join()
 
         assert errors == [], f"Thread errors: {errors}"
-        assert tracker.month_spent() == pytest.approx(n_threads * n_ops * 0.01)
+        assert tracker.month_usage()["request_count"] == n_threads * n_ops
 
     def test_concurrent_record_and_read(self, tmp_path: object) -> None:
         from pathlib import Path
@@ -188,7 +166,6 @@ class TestThreadSafety:
                 for _ in range(50):
                     tracker.record_request(
                         "m",
-                        cost_usd=0.01,
                         tokens=10,
                         latency_ms=10,
                         task_type="test",
@@ -199,8 +176,7 @@ class TestThreadSafety:
         def reader() -> None:
             try:
                 for _ in range(50):
-                    tracker.month_stats(budget=5.0)
-                    tracker.can_spend(budget=5.0, amount=0.01)
+                    tracker.month_usage()
             except Exception as exc:
                 errors.append(exc)
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,4 +1,16 @@
-"""Tests for Ollama and OpenRouter HTTP clients."""
+"""Tests for the OpenAI-compatible HTTP client.
+
+HIVE-384 removed ``OllamaClient`` and ``OpenRouterClient``, so their test
+classes went with them — they exercised transports that no longer exist, and a
+test of a deleted class is not coverage.
+
+What was preserved rather than deleted with them: the **ReadTimeout →
+ConnectionError** conversion, which was covered twice (once per retired client)
+and is now covered once against ``OpenAICompatibleClient``. That behaviour
+belongs to the surviving transport, and it is load-bearing — a read timeout
+surfacing as ``ConnectionError`` is what lets the worker classify a stalled
+provider as *pool unavailable* rather than as a failed task.
+"""
 
 from __future__ import annotations
 
@@ -11,10 +23,7 @@ import pytest
 from hive.clients import (
     ClientResponse,
     EmbedResponse,
-    ModelInfo,
-    OllamaClient,
     OpenAICompatibleClient,
-    OpenRouterClient,
 )
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -32,297 +41,24 @@ def _mock_response(
     return resp
 
 
-# ── OllamaClient ────────────────────────────────────────────────────
-
-
-class TestOllamaGenerate:
-    """Ollama /api/chat generation."""
-
-    @pytest.mark.asyncio
-    async def test_generate_success(self) -> None:
-        client = OllamaClient(endpoint="http://localhost:11434", model="qwen2.5-coder:7b")
-        mock_resp = _mock_response(
-            json_data={
-                "message": {"content": "def hello(): pass"},
-                "eval_count": 42,
-                "total_duration": 1_500_000_000,  # 1.5s in nanoseconds
-            }
-        )
-        with patch.object(client._http, "post", new_callable=AsyncMock, return_value=mock_resp):
-            result = await client.generate("Write a hello function")
-
-        assert isinstance(result, ClientResponse)
-        assert result.text == "def hello(): pass"
-        assert result.model == "qwen2.5-coder:7b"
-        assert result.tokens == 42
-        assert result.cost_usd == 0.0
-        assert result.latency_ms == 1500
-
-    @pytest.mark.asyncio
-    async def test_generate_timeout(self) -> None:
-        client = OllamaClient(endpoint="http://localhost:11434", model="test")
-        with (
-            patch.object(
-                client._http,
-                "post",
-                new_callable=AsyncMock,
-                side_effect=httpx.ConnectTimeout("timeout"),
-            ),
-            pytest.raises(ConnectionError, match="Ollama"),
-        ):
-            await client.generate("test")
-
-    @pytest.mark.asyncio
-    async def test_generate_connection_error(self) -> None:
-        client = OllamaClient(endpoint="http://localhost:11434", model="test")
-        with (
-            patch.object(
-                client._http,
-                "post",
-                new_callable=AsyncMock,
-                side_effect=httpx.ConnectError("refused"),
-            ),
-            pytest.raises(ConnectionError, match="Ollama"),
-        ):
-            await client.generate("test")
-
-
-class TestOllamaAvailability:
-    """Ollama health check."""
-
-    @pytest.mark.asyncio
-    async def test_is_available_true(self) -> None:
-        client = OllamaClient(endpoint="http://localhost:11434", model="test")
-        mock_resp = _mock_response(200)
-        with patch.object(
-            client._probe_http,
-            "get",
-            new_callable=AsyncMock,
-            return_value=mock_resp,
-        ):
-            assert await client.is_available() is True
-
-    @pytest.mark.asyncio
-    async def test_is_available_false_on_error(self) -> None:
-        client = OllamaClient(endpoint="http://localhost:11434", model="test")
-        with patch.object(
-            client._probe_http,
-            "get",
-            new_callable=AsyncMock,
-            side_effect=httpx.ConnectError("down"),
-        ):
-            assert await client.is_available() is False
-
-    @pytest.mark.asyncio
-    async def test_is_available_caches_within_ttl(self) -> None:
-        """Second call within TTL must not re-issue the HTTP probe."""
-        client = OllamaClient(endpoint="http://localhost:11434", model="test")
-        mock_resp = _mock_response(200)
-        with patch.object(
-            client._probe_http,
-            "get",
-            new_callable=AsyncMock,
-            return_value=mock_resp,
-        ) as mock_get:
-            assert await client.is_available() is True
-            assert await client.is_available() is True
-            assert await client.is_available() is True
-            assert mock_get.call_count == 1, "cache must suppress repeat probes"
-
-
-# ── OpenRouterClient ────────────────────────────────────────────────
-
-
-class TestOpenRouterGenerate:
-    """OpenRouter /api/v1/chat/completions."""
-
-    @pytest.mark.asyncio
-    async def test_generate_success(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="qwen/qwen3-coder:free")
-        mock_resp = _mock_response(
-            json_data={
-                "choices": [{"message": {"content": "result text"}}],
-                "usage": {"total_tokens": 150},
-                "model": "qwen/qwen3-coder:free",
-            }
-        )
-        with patch.object(client._http, "post", new_callable=AsyncMock, return_value=mock_resp):
-            result = await client.generate("Explain this code")
-
-        assert isinstance(result, ClientResponse)
-        assert result.text == "result text"
-        assert result.tokens == 150
-        assert result.model == "qwen/qwen3-coder:free"
-
-    @pytest.mark.asyncio
-    async def test_generate_with_explicit_model(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="default-model")
-        mock_resp = _mock_response(
-            json_data={
-                "choices": [{"message": {"content": "ok"}}],
-                "usage": {"total_tokens": 10},
-                "model": "deepseek/deepseek-v3.2",
-            }
-        )
-        with patch.object(
-            client._http, "post", new_callable=AsyncMock, return_value=mock_resp
-        ) as mock_post:
-            await client.generate("test", model="deepseek/deepseek-v3.2")
-
-        # Verify the explicit model was sent in the request body
-        call_kwargs = mock_post.call_args
-        assert call_kwargs[1]["json"]["model"] == "deepseek/deepseek-v3.2"
-
-    @pytest.mark.asyncio
-    async def test_generate_rate_limit(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="m")
-        mock_resp = _mock_response(
-            status_code=429, json_data={"error": {"message": "rate limited"}}
-        )
-        with (
-            patch.object(client._http, "post", new_callable=AsyncMock, return_value=mock_resp),
-            pytest.raises(RuntimeError, match="rate limit"),
-        ):
-            await client.generate("test")
-
-    @pytest.mark.asyncio
-    async def test_generate_api_error(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="m")
-        mock_resp = _mock_response(
-            status_code=500, json_data={"error": {"message": "internal error"}}
-        )
-        with (
-            patch.object(client._http, "post", new_callable=AsyncMock, return_value=mock_resp),
-            pytest.raises(RuntimeError, match="OpenRouter API error"),
-        ):
-            await client.generate("test")
-
-    @pytest.mark.asyncio
-    async def test_generate_connection_error(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="m")
-        with (
-            patch.object(
-                client._http, "post", new_callable=AsyncMock, side_effect=httpx.ConnectError("down")
-            ),
-            pytest.raises(ConnectionError, match="OpenRouter"),
-        ):
-            await client.generate("test")
-
-    @pytest.mark.asyncio
-    async def test_generate_extracts_cost(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="m")
-        mock_resp = _mock_response(
-            json_data={
-                "choices": [{"message": {"content": "x"}}],
-                "usage": {"total_tokens": 50, "cost": 0.0012},
-                "model": "m",
-            }
-        )
-        with patch.object(client._http, "post", new_callable=AsyncMock, return_value=mock_resp):
-            result = await client.generate("test")
-
-        assert result.cost_usd == pytest.approx(0.0012)
-
-
-class TestOpenRouterListModels:
-    """OpenRouter /api/v1/models."""
-
-    @pytest.mark.asyncio
-    async def test_list_models(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="m")
-        mock_resp = _mock_response(
-            json_data={
-                "data": [
-                    {
-                        "id": "qwen/qwen3-coder:free",
-                        "name": "Qwen3 Coder (free)",
-                        "context_length": 65536,
-                        "pricing": {"prompt": "0.0", "completion": "0.0"},
-                    },
-                    {
-                        "id": "deepseek/deepseek-v3",
-                        "name": "DeepSeek V3",
-                        "context_length": 128000,
-                        "pricing": {"prompt": "0.00014", "completion": "0.00028"},
-                    },
-                ],
-            }
-        )
-        with patch.object(client._http, "get", new_callable=AsyncMock, return_value=mock_resp):
-            models = await client.list_models()
-
-        assert len(models) == 2
-        assert isinstance(models[0], ModelInfo)
-        assert models[0].id == "qwen/qwen3-coder:free"
-        assert models[0].is_free is True
-        assert models[1].is_free is False
-
-    @pytest.mark.asyncio
-    async def test_list_models_connection_error(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="m")
-        with (
-            patch.object(
-                client._http, "get", new_callable=AsyncMock, side_effect=httpx.ConnectError("down")
-            ),
-            pytest.raises(ConnectionError, match="OpenRouter"),
-        ):
-            await client.list_models()
-
-    @pytest.mark.asyncio
-    async def test_list_models_http_error(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="m")
-        mock_resp = _mock_response(status_code=500, json_data={"error": "internal"})
-        with (
-            patch.object(client._http, "get", new_callable=AsyncMock, return_value=mock_resp),
-            pytest.raises(RuntimeError, match="models error"),
-        ):
-            await client.list_models()
-
-    @pytest.mark.asyncio
-    async def test_list_models_malformed_pricing(self) -> None:
-        """Malformed pricing values default to 0.0 instead of crashing."""
-        client = OpenRouterClient(api_key="sk-test", default_model="m")
-        mock_resp = _mock_response(
-            json_data={
-                "data": [
-                    {
-                        "id": "bad-model",
-                        "name": "Bad Pricing",
-                        "context_length": 4096,
-                        "pricing": {"prompt": "not-a-number", "completion": None},
-                    },
-                ],
-            }
-        )
-        with patch.object(client._http, "get", new_callable=AsyncMock, return_value=mock_resp):
-            models = await client.list_models()
-
-        assert len(models) == 1
-        assert models[0].cost_per_million_input == 0.0
-        assert models[0].cost_per_million_output == 0.0
-        assert models[0].is_free is True
-
-    @pytest.mark.asyncio
-    async def test_list_models_read_timeout(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="m")
-        with (
-            patch.object(
-                client._http,
-                "get",
-                new_callable=AsyncMock,
-                side_effect=httpx.ReadTimeout("read timed out"),
-            ),
-            pytest.raises(ConnectionError, match="timed out"),
-        ):
-            await client.list_models()
-
-
 class TestReadTimeoutResilience:
-    """Verify ReadTimeout is caught and converted to ConnectionError."""
+    """A read timeout must surface as ConnectionError, not as a raw httpx error.
+
+    Kept from the retired clients' tests: the worker classifies
+    ``ConnectionError`` as *pool unavailable* (retry elsewhere is legitimate)
+    and other failures as *task failed*. If a stalled provider leaked an
+    httpx exception instead, it would be classified as a task failure and the
+    dispatcher would stop advancing its chain on exactly the case the chain
+    exists for.
+    """
 
     @pytest.mark.asyncio
-    async def test_ollama_read_timeout(self) -> None:
-        client = OllamaClient(endpoint="http://localhost:11434", model="test")
+    async def test_read_timeout_becomes_connection_error(self) -> None:
+        client = OpenAICompatibleClient(
+            base_url="https://api.nan.example/v1",
+            api_key="test-key",
+            default_model="deepseek-v4-flash",
+        )
         with (
             patch.object(
                 client._http,
@@ -333,34 +69,6 @@ class TestReadTimeoutResilience:
             pytest.raises(ConnectionError, match="timed out"),
         ):
             await client.generate("test")
-
-    @pytest.mark.asyncio
-    async def test_openrouter_read_timeout(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="m")
-        with (
-            patch.object(
-                client._http,
-                "post",
-                new_callable=AsyncMock,
-                side_effect=httpx.ReadTimeout("inference took too long"),
-            ),
-            pytest.raises(ConnectionError, match="timed out"),
-        ):
-            await client.generate("test")
-
-    @pytest.mark.asyncio
-    async def test_ollama_is_available_read_timeout(self) -> None:
-        client = OllamaClient(endpoint="http://localhost:11434", model="test")
-        with patch.object(
-            client._probe_http,
-            "get",
-            new_callable=AsyncMock,
-            side_effect=httpx.ReadTimeout("slow"),
-        ):
-            assert await client.is_available() is False
-
-
-# ── OpenAICompatibleClient (HIVE-211: provider-parameterized) ────────
 
 
 class TestOpenAICompatibleChat:
@@ -557,22 +265,3 @@ class TestOpenAICompatibleEmbed:
             pytest.raises(RuntimeError, match="NaN"),
         ):
             await client.embed(["t"])
-
-
-class TestOpenRouterBackwardCompat:
-    """OpenRouterClient must remain a drop-in (now a thin subclass)."""
-
-    def test_openrouter_is_subclass_of_generalized_client(self) -> None:
-        client = OpenRouterClient(api_key="sk-test", default_model="m")
-        assert isinstance(client, OpenAICompatibleClient)
-
-    @pytest.mark.asyncio
-    async def test_openrouter_can_embed(self) -> None:
-        """The subclass inherits embed() for free."""
-        client = OpenRouterClient(api_key="sk-test", default_model="text-embedding-3-small")
-        mock_resp = _mock_response(
-            json_data={"data": [{"index": 0, "embedding": [0.9]}], "usage": {"total_tokens": 2}}
-        )
-        with patch.object(client._http, "post", new_callable=AsyncMock, return_value=mock_resp):
-            result = await client.embed(["x"])
-        assert result.vectors == [[0.9]]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ def _isolate_hive_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Strip ambient hive configuration before every test.
 
     ``HiveSettings`` reads ``HIVE_*`` env vars plus the unprefixed
-    ``VAULT_PATH`` / ``OPENROUTER_API_KEY`` deploy aliases. A developer or
+    ``VAULT_PATH`` / ``NAN_API_KEY`` deploy aliases. A developer or
     deploy box with any of these set (a real ``VAULT_PATH`` is the normal
     case) would otherwise mask the hardcoded defaults and fail the
     default-value assertions — green in CI, red locally. Clearing here runs
@@ -25,26 +25,16 @@ def _isolate_hive_env(monkeypatch: pytest.MonkeyPatch) -> None:
             monkeypatch.delenv(key, raising=False)
     monkeypatch.delenv("VAULT_PATH", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    # HIVE-384: NAN_API_KEY is the launcher-side name of the worker credential,
+    # accepted as an unprefixed alias. It is present in a real developer
+    # environment, so leaving it set would mask the fallback assertions below —
+    # green in CI, red locally, which is the failure this fixture exists for.
+    monkeypatch.delenv("NAN_API_KEY", raising=False)
 
 
 class TestDefaults:
     def test_vault_path_default(self) -> None:
         assert HiveSettings().vault_path == Path.home() / "Projects" / "knowledge"
-
-    def test_ollama_endpoint_default(self) -> None:
-        assert HiveSettings().ollama_endpoint == "http://localhost:11434"
-
-    def test_ollama_model_default(self) -> None:
-        assert HiveSettings().ollama_model == "qwen2.5-coder:7b"
-
-    def test_openrouter_api_key_default_none(self) -> None:
-        assert HiveSettings().openrouter_api_key is None
-
-    def test_openrouter_budget_default(self) -> None:
-        assert HiveSettings().openrouter_budget == 1.0
-
-    def test_openrouter_model_default(self) -> None:
-        assert HiveSettings().openrouter_model == "qwen/qwen3-coder:free"
 
     def test_db_path_default(self) -> None:
         expected = str(Path.home() / ".local" / "share" / "hive" / "worker.db")
@@ -126,17 +116,9 @@ class TestEnvOverride:
         assert HiveSettings().post_kill_drain_s == float(value)
 
     def test_hive_prefix_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("HIVE_OLLAMA_MODEL", "llama3:8b")
-        assert HiveSettings().ollama_model == "llama3:8b"
-
-    def test_openrouter_key_without_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-123")
-        assert HiveSettings().openrouter_api_key == "sk-test-123"
-
-    def test_hive_prefixed_key_takes_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("OPENROUTER_API_KEY", "bare")
-        monkeypatch.setenv("HIVE_OPENROUTER_API_KEY", "prefixed")
-        assert HiveSettings().openrouter_api_key == "prefixed"
+        """The HIVE_ prefix reaches a plain field (was HIVE_OLLAMA_MODEL)."""
+        monkeypatch.setenv("HIVE_WORKER_MODEL", "deepseek-v4-flash")
+        assert HiveSettings().worker_model == "deepseek-v4-flash"
 
     def test_vault_path_coercion(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HIVE_VAULT_PATH", "/tmp/vault")
@@ -335,3 +317,90 @@ class TestValidation:
     def test_invalid_budget_type_raises(self) -> None:
         with pytest.raises(ValidationError):
             HiveSettings(openrouter_budget="not-a-number")  # type: ignore[arg-type]
+
+
+class TestWorkerSettings:
+    """HIVE-384: the worker's own provider settings, with the embed fallback.
+
+    The worker is not an embedder, so it gets honest names — but the two point
+    at the same NaN endpoint in the default deployment, and requiring both to be
+    set would mean a machine that already works stops working on upgrade. Hence
+    the fallback: ``HIVE_WORKER_*`` when present, ``HIVE_EMBED_*`` otherwise.
+    """
+
+    def test_falls_back_to_embed_when_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("HIVE_EMBED_BASE_URL", "https://api.nan.example/v1")
+        monkeypatch.setenv("HIVE_EMBED_API_KEY", "embed-key")
+        monkeypatch.setenv("HIVE_EMBED_MODEL", "qwen3-embedding")
+        s = HiveSettings()
+        assert s.worker_base_url == "https://api.nan.example/v1"
+        assert s.worker_api_key == "embed-key"
+        assert s.worker_model == "qwen3-embedding"
+
+    def test_explicit_worker_settings_win_over_embed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("HIVE_EMBED_BASE_URL", "https://embed.example/v1")
+        monkeypatch.setenv("HIVE_EMBED_API_KEY", "embed-key")
+        monkeypatch.setenv("HIVE_EMBED_MODEL", "qwen3-embedding")
+        monkeypatch.setenv("HIVE_WORKER_BASE_URL", "https://worker.example/v1")
+        monkeypatch.setenv("HIVE_WORKER_API_KEY", "worker-key")
+        monkeypatch.setenv("HIVE_WORKER_MODEL", "deepseek-v4-flash")
+        s = HiveSettings()
+        assert s.worker_base_url == "https://worker.example/v1"
+        assert s.worker_api_key == "worker-key"
+        assert s.worker_model == "deepseek-v4-flash"
+
+    def test_nan_api_key_alias_populates_the_worker_key(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The launcher injects the registry's name; hive must accept it.
+
+        Without this alias the launcher would export ``NAN_API_KEY`` and hive
+        would read ``HIVE_WORKER_API_KEY``, so authentication would fail for a
+        reason no error message explains.
+        """
+        monkeypatch.setenv("NAN_API_KEY", "from-the-launcher")
+        assert HiveSettings().worker_api_key == "from-the-launcher"
+
+    def test_prefixed_name_wins_over_the_alias(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("NAN_API_KEY", "alias-value")
+        monkeypatch.setenv("HIVE_WORKER_API_KEY", "explicit-value")
+        assert HiveSettings().worker_api_key == "explicit-value"
+
+    def test_all_empty_is_the_disabled_default(self) -> None:
+        """No worker configuration at all resolves to empty, never to a guess."""
+        s = HiveSettings()
+        assert s.worker_base_url == ""
+        assert s.worker_api_key == ""
+        assert s.worker_model == ""
+
+
+class TestRetiredProviderSettings:
+    """HIVE-384: Ollama and OpenRouter are removed, not deprecated.
+
+    Asserted rather than reviewed by eye, so a partial revert is caught by the
+    suite instead of by a reader.
+    """
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "ollama_endpoint",
+            "ollama_model",
+            "openrouter_api_key",
+            "openrouter_budget",
+            "openrouter_model",
+            "openrouter_paid_model",
+        ],
+    )
+    def test_retired_field_is_gone(self, field: str) -> None:
+        assert field not in HiveSettings.model_fields

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from hive.clients import ClientResponse, ModelInfo, OpenRouterClient
+from hive.clients import ClientResponse, ModelInfo, OpenAICompatibleClient
 from hive.server import create_server
 
 if TYPE_CHECKING:
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from fastmcp.tools import ToolResult
 
     from hive.budget import BudgetTracker
-    from hive.clients import OllamaClient
 
 
 def _text(result: ToolResult) -> str:
@@ -683,9 +682,10 @@ class TestVaultHealthIdentity:
         secret = "sk-DO-NOT-LEAK-CANARY-12345"
         mcp = create_server(
             vault_path=mock_vault,
-            openrouter_client=OpenRouterClient(
+            worker_client=OpenAICompatibleClient(
+                base_url="https://api.nan.example/v1",
                 api_key=secret,
-                default_model="qwen/qwen3-coder:free",
+                default_model="deepseek-v4-flash",
             ),
         )
         try:
@@ -693,7 +693,7 @@ class TestVaultHealthIdentity:
             assert secret not in result
             assert "## server" in result
             # presence boolean is exposed instead
-            assert "openrouter" in result.lower()
+            assert "worker" in result.lower()
         finally:
             _close_server(mcp)
 
@@ -741,7 +741,7 @@ class TestVaultHealthRuntime:
         assert "## runtime" in result
         assert "uptime_s" in result
         assert "tools_registered" in result
-        assert "openrouter_budget" in result
+        assert "worker_usage" in result
 
     async def test_runtime_lists_registered_tool_names(
         self,
@@ -920,9 +920,10 @@ class TestVaultHealthRuntime:
         secret = "sk-RUNTIME-NEVER-LEAK-ABCDEF"
         mcp = create_server(
             vault_path=mock_vault,
-            openrouter_client=OpenRouterClient(
+            worker_client=OpenAICompatibleClient(
+                base_url="https://api.nan.example/v1",
                 api_key=secret,
-                default_model="qwen/qwen3-coder:free",
+                default_model="deepseek-v4-flash",
             ),
         )
         try:
@@ -933,8 +934,11 @@ class TestVaultHealthRuntime:
                 ),
             )
             assert secret not in result
-            # budget block exposes cap+spent, not credentials
-            assert "openrouter_budget" in result
+            # The usage block reports volume, never credentials. The block must
+            # be PRESENT as well as clean: an assertion that a secret is absent
+            # passes trivially when the whole section is missing, which is the
+            # way a leak test quietly stops testing anything.
+            assert "worker_usage" in result
         finally:
             _close_server(mcp)
 
@@ -2278,31 +2282,38 @@ class TestVaultUsage:
 def worker(
     mock_vault: Path,
     budget: BudgetTracker,
-    ollama: OllamaClient,
-    openrouter: OpenRouterClient,
+    worker_client: OpenAICompatibleClient,
 ) -> FastMCP:
     """Create a unified server with worker deps for worker-specific tests."""
     return create_server(
         vault_path=mock_vault,
         budget_tracker=budget,
-        ollama_client=ollama,
-        openrouter_client=openrouter,
+        worker_client=worker_client,
     )
 
 
-# ── delegate_task: auto routing ─────────────────────────────────────
+# ── delegate_task: single-shot dispatch ─────────────────────────────
 
 
-class TestDelegateTaskAutoRouting:
-    """Auto routing: Ollama first, then OpenRouter free, then paid."""
+class TestDelegateTaskDispatch:
+    """One worker, one shot (HIVE-384).
+
+    The tiered ladder these tests replaced (Ollama → OpenRouter free →
+    OpenRouter paid → reject) went with its providers, and the shape went with
+    it deliberately: choosing among pools belongs to the dispatcher, not to a
+    backend. What is asserted here instead is the property that makes such a
+    dispatcher possible — that a failure is *classified* rather than collapsed,
+    and that exactly one attempt is made.
+    """
 
     @pytest.mark.asyncio
-    async def test_ollama_first_when_available(self, worker: FastMCP, ollama: OllamaClient) -> None:
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+    async def test_success_returns_output_and_names_the_model(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
+    ) -> None:
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=ClientResponse(
                 text="hello world",
-                model="qwen2.5-coder:7b",
+                model="deepseek-v4-flash",
                 tokens=10,
                 cost_usd=0.0,
                 latency_ms=200,
@@ -2310,275 +2321,177 @@ class TestDelegateTaskAutoRouting:
         )
         result = _text(await worker.call_tool("delegate_task", {"prompt": "say hello"}))
         assert "hello world" in result
-        assert "qwen2.5-coder:7b" in result
+        assert "deepseek-v4-flash" in result
 
     @pytest.mark.asyncio
-    async def test_fallback_to_openrouter_free_when_ollama_down(
-        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    async def test_exactly_one_attempt_on_failure(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
     ) -> None:
-        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
-        openrouter.generate = AsyncMock(  # type: ignore[method-assign]
-            return_value=ClientResponse(
-                text="from openrouter",
-                model="qwen/qwen3-coder:free",
-                tokens=50,
-                cost_usd=0.0,
-                latency_ms=800,
-            )
+        """No retry, no second provider — the caller owns the fallback chain.
+
+        A backend that retries on its own is a second routing authority: the
+        dispatcher can no longer attribute which model answered, and a bad
+        answer silently becomes a different model's answer.
+        """
+        gen = AsyncMock(side_effect=ConnectionError("refused"))
+        worker_client.generate = gen  # type: ignore[method-assign]
+        await worker.call_tool("delegate_task", {"prompt": "test"})
+        assert gen.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_unreachable_provider_reports_unavailability(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
+    ) -> None:
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
+            side_effect=ConnectionError("connection refused"),
         )
         result = _text(await worker.call_tool("delegate_task", {"prompt": "test"}))
-        assert "from openrouter" in result
+        assert "unreachable" in result.lower()
 
     @pytest.mark.asyncio
-    async def test_ollama_error_falls_to_openrouter(
-        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    async def test_provider_error_is_not_reported_as_unavailability(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
     ) -> None:
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(side_effect=ConnectionError("ollama failed"))  # type: ignore[method-assign]
-        openrouter.generate = AsyncMock(  # type: ignore[method-assign]
-            return_value=ClientResponse(
-                text="fallback ok",
-                model="qwen/qwen3-coder:free",
-                tokens=30,
-                cost_usd=0.0,
-                latency_ms=500,
-            )
+        """The two failure classes must stay distinguishable in the output.
+
+        A dispatcher advances its chain on *pool unavailable* and must not on
+        *task failed*; if the surface text conflated them the distinction the
+        classification exists for would be unobservable from outside.
+        """
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("model returned malformed output"),
         )
         result = _text(await worker.call_tool("delegate_task", {"prompt": "test"}))
-        assert "fallback ok" in result
+        assert "worker error" in result.lower()
+        assert "unreachable" not in result.lower()
 
     @pytest.mark.asyncio
-    async def test_all_unavailable_returns_reject(
-        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    async def test_unconfigured_worker_says_so(self, mock_vault: Path) -> None:
+        """No worker configured is a distinct, stated outcome, not a crash."""
+        mcp = create_server(vault_path=mock_vault)
+        try:
+            result = _text(await mcp.call_tool("delegate_task", {"prompt": "test"}))
+            assert "not configured" in result.lower()
+        finally:
+            _close_server(mcp)
+
+    @pytest.mark.asyncio
+    async def test_explicit_model_is_passed_through(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
     ) -> None:
-        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
-        openrouter.generate = AsyncMock(side_effect=ConnectionError("down"))  # type: ignore[method-assign]
-        result = _text(await worker.call_tool("delegate_task", {"prompt": "test"}))
-        assert "The host should handle this task directly" in result
-
-
-# ── delegate_task: budget enforcement ───────────────────────────────
-
-
-class TestDelegateTaskBudget:
-    """Budget cap enforcement for paid models."""
-
-    @pytest.mark.asyncio
-    async def test_max_cost_zero_skips_paid(
-        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
-    ) -> None:
-        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
-        # Free model fails
-        openrouter.generate = AsyncMock(side_effect=RuntimeError("rate limit"))  # type: ignore[method-assign]
-        result = _text(
-            await worker.call_tool("delegate_task", {"prompt": "test", "max_cost_per_request": 0.0})
-        )
-        assert "The host should handle this task directly" in result
-
-    @pytest.mark.asyncio
-    async def test_max_cost_allows_paid_fallback(
-        self,
-        worker: FastMCP,
-        ollama: OllamaClient,
-        openrouter: OpenRouterClient,
-    ) -> None:
-        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
-
-        call_count = 0
-
-        async def _side_effect(*args: object, **kwargs: object) -> ClientResponse:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                # First call: free model fails
-                raise RuntimeError("rate limit")
-            # Second call: paid model succeeds
-            return ClientResponse(
-                text="paid result",
-                model="deepseek/deepseek-v3",
-                tokens=100,
-                cost_usd=0.03,
-                latency_ms=1000,
-            )
-
-        openrouter.generate = AsyncMock(side_effect=_side_effect)  # type: ignore[method-assign]
-
-        result = _text(
-            await worker.call_tool(
-                "delegate_task", {"prompt": "test", "max_cost_per_request": 0.05}
-            )
-        )
-        assert "paid result" in result
-
-    @pytest.mark.asyncio
-    async def test_budget_exhausted_rejects_paid(
-        self,
-        worker: FastMCP,
-        budget: BudgetTracker,
-        ollama: OllamaClient,
-        openrouter: OpenRouterClient,
-    ) -> None:
-        # Exhaust budget
-        budget.record_request("m", cost_usd=5.0, tokens=100, latency_ms=100, task_type="general")
-        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
-        openrouter.generate = AsyncMock(side_effect=RuntimeError("rate limit"))  # type: ignore[method-assign]
-
-        result = _text(
-            await worker.call_tool(
-                "delegate_task", {"prompt": "test", "max_cost_per_request": 0.10}
-            )
-        )
-        assert "The host should handle this task directly" in result
-
-
-# ── delegate_task: explicit model ───────────────────────────────────
-
-
-class TestDelegateTaskExplicitModel:
-    """Explicit model selection bypasses auto-routing."""
-
-    @pytest.mark.asyncio
-    async def test_explicit_ollama(self, worker: FastMCP, ollama: OllamaClient) -> None:
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        gen = AsyncMock(
             return_value=ClientResponse(
-                text="explicit ollama",
-                model="qwen2.5-coder:7b",
-                tokens=20,
-                cost_usd=0.0,
-                latency_ms=150,
+                text="ok", model="mimo-v2.5", tokens=5, cost_usd=0.0, latency_ms=100
             )
         )
-        result = _text(
-            await worker.call_tool("delegate_task", {"prompt": "test", "model": "ollama"})
+        worker_client.generate = gen  # type: ignore[method-assign]
+        await worker.call_tool(
+            "delegate_task",
+            {"prompt": "test", "model": "mimo-v2.5"},
         )
-        assert "explicit ollama" in result
+        assert gen.await_args is not None
+        assert gen.await_args.kwargs["model"] == "mimo-v2.5"
+
+
+# ── delegate_task: the retired provider aliases ─────────────────────
+
+
+class TestRetiredModelAliases:
+    """4.0.0 removed the provider vocabulary; passing it must fail loudly.
+
+    A dead alias that is quietly accepted reaches the caller later as a
+    confusing inference failure. Rejected with a message naming the
+    replacement, it is a break they can fix in one read.
+    """
 
     @pytest.mark.asyncio
-    async def test_explicit_openrouter_free(
-        self, worker: FastMCP, openrouter: OpenRouterClient
+    @pytest.mark.parametrize(
+        "alias",
+        ["auto", "ollama", "openrouter-free", "openrouter"],
+    )
+    async def test_alias_is_rejected(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient, alias: str
     ) -> None:
-        openrouter.generate = AsyncMock(  # type: ignore[method-assign]
-            return_value=ClientResponse(
-                text="explicit free",
-                model="qwen/qwen3-coder:free",
-                tokens=30,
-                cost_usd=0.0,
-                latency_ms=400,
-            )
-        )
-        result = _text(
-            await worker.call_tool("delegate_task", {"prompt": "test", "model": "openrouter-free"})
-        )
-        assert "explicit free" in result
-
-    @pytest.mark.asyncio
-    async def test_explicit_openrouter_paid(
-        self,
-        worker: FastMCP,
-        openrouter: OpenRouterClient,
-    ) -> None:
-        openrouter.generate = AsyncMock(  # type: ignore[method-assign]
-            return_value=ClientResponse(
-                text="explicit paid",
-                model="qwen/qwen3-coder",
-                tokens=50,
-                cost_usd=0.001,
-                latency_ms=300,
-            )
-        )
-        result = _text(
-            await worker.call_tool("delegate_task", {"prompt": "test", "model": "openrouter"})
-        )
-        assert "explicit paid" in result
-
-    @pytest.mark.asyncio
-    async def test_explicit_custom_model(
-        self,
-        worker: FastMCP,
-        openrouter: OpenRouterClient,
-    ) -> None:
-        openrouter.generate = AsyncMock(  # type: ignore[method-assign]
-            return_value=ClientResponse(
-                text="custom model output",
-                model="deepseek/deepseek-v3",
-                tokens=40,
-                cost_usd=0.0005,
-                latency_ms=250,
-            )
-        )
-        result = _text(
-            await worker.call_tool(
-                "delegate_task",
-                {"prompt": "test", "model": "deepseek/deepseek-v3"},
-            )
-        )
-        assert "custom model output" in result
-
-    @pytest.mark.asyncio
-    async def test_empty_prompt_no_project_rejected(self, worker: FastMCP) -> None:
-        result = _text(await worker.call_tool("delegate_task", {}))
-        assert "required" in result.lower()
+        gen = AsyncMock()
+        worker_client.generate = gen  # type: ignore[method-assign]
+        result = _text(await worker.call_tool("delegate_task", {"prompt": "test", "model": alias}))
+        assert "removed in 4.0.0" in result
+        # Rejected before dispatch: no quota is spent discovering the break.
+        assert gen.await_count == 0
 
 
-# ── delegate_task: records to budget tracker ────────────────────────
+# ── delegate_task: records usage telemetry ──────────────────────────
 
 
 class TestDelegateTaskRecording:
-    """Successful requests are recorded in the budget tracker."""
+    """A successful call is recorded as usage, which is what survived the cap."""
 
     @pytest.mark.asyncio
-    async def test_records_on_success(
-        self, worker: FastMCP, budget: BudgetTracker, ollama: OllamaClient
+    async def test_records_tokens_and_latency(
+        self,
+        worker: FastMCP,
+        budget: BudgetTracker,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=ClientResponse(
-                text="ok", model="qwen2.5-coder:7b", tokens=10, cost_usd=0.0, latency_ms=100
+                text="ok",
+                model="deepseek-v4-flash",
+                tokens=42,
+                cost_usd=0.0,
+                latency_ms=321,
             )
         )
         await worker.call_tool("delegate_task", {"prompt": "test"})
-        assert budget.month_stats(5.0)["request_count"] == 1
+        usage = budget.month_usage()
+        assert usage["request_count"] == 1
+        assert usage["total_tokens"] == 42
+        assert usage["by_model"]["deepseek-v4-flash"]["avg_latency_ms"] == 321
 
 
 # ── worker_status ───────────────────────────────────────────────────
 
 
 class TestWorkerStatus:
-    """worker_status tool shows budget, connectivity, and available models."""
+    """worker_status reports configuration, probed reachability, and usage.
+
+    The distinction these tests defend is the one whose absence caused #384:
+    **configured is not reachable.** The old surface reported providers by
+    whether a client object existed, so it said the worker was there while it
+    served zero models, for an unknown length of time and with nobody looking.
+    """
 
     @pytest.mark.asyncio
-    async def test_status_shows_budget(
-        self,
-        worker: FastMCP,
-        budget: BudgetTracker,
-        ollama: OllamaClient,
-        openrouter: OpenRouterClient,
+    async def test_reports_configuration_and_model(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
     ) -> None:
-        budget.record_request("m", cost_usd=1.23, tokens=100, latency_ms=100, task_type="general")
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        worker_client.list_models = AsyncMock(return_value=[])  # type: ignore[method-assign]
         result = _text(await worker.call_tool("worker_status", {}))
-        assert "1.23" in result
-        assert "$1.0" in result
+        assert "Configured: yes" in result
+        assert "deepseek-v4-flash" in result
 
     @pytest.mark.asyncio
-    async def test_status_shows_ollama_connectivity(
-        self, worker: FastMCP, ollama: OllamaClient
+    async def test_unreachable_provider_is_reported_as_not_reachable(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
     ) -> None:
-        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        """Configured and unreachable must be visibly different states."""
+        worker_client.list_models = AsyncMock(  # type: ignore[method-assign]
+            side_effect=ConnectionError("connection refused"),
+        )
         result = _text(await worker.call_tool("worker_status", {}))
-        assert "offline" in result.lower() or "unavailable" in result.lower()
+        assert "Configured: yes" in result
+        assert "Reachable: NO" in result
 
     @pytest.mark.asyncio
-    async def test_status_includes_models(
-        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    async def test_reachable_provider_reports_its_models(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
     ) -> None:
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        openrouter.list_models = AsyncMock(  # type: ignore[method-assign]
+        worker_client.list_models = AsyncMock(  # type: ignore[method-assign]
             return_value=[
                 ModelInfo(
-                    id="qwen/qwen3-coder:free",
-                    name="Qwen3 Coder",
-                    context_length=65536,
+                    id="deepseek-v4-flash",
+                    name="DeepSeek V4 Flash",
+                    context_length=1048576,
                     cost_per_million_input=0.0,
                     cost_per_million_output=0.0,
                     is_free=True,
@@ -2586,17 +2499,50 @@ class TestWorkerStatus:
             ]
         )
         result = _text(await worker.call_tool("worker_status", {}))
-        assert "qwen2.5-coder:7b" in result
-        assert "qwen/qwen3-coder:free" in result
+        assert "Reachable: yes" in result
+        assert "DeepSeek V4 Flash" in result
 
     @pytest.mark.asyncio
-    async def test_status_without_models(
-        self, worker: FastMCP, ollama: OllamaClient, openrouter: OpenRouterClient
+    async def test_unconfigured_worker_says_what_to_set(self, mock_vault: Path) -> None:
+        mcp = create_server(vault_path=mock_vault)
+        try:
+            result = _text(await mcp.call_tool("worker_status", {}))
+            assert "Configured: no" in result
+            assert "HIVE_WORKER_BASE_URL" in result
+        finally:
+            _close_server(mcp)
+
+    @pytest.mark.asyncio
+    async def test_without_models_it_does_not_claim_reachability(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
     ) -> None:
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        """Skipping the probe must report `unprobed`, never `yes`.
+
+        An unprobed backend reported as reachable is precisely the false
+        assurance this tool exists to stop giving.
+        """
+        probe = AsyncMock(return_value=[])
+        worker_client.list_models = probe  # type: ignore[method-assign]
         result = _text(await worker.call_tool("worker_status", {"include_models": False}))
+        assert "Reachable: unprobed" in result
         assert "Available Models" not in result
-        assert "Budget" in result
+        assert probe.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_reports_usage_not_dollars(
+        self,
+        worker: FastMCP,
+        budget: BudgetTracker,
+        worker_client: OpenAICompatibleClient,
+    ) -> None:
+        worker_client.list_models = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        budget.record_request("m", tokens=100, latency_ms=100)
+        result = _text(await worker.call_tool("worker_status", {}))
+        assert "Usage this month" in result
+        assert "Tokens: 100" in result
+        # A dollar figure on a flat subscription would always read zero, and a
+        # gauge that never moves looks like a working gauge.
+        assert "$" not in result
 
 
 # ── Multi-scope vault tests ─────────────────────────────────────────
@@ -3685,15 +3631,13 @@ class TestSectionFallback:
 def worker_vault(
     git_vault: Path,
     budget: BudgetTracker,
-    ollama: OllamaClient,
-    openrouter: OpenRouterClient,
+    worker_client: OpenAICompatibleClient,
 ) -> FastMCP:
     """Server with git vault + worker deps for capture_lesson (batch) tests."""
     return create_server(
         vault_path=git_vault,
         budget_tracker=budget,
-        ollama_client=ollama,
-        openrouter_client=openrouter,
+        worker_client=worker_client,
     )
 
 
@@ -3737,10 +3681,9 @@ class TestExtractLessons:
         self,
         git_vault: Path,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(_VALID_LESSONS_JSON),
         )
         result = _text(
@@ -3761,7 +3704,7 @@ class TestExtractLessons:
         self,
         git_vault: Path,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
         # Pre-write a lesson with same title
         lessons_file = git_vault / "10_projects" / "testproject" / "90-lessons.md"
@@ -3769,8 +3712,7 @@ class TestExtractLessons:
         lessons_file.write_text(
             existing + "\n### [2026-01-01] Always check return values\nExisting.\n"
         )
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(_VALID_LESSONS_JSON),
         )
         result = _text(
@@ -3787,7 +3729,7 @@ class TestExtractLessons:
     async def test_filters_low_confidence(
         self,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
         low_conf = json.dumps(
             [
@@ -3801,8 +3743,7 @@ class TestExtractLessons:
                 },
             ]
         )
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(low_conf),
         )
         result = _text(
@@ -3817,11 +3758,9 @@ class TestExtractLessons:
     async def test_worker_unavailable(
         self,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
-        openrouter: OpenRouterClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
-        ollama.is_available = AsyncMock(return_value=False)  # type: ignore[method-assign]
-        openrouter.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             side_effect=ConnectionError("no workers"),
         )
         result = _text(
@@ -3836,10 +3775,9 @@ class TestExtractLessons:
     async def test_worker_invalid_json(
         self,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response("This is not JSON at all, just text."),
         )
         result = _text(
@@ -3854,10 +3792,9 @@ class TestExtractLessons:
     async def test_worker_empty_array(
         self,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response("[]"),
         )
         result = _text(
@@ -3873,7 +3810,7 @@ class TestExtractLessons:
         self,
         git_vault: Path,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
         """Worker wraps JSON in markdown fences — still parsed correctly."""
         wrapped = (
@@ -3892,8 +3829,7 @@ class TestExtractLessons:
             )
             + "\n```"
         )
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(wrapped),
         )
         result = _text(
@@ -3909,7 +3845,7 @@ class TestExtractLessons:
         self,
         git_vault: Path,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
         many = json.dumps(
             [
@@ -3924,8 +3860,7 @@ class TestExtractLessons:
                 for i in range(10)
             ]
         )
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(many),
         )
         await worker_vault.call_tool(
@@ -3942,7 +3877,7 @@ class TestExtractLessons:
         self,
         git_vault: Path,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
         """Worker output with newlines in fields is sanitized."""
         injected = json.dumps(
@@ -3957,8 +3892,7 @@ class TestExtractLessons:
                 }
             ]
         )
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(injected),
         )
         result = _text(
@@ -3978,15 +3912,14 @@ class TestExtractLessons:
         self,
         git_vault: Path,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
         """Filesystem errors during lesson write are reported, not silently dropped."""
         lessons_file = git_vault / "10_projects" / "testproject" / "90-lessons.md"
         # Make file read-only so appends fail
         lessons_file.chmod(0o444)
         try:
-            ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-            ollama.generate = AsyncMock(  # type: ignore[method-assign]
+            worker_client.generate = AsyncMock(  # type: ignore[method-assign]
                 return_value=_worker_response(_VALID_LESSONS_JSON),
             )
             result = _text(
@@ -4005,11 +3938,10 @@ class TestExtractLessons:
         self,
         git_vault: Path,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
         """User text with curly braces (code, JSON) doesn't crash str.format()."""
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(_VALID_LESSONS_JSON),
         )
         # Text containing curly braces — would crash without escaping
@@ -4026,7 +3958,7 @@ class TestExtractLessons:
         self,
         git_vault: Path,
         worker_vault: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
         """Tags with newlines are sanitized to prevent markdown injection."""
         injected_tags = json.dumps(
@@ -4041,8 +3973,7 @@ class TestExtractLessons:
                 }
             ]
         )
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
             return_value=_worker_response(injected_tags),
         )
         result = _text(
@@ -4804,7 +4735,7 @@ class TestToolTimeouts:
     async def test_delegate_task_timeout(
         self,
         worker: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
         """delegate_task returns timeout message when worker hangs."""
 
@@ -4812,8 +4743,7 @@ class TestToolTimeouts:
             await asyncio.sleep(999)
             raise AssertionError("unreachable")
 
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(side_effect=slow_generate)  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(side_effect=slow_generate)  # type: ignore[method-assign]
 
         ctx = worker._hive_ctx  # type: ignore[attr-defined]
         ctx.tool_timeout = 0.1
@@ -4825,15 +4755,23 @@ class TestToolTimeouts:
     async def test_worker_status_timeout(
         self,
         worker: FastMCP,
-        ollama: OllamaClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
-        """worker_status returns timeout message when connectivity check hangs."""
+        """worker_status returns timeout message when the probe hangs.
 
-        async def slow_check() -> bool:
+        The probe is now `list_models` — a real network call — rather than the
+        retired Ollama availability check. That makes this case more likely in
+        practice, not less: an endpoint that accepts the connection and then
+        stalls is exactly what a saturated provider looks like.
+        """
+
+        async def slow_check(*a: object, **kw: object) -> list[ModelInfo]:
             await asyncio.sleep(999)
-            return True
+            raise AssertionError("unreachable")
 
-        ollama.is_available = AsyncMock(side_effect=slow_check)  # type: ignore[method-assign]
+        worker_client.list_models = AsyncMock(  # type: ignore[method-assign]
+            side_effect=slow_check,
+        )
 
         ctx = worker._hive_ctx  # type: ignore[attr-defined]
         ctx.tool_timeout = 0.1
@@ -4846,23 +4784,20 @@ class TestToolTimeouts:
         self,
         git_vault: Path,
         budget: BudgetTracker,
-        ollama: OllamaClient,
-        openrouter: OpenRouterClient,
+        worker_client: OpenAICompatibleClient,
     ) -> None:
         """capture_lesson batch mode returns timeout when worker hangs."""
         mcp = create_server(
             vault_path=git_vault,
             budget_tracker=budget,
-            ollama_client=ollama,
-            openrouter_client=openrouter,
+            worker_client=worker_client,
         )
 
         async def slow_generate(*a: object, **kw: object) -> ClientResponse:
             await asyncio.sleep(999)
             raise AssertionError("unreachable")
 
-        ollama.is_available = AsyncMock(return_value=True)  # type: ignore[method-assign]
-        ollama.generate = AsyncMock(side_effect=slow_generate)  # type: ignore[method-assign]
+        worker_client.generate = AsyncMock(side_effect=slow_generate)  # type: ignore[method-assign]
 
         ctx = mcp._hive_ctx  # type: ignore[attr-defined]
         ctx.tool_timeout = 0.1

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,7 +1,8 @@
-"""Smoke tests — real HTTP calls to Ollama and OpenRouter + vault tool checks.
+"""Smoke tests — real HTTP calls to the NaN worker + vault tool checks.
 
 Run with:  pytest -m smoke -v
-Requires:  Ollama running + OPENROUTER_API_KEY set (for worker tests).
+Requires:  a reachable worker endpoint (HIVE_WORKER_BASE_URL) and its credential
+           (HIVE_WORKER_API_KEY, or NAN_API_KEY as the launcher injects it).
 Vault smoke tests always run (no external deps needed).
 """
 
@@ -18,7 +19,7 @@ import httpx
 import pytest
 
 from hive.budget import BudgetTracker
-from hive.clients import OllamaClient, OpenRouterClient
+from hive.clients import OpenAICompatibleClient
 from hive.server import create_server
 
 if TYPE_CHECKING:
@@ -28,12 +29,15 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.smoke
 
-OLLAMA_ENDPOINT = os.environ.get("HIVE_OLLAMA_ENDPOINT", "http://ollama.kubelab.live:11434")
-OLLAMA_MODEL = os.environ.get("HIVE_OLLAMA_MODEL", "qwen2.5-coder:7b")
-OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY") or os.environ.get(
-    "HIVE_OPENROUTER_API_KEY"
+# HIVE-384: the smoke tests run against the single NaN-backed worker.
+# The credential is read under BOTH names the deployment uses — the prefixed one
+# hive owns, and the registry name the launcher injects — so a smoke run works
+# whether it is started by hand or through `dotf secrets run`.
+WORKER_BASE_URL = os.environ.get("HIVE_WORKER_BASE_URL") or os.environ.get(
+    "HIVE_EMBED_BASE_URL", ""
 )
-OPENROUTER_MODEL = os.environ.get("HIVE_OPENROUTER_MODEL", "qwen/qwen3-coder:free")
+WORKER_MODEL = os.environ.get("HIVE_WORKER_MODEL", "deepseek-v4-flash")
+WORKER_API_KEY = os.environ.get("HIVE_WORKER_API_KEY") or os.environ.get("NAN_API_KEY", "")
 
 # Trivial prompt to keep latency and token usage minimal.
 PING_PROMPT = "Reply with exactly one word: pong"
@@ -47,16 +51,31 @@ def _resource_text(result: ResourceResult) -> str:
     return str(result.contents[0].content)
 
 
-def _ollama_reachable() -> bool:
+def _worker_reachable() -> bool:
+    """Probe the configured worker endpoint.
+
+    Configuration alone is not enough to run these tests: the whole point of
+    #384 is that a configured-but-unreachable worker looked healthy for an
+    unknown length of time. So the skip condition is a probe, not a truthy
+    env var.
+    """
+    if not WORKER_BASE_URL or not WORKER_API_KEY:
+        return False
     try:
-        resp = httpx.get(f"{OLLAMA_ENDPOINT}/", timeout=5)
+        resp = httpx.get(
+            f"{WORKER_BASE_URL}/models",
+            headers={"Authorization": f"Bearer {WORKER_API_KEY}"},
+            timeout=5,
+        )
         return resp.status_code == 200
     except (httpx.ConnectError, httpx.ConnectTimeout):
         return False
 
 
-skip_no_ollama = pytest.mark.skipif(not _ollama_reachable(), reason="Ollama not reachable")
-skip_no_openrouter = pytest.mark.skipif(not OPENROUTER_API_KEY, reason="OPENROUTER_API_KEY not set")
+skip_no_worker = pytest.mark.skipif(
+    not _worker_reachable(),
+    reason="worker endpoint not configured or not reachable",
+)
 
 
 # ── Fixtures ────────────────────────────────────────────────────────
@@ -92,15 +111,15 @@ def smoke_budget(tmp_path: Path) -> BudgetTracker:
 
 
 @pytest.fixture
-def ollama_client() -> OllamaClient:
-    return OllamaClient(endpoint=OLLAMA_ENDPOINT, model=OLLAMA_MODEL)
-
-
-@pytest.fixture
-def openrouter_client() -> OpenRouterClient | None:
-    if not OPENROUTER_API_KEY:
+def smoke_worker_client() -> OpenAICompatibleClient | None:
+    if not WORKER_BASE_URL or not WORKER_API_KEY:
         return None
-    return OpenRouterClient(api_key=OPENROUTER_API_KEY, default_model=OPENROUTER_MODEL)
+    return OpenAICompatibleClient(
+        base_url=WORKER_BASE_URL,
+        api_key=WORKER_API_KEY,
+        default_model=WORKER_MODEL,
+        provider_name="NaN",
+    )
 
 
 @pytest.fixture
@@ -156,15 +175,13 @@ def smoke_vault(tmp_path: Path) -> Path:
 @pytest.fixture
 def server(
     smoke_budget: BudgetTracker,
-    ollama_client: OllamaClient,
-    openrouter_client: OpenRouterClient | None,
+    smoke_worker_client: OpenAICompatibleClient,
     smoke_vault: Path,
 ) -> FastMCP:
     return create_server(
         vault_path=smoke_vault,
         budget_tracker=smoke_budget,
-        ollama_client=ollama_client,
-        openrouter_client=openrouter_client,
+        worker_client=smoke_worker_client,
     )
 
 
@@ -596,146 +613,54 @@ class TestEdgeCasesSmoke:
         lines_before_truncation = result.split("[...")[0].strip().splitlines()
         assert len(lines_before_truncation) == 10
 
-    # G4
-    async def test_budget_exhausted(
-        self,
-        server: FastMCP,
-        smoke_budget: BudgetTracker,
-    ) -> None:
-        smoke_budget.record_request(model="test", cost_usd=5.0, tokens=0, latency_ms=0)
-        result = _text(
-            await server.call_tool(
-                "delegate_task",
-                {"prompt": PING_PROMPT, "model": "openrouter", "max_cost_per_request": 0.01},
-            )
-        )
-        assert "budget" in result.lower()
 
+@skip_no_worker
+class TestWorkerDispatch:
+    """A real dispatch against the configured worker.
 
-# ══════════════════════════════════════════════════════════════════════
-# Worker smoke tests (need real infra)
-# ══════════════════════════════════════════════════════════════════════
+    This is the criterion the whole change exists to make passable: before
+    #384 the worker reached zero models, so no smoke test of it could pass on
+    any machine.
+    """
 
-
-@skip_no_ollama
-class TestOllamaDirect:
-    """Real calls to Ollama."""
-
-    async def test_delegate_ollama_returns_response(self, server: FastMCP) -> None:
-        result = _text(
-            await server.call_tool("delegate_task", {"prompt": PING_PROMPT, "model": "ollama"})
-        )
-        assert "Worker Response" in result
-        assert "qwen2.5-coder" in result
-
-    async def test_delegate_ollama_has_tokens_and_latency(self, server: FastMCP) -> None:
-        result = _text(
-            await server.call_tool("delegate_task", {"prompt": PING_PROMPT, "model": "ollama"})
-        )
-        assert "tokens" in result
-        assert "$0.00" in result
-
-    async def test_ollama_records_budget(
-        self, server: FastMCP, smoke_budget: BudgetTracker
-    ) -> None:
-        await server.call_tool("delegate_task", {"prompt": PING_PROMPT, "model": "ollama"})
-        stats = smoke_budget.month_stats(5.0)
-        assert stats["request_count"] == 1
-        assert stats["spent"] == 0.0
-
-
-@skip_no_openrouter
-class TestOpenRouterFreeDirect:
-    """Real calls to OpenRouter free tier."""
-
-    async def test_delegate_openrouter_free_returns_response(self, server: FastMCP) -> None:
-        result = _text(
-            await server.call_tool(
-                "delegate_task", {"prompt": PING_PROMPT, "model": "openrouter-free"}
-            )
-        )
-        assert "Worker Response" in result
-
-    async def test_openrouter_free_records_budget(
-        self, server: FastMCP, smoke_budget: BudgetTracker
-    ) -> None:
-        await server.call_tool("delegate_task", {"prompt": PING_PROMPT, "model": "openrouter-free"})
-        stats = smoke_budget.month_stats(5.0)
-        assert stats["request_count"] == 1
-
-
-@skip_no_openrouter
-class TestOpenRouterPaidDirect:
-    """Real calls to OpenRouter paid tier."""
-
-    async def test_delegate_paid_returns_response(self, server: FastMCP) -> None:
-        result = _text(
-            await server.call_tool(
-                "delegate_task",
-                {"prompt": PING_PROMPT, "model": "openrouter", "max_cost_per_request": 0.01},
-            )
-        )
-        assert "Worker Response" in result
-        assert "qwen" in result.lower()
-
-    async def test_paid_records_nonzero_cost(
-        self, server: FastMCP, smoke_budget: BudgetTracker
-    ) -> None:
-        await server.call_tool(
-            "delegate_task",
-            {"prompt": PING_PROMPT, "model": "openrouter", "max_cost_per_request": 0.01},
-        )
-        stats = smoke_budget.month_stats(5.0)
-        assert stats["request_count"] == 1
-        assert stats["spent"] >= 0.0
-
-    async def test_paid_budget_guard_blocks_when_exhausted(
-        self, server: FastMCP, smoke_budget: BudgetTracker
-    ) -> None:
-        smoke_budget.record_request(model="test", cost_usd=5.0, tokens=0, latency_ms=0)
-        result = _text(
-            await server.call_tool(
-                "delegate_task",
-                {"prompt": PING_PROMPT, "model": "openrouter", "max_cost_per_request": 0.01},
-            )
-        )
-        assert "budget" in result.lower()
-
-
-@skip_no_ollama
-class TestAutoRouting:
-    """Auto routing with real backends."""
-
-    async def test_auto_picks_ollama_first(self, server: FastMCP) -> None:
+    async def test_dispatch_returns_a_real_response(self, server: FastMCP) -> None:
         result = _text(await server.call_tool("delegate_task", {"prompt": PING_PROMPT}))
         assert "Worker Response" in result
-        assert "qwen2.5-coder" in result
+        assert WORKER_MODEL in result
 
-    async def test_auto_records_budget(self, server: FastMCP, smoke_budget: BudgetTracker) -> None:
+    async def test_dispatch_records_usage(
+        self, server: FastMCP, smoke_budget: BudgetTracker
+    ) -> None:
         await server.call_tool("delegate_task", {"prompt": PING_PROMPT})
-        stats = smoke_budget.month_stats(5.0)
-        assert stats["request_count"] == 1
+        usage = smoke_budget.month_usage()
+        assert usage["request_count"] == 1
+        assert usage["total_tokens"] > 0
 
 
 class TestWorkerStatusSmoke:
     """Real status + model listing."""
 
-    @skip_no_ollama
-    async def test_status_shows_ollama_online(self, server: FastMCP) -> None:
-        result = _text(await server.call_tool("worker_status", {}))
-        assert "online" in result.lower()
+    @skip_no_worker
+    async def test_status_reports_reachable_against_a_real_endpoint(self, server: FastMCP) -> None:
+        """The probe, exercised for real — the assertion CI cannot make.
 
-    @skip_no_ollama
-    async def test_status_shows_ollama_model(self, server: FastMCP) -> None:
+        Unit tests can only prove the reachable/unreachable branches render
+        differently. Only a live endpoint proves the probe actually reaches one.
+        """
         result = _text(await server.call_tool("worker_status", {}))
-        assert OLLAMA_MODEL in result
+        assert "Reachable: yes" in result
 
-    @skip_no_openrouter
-    async def test_status_shows_openrouter_models(self, server: FastMCP) -> None:
+    @skip_no_worker
+    async def test_status_shows_the_configured_model(self, server: FastMCP) -> None:
         result = _text(await server.call_tool("worker_status", {}))
-        assert "OpenRouter" in result
+        assert WORKER_MODEL in result
 
-    async def test_status_shows_budget(self, server: FastMCP) -> None:
+    @skip_no_worker
+    async def test_status_lists_worker_models(self, server: FastMCP) -> None:
         result = _text(await server.call_tool("worker_status", {}))
-        assert "Budget" in result
-        assert "$" in result
+        assert "Available Models" in result
+
+    async def test_status_reports_usage_not_dollars(self, server: FastMCP) -> None:
+        result = _text(await server.call_tool("worker_status", {}))
+        assert "Usage this month" in result
+        assert "$" not in result


### PR DESCRIPTION
Implements the provider layer of #384, following its spec at
`specs/HIVE-384-nan-worker-and-delegate-verb/`. **PR 1 of 2** — the `hive delegate` verb, the
result-carried status and `delegate_task`'s `timeout_s` follow in PR 2, as the spec's PR sequence
declares. Both land before the release; release-please accumulates them into one `4.0.0`.

## The defect

`worker_status`, measured 2026-08-22:

```
- Ollama: offline / unavailable
- OpenRouter: no API key
### Available Models  — none
```

**Zero reachable models.** Ollama was not running and OpenRouter was retired upstream in August
2026, so `delegate_task` was a declared capability with no backend for an unknown length of time,
and nothing noticed. It became load-bearing when `mlorentedev/dotfiles#1190` made hive one of two
backends of an executor seam.

## What changes

**One worker, OpenAI-compatible, pointed at NaN.** This is a removal plus a re-route rather than a
new integration: `HiveSettings` already carried that transport for embeddings and synthesis, with a
comment reading *"default config points at NaN"*.

`HIVE_WORKER_BASE_URL` / `_API_KEY` / `_MODEL`, each falling back **per field** to its `HIVE_EMBED_*`
counterpart when unset — so a machine that works today keeps working, and a deployment can override
the model alone while inheriting the endpoint. `NAN_API_KEY` is accepted as an `AliasChoices` alias
because that is the name the launcher injects; without it the launcher would export one name and
hive would read another, failing authentication for a reason no error message explains.

**`None` means unconfigured, and the client is built only when it is configured.** The old shape had
a non-optional Ollama client that always existed and never answered — which is precisely how a dead
backend stays invisible.

## Two decisions worth reading before the diff

**Failures are classified as data, not as exception types.** `_try_worker` returned
`(None, "some string")` for everything, catching `(ConnectionError, RuntimeError)` and then broad
`Exception` into one shape. It now returns `(response, status, detail)` with `status` in
`ok | pool_unavailable | task_failed`. A caller must be able to tell *the provider was unreachable*
from *the provider answered and the answer failed*: it may retry the first elsewhere and must not
retry the second, because collapsing them turns a bad answer into a silent retry on a different
model. Exception types also do not survive the JSON-RPC boundary the verb will cross in PR 2.

Unknown failures classify as `task_failed`, never as `pool_unavailable` — **the fail-closed direction
is the one that does not retry.**

**There is no fallback inside hive, on purpose.** The tiered ladder (Ollama → OpenRouter free →
OpenRouter paid → reject) went with its providers and the *shape* went with it too: choosing among
pools belongs to the caller that owns a routing map. A backend that falls back on its own is a
second routing authority, and its answer can no longer be attributed to a model.

## Also in scope, because each would otherwise be found later

- **`capture_lesson` is the worker's second consumer** — its MCP surface is unchanged, but its
  provider re-routes and its own two-tier ladder collapses to the same single shot.
- **`budget.py` shrinks rather than disappears.** `record_request` and a new `month_usage` stay:
  tokens and latency are what `worker_status`, `/status` and `usage.db` read. The cap
  (`can_spend` / `month_spent` / `month_remaining`) goes — on a flat subscription a dollar cap
  measures the wrong quantity. `cost_usd` keeps its column so an existing `worker.db` opens
  unchanged, but has no caller. The class name is now a misnomer and is **declared** as one in the
  docstring rather than renamed here: that rename touches 83 call sites across ten files and would
  bury this diff's substance in churn. Tracked as #387.
- **`worker_status` reports configuration and probed reachability separately**, and `/status` and
  `vault_health` drop their dollar blocks. A gauge that always reads zero looks like a working gauge.
- **Retired aliases** (`auto`, `ollama`, `openrouter-free`, `openrouter`) are rejected **before
  dispatch** with a message naming the replacement. A silently-accepted dead alias reaches the caller
  as a confusing inference failure instead of a clear validation error.
- **Stale authority surfaces**: `AGENTS.md` described the cost ladder and named Ollama as primary;
  the `Makefile` smoke help and the smoke suite named credentials that are gone. The smoke skip
  condition now **probes** the endpoint rather than checking that variables are set — same reasoning
  as the defect itself.

## Verification

`make check`: **881 passed, 2 skipped, 54 deselected, 85% coverage, exit 0.**

Against the baseline (904 passed, 63 deselected) that is 23 fewer unit tests and 9 fewer smoke tests,
removed with their subject. **Coverage held at 85%**, so nothing lost an assertion that still had
something to assert. What was deliberately kept is listed in the test commit's message — notably the
ReadTimeout→ConnectionError conversion, `budget.py`'s thread-safety tests, and the API-key leak test,
which now also asserts the usage block is *present*: an absence assertion passes trivially when the
whole section is missing.

`worker_status` is asserted **in both directions** — reachable and not, probed and unprobed. A field
only ever checked in one state is not checked.

## Not verified here

**AC5's live smoke has not been run**: it needs a reachable NaN endpoint and the credential, and the
spec's open question of whether CI gets one is still open. The smoke tests are re-pointed and
collect (44), but a real inference has not been performed. That is the one criterion this PR cannot
prove, and it is stated rather than implied by a green check.

BREAKING CHANGE: the delegate worker is now a single OpenAI-compatible provider. Ollama and
OpenRouter are removed, `delegate_task` loses `max_cost_per_request`, and its `model` parameter no
longer accepts `auto` / `ollama` / `openrouter-free` / `openrouter`. Configure the worker with
`HIVE_WORKER_BASE_URL`, `HIVE_WORKER_API_KEY` (or `NAN_API_KEY`) and `HIVE_WORKER_MODEL`; each falls
back to its `HIVE_EMBED_*` counterpart when unset.
