### PR TITLE
fix: gate the smoke worker fixture on the model, and drop a stale alias from the docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Smoke tests are marked `@pytest.mark.smoke` and excluded by default; they requir
 
 ## Configuration
 
-`HiveSettings` (pydantic-settings) reads `HIVE_*` env vars. Two settings accept an unprefixed alias for ergonomic deploy: `VAULT_PATH` → `vault_path`, `OPENROUTER_API_KEY` → `openrouter_api_key`. Vault default is `~/Projects/knowledge`. Worker DBs default to `~/.local/share/hive/{worker,relevance}.db`.
+`HiveSettings` (pydantic-settings) reads `HIVE_*` env vars. One setting accepts an unprefixed alias for ergonomic deploy: `VAULT_PATH` → `vault_path`. The `OPENROUTER_API_KEY` alias documented here previously went away with its setting in 4.0.0; no provider-named variable is read (#391). Vault default is `~/Projects/knowledge`. Worker DBs default to `~/.local/share/hive/{worker,relevance}.db`.
 
 ## Documentation site (i18n)
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -119,7 +119,11 @@ def smoke_budget(tmp_path: Path) -> BudgetTracker:
 
 @pytest.fixture
 def smoke_worker_client() -> OpenAICompatibleClient | None:
-    if not WORKER_BASE_URL or not WORKER_API_KEY:
+    # Same three requirements `_worker_reachable` gates on, so the fixture can
+    # never hand out a client the probe would have refused — in particular one
+    # carrying `default_model=""`, which hive cannot supply a default for now
+    # that it assumes no provider's model ids (#391).
+    if not WORKER_BASE_URL or not WORKER_API_KEY or not WORKER_MODEL:
         return None
     return OpenAICompatibleClient(
         base_url=WORKER_BASE_URL,


### PR DESCRIPTION
fix: gate the smoke worker fixture on the model, and drop a stale alias from the docs

Applies two review findings.

`AGENTS.md` still documented `OPENROUTER_API_KEY` as an accepted unprefixed
alias, which contradicts the rule this branch states three sections earlier. The
setting behind it went away with the provider in 4.0.0 — `openrouter_api_key` is
not in `HiveSettings.model_fields`, and `TestRetiredProviderSettings` already
asserts that — so the line was stale documentation, now removed.

`smoke_worker_client` gated on the endpoint and the credential but not the model,
while `_worker_reachable` requires all three. The fixture could therefore hand
out a client carrying `default_model=""`, which hive can no longer substitute a
default for now that it assumes no provider's model ids. The fixture now gates on
the same three values as the probe.

The reviewer's stated reason for that second finding does not hold and is
recorded as declined: `TestWorkerDispatch` **is** decorated with
`@skip_no_worker` (`tests/test_smoke.py:623`), so live dispatch was already gated
and never sent an empty model to an endpoint. The fix is applied for consistency
between the fixture and the probe, not for the failure that was described.

Verified: ruff check, ruff format --check and mypy --strict clean; test_smoke.py
collects (44 deselected, smoke excluded by default as designed).

Refs #391

Follow-up to #392, which merged before these two review findings were applied.

## Review triage — #392

| Finding | Severity | Disposition |
|---|---|---|
| `AGENTS.md` still documents `OPENROUTER_API_KEY` as an accepted alias, contradicting the new rule | Minor | **Applied.** Verified stale: `openrouter_api_key` is absent from `HiveSettings.model_fields`, and `TestRetiredProviderSettings` already asserts it. |
| "Gate live dispatch tests on `WORKER_MODEL`" — `TestWorkerDispatch` has no `skip_no_worker` marker, so it sends `default_model=""` to a live endpoint | Major | **Applied, stated reason declined.** `TestWorkerDispatch` **is** decorated with `@skip_no_worker` (`tests/test_smoke.py:623`), and `skip_no_worker` gates on `_worker_reachable()`, which #392 changed to require `WORKER_MODEL`. Live dispatch was already gated and no empty model could reach an endpoint. The fixture change is applied anyway so its guard matches the probe's, removing the possibility rather than relying on every consumer carrying the marker. |
| CodeRabbit walkthrough | — | Summary, no findings. |

CI on #392: `check (3.12)`, `check (3.13)`, `docker`, `cross_worker_lock` (ubuntu + windows) and GitGuardian all green. `add-to-project` failed on the shared GraphQL quota — the same mechanism `docs/lessons/lesson-089` records; re-run requested, not a code defect.