### PR TITLE
feat: add the hive delegate verb, the dispatch seam a router can call

### DIFF
--- a/specs/HIVE-384-nan-worker-and-delegate-verb/features.json
+++ b/specs/HIVE-384-nan-worker-and-delegate-verb/features.json
@@ -1,57 +1,57 @@
 [
   {
     "id": "HIVE-384-nan-worker-and-delegate-verb-f1",
-    "behavior": "AC1 — `hive delegate` writes one JSON object to stdout with status, model, duration_ms and output, logs to stderr, and requires --model and --timeout rather than defaulting them",
-    "verification": "uv run pytest tests/test_delegate_verb.py -k contract",
+    "behavior": "AC1 — `hive delegate` writes exactly one JSON object to stdout carrying status, model, degraded, tokens, duration_ms and output, keeps every log line on stderr, and rejects a call missing --model, --timeout or --prompt rather than defaulting it",
+    "verification": "uv run pytest tests/test_delegate_verb.py::TestWireContract tests/test_delegate_verb.py::TestRequiredArguments",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "HIVE-384-nan-worker-and-delegate-verb-f2",
-    "behavior": "AC2 — an unreachable or rate-limited provider exits 3 (pool unavailable) while a worker answering with a failure exits 1 (task failed), on separate code paths",
-    "verification": "uv run pytest tests/test_delegate_verb.py -k exit_codes",
+    "behavior": "AC2 — a pool that refuses (unreachable, 429, 401/403) exits 3 so the dispatcher advances its chain, while a worker that answered with a failure exits 1 so it does not; an unrecognised status falls closed to 1",
+    "verification": "uv run pytest tests/test_delegate_verb.py::TestExitCodesSeparateTheFailureClasses tests/test_pool_classification.py",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "HIVE-384-nan-worker-and-delegate-verb-f3",
-    "behavior": "AC3 — a worker outliving its deadline is killed via bounded_call and the verb returns exit 4 without waiting for it",
-    "verification": "uv run pytest tests/test_delegate_verb.py -k timeout",
+    "behavior": "AC3 — a per-dispatch --timeout replaces the ambient tool timeout in both directions (a longer one raises the ceiling, a shorter one cuts the call short), the verb returns within the deadline rather than deadline plus the 2s grace, and the timeout detail names the deadline that actually expired",
+    "verification": "uv run pytest tests/test_delegate_deadline_and_route.py::TestTheDeadlineIsTheOneAskedFor",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "HIVE-384-nan-worker-and-delegate-verb-f4",
-    "behavior": "AC4 — with a daemon reachable the verb routes through the client path; with none it falls back to in-process stdio and marks degraded mode in its output",
-    "verification": "uv run pytest tests/test_delegate_verb.py -k daemon_fallback",
+    "behavior": "AC4 — degraded is false when the call went through a reachable daemon and true on the in-process fallback, asserted in BOTH directions plus the two ways a daemon can be present and unusable (stale state, TCP accepted then session failed)",
+    "verification": "uv run pytest tests/test_delegate_deadline_and_route.py::TestDegradedIsReportedInBothDirections",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "HIVE-384-nan-worker-and-delegate-verb-f5",
-    "behavior": "AC5 — the worker resolves HIVE_WORKER_* settings and falls back to HIVE_EMBED_* when unset",
-    "verification": "uv run pytest tests/test_config.py -k worker_settings_fallback_and_key_alias",
+    "behavior": "AC5 — the worker resolves HIVE_WORKER_BASE_URL / _MODEL / _API_KEY and falls back to the HIVE_EMBED_* counterpart per field when unset, with both unset meaning disabled rather than a guessed endpoint",
+    "verification": "uv run pytest tests/test_config.py::TestWorkerSettings",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "HIVE-384-nan-worker-and-delegate-verb-f6",
-    "behavior": "AC5 — the worker performs a real inference against NaN and worker_status reports a reachable provider with the resolved model",
-    "verification": "uv run pytest -m smoke -k worker_reaches_nan",
+    "behavior": "AC5 — the worker performs a real inference against a live endpoint and worker_status reports it reachable with the resolved model (skips unless one is configured AND the probe reaches it)",
+    "verification": "uv run pytest tests/test_smoke.py::TestWorkerDispatch -m smoke",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "HIVE-384-nan-worker-and-delegate-verb-f7",
-    "behavior": "AC6 — no settings field, MCP parameter, Makefile help string or documentation line names Ollama or OpenRouter for the worker",
-    "verification": "uv run pytest tests/test_provider_removal.py",
+    "behavior": "AC6 — the retired providers are gone from every shipped surface: no settings field, no provider-named env alias, and no provider brand in any module that configures or describes a client",
+    "verification": "uv run pytest tests/test_config.py::TestRetiredProviderSettings tests/test_provider_neutrality.py",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "HIVE-384-nan-worker-and-delegate-verb-f8",
-    "behavior": "AC7 — a planted credential value appears in no log line, no worker_status output and no crash artifact",
-    "verification": "uv run pytest tests/test_delegate_verb.py -k credential_never_emitted",
+    "behavior": "AC7 — a planted credential appears in no repr of the settings, no worker_status output, no log record and no result record, including when a provider echoes it back in a 401 body",
+    "verification": "uv run pytest tests/test_credential_never_emitted.py",
     "state": "pending",
     "evidence": ""
   }

--- a/specs/HIVE-384-nan-worker-and-delegate-verb/tasks.md
+++ b/specs/HIVE-384-nan-worker-and-delegate-verb/tasks.md
@@ -19,8 +19,14 @@ Declared here so no PR silently absorbs the next:
 | **1** | the provider layer: `HIVE_WORKER_*` settings with the `HIVE_EMBED_*` fallback and the `NAN_API_KEY` alias, Ollama and OpenRouter removed, the three `_try_worker` call sites re-routed, `budget.py` trimmed, `worker_status` reshaped, and the stale surfaces (`AGENTS.md`, `Makefile`, tests) | AC5, AC6, AC7 |
 | **2** | the verb: `hive delegate`, the result-carried status classification, `delegate_task`'s `timeout_s` and `model` migration, exit-code mapping, daemon routing and the degraded flag | AC1, AC2, AC3, AC4 |
 
-Both land before the release; release-please accumulates them into one `4.0.0`. **PR 1 carries the
-`feat!`** — it is where the providers and the MCP parameters actually disappear.
+**PR 1 carries the `feat!`** — it is where the providers and the MCP parameters actually disappear.
+
+**Corrected 2026-08-23, after the fact.** This planned for both PRs to land before one release, with
+release-please accumulating them into a single `4.0.0`. That is not what happened: PR 1 merged
+(`#390`) and `4.0.0` published carrying it alone, so **PR 2 ships in `4.1.0`** as a `feat`, and the
+"after the release publishes, `uv tool upgrade`" step in Closing runs a second time before CLI-042's
+AC6 can be re-checked. Two follow-ups also landed between them, both `fix` on the same release line:
+`#392` (no provider named in shipped surfaces) and `#394` (its review findings).
 
 ## Setup
 
@@ -35,17 +41,17 @@ Both land before the release; release-please accumulates them into one `4.0.0`. 
 
 ### The worker's provider layer
 
-- [ ] [P] [AC5] Failing test: the worker resolves its endpoint from `HIVE_WORKER_BASE_URL` and falls
+- [x] [P] [AC5] Failing test: the worker resolves its endpoint from `HIVE_WORKER_BASE_URL` and falls
       back to `HIVE_EMBED_BASE_URL` when unset (same for the key and the model)
-- [ ] [AC5] Add the `HIVE_WORKER_*` settings to `HiveSettings` with that fallback
-- [ ] [AC5] Route the worker through the OpenAI-compatible transport already used for embeddings and
+- [x] [AC5] Add the `HIVE_WORKER_*` settings to `HiveSettings` with that fallback
+- [x] [AC5] Route the worker through the OpenAI-compatible transport already used for embeddings and
       synthesis
-- [ ] [AC6] Remove the Ollama and OpenRouter providers, `ollama_endpoint`, `ollama_model`,
+- [x] [AC6] Remove the Ollama and OpenRouter providers, `ollama_endpoint`, `ollama_model`,
       `openrouter_api_key` (**and its unprefixed alias**), `openrouter_budget`, `openrouter_model`,
       `openrouter_paid_model`
-- [ ] [AC6] Remove `max_cost_per_request` from `delegate_task`'s MCP parameters — the declared
+- [x] [AC6] Remove `max_cost_per_request` from `delegate_task`'s MCP parameters — the declared
       amendment to ADR-011 §5, stated in the commit body, not slipped in
-- [ ] [AC6] **Migrate `delegate_task`'s `model` parameter**, which today is `model: str = "auto"`
+- [x] [AC6] **Migrate `delegate_task`'s `model` parameter**, which today is `model: str = "auto"`
       carrying the legacy provider vocabulary. Removing only `max_cost_per_request` would leave the
       old model contract standing after every other task is done. Three parts, and the third is the
       one that makes it a migration rather than a rename:
@@ -56,8 +62,8 @@ Both land before the release; release-please accumulates them into one `4.0.0`. 
         with an error naming the replacement, rather than passing them through to a provider that no
         longer exists. A silently-accepted dead alias is how a caller discovers the break as a
         confusing inference failure instead of a clear validation error.
-- [ ] [AC6] Assertion that a legacy `model` value is rejected, so the migration cannot regress
-- [ ] [AC6] Assertion that keeps them gone: no settings field, MCP parameter, or documentation line
+- [x] [AC6] Assertion that a legacy `model` value is rejected, so the migration cannot regress
+- [x] [AC6] Assertion that keeps them gone: no settings field, MCP parameter, or documentation line
       names Ollama or OpenRouter for the worker
 
 ### The verb
@@ -81,27 +87,30 @@ Both land before the release; release-please accumulates them into one `4.0.0`. 
 
 ### Credential handling
 
-- [ ] [P] [AC7] Failing test: with a planted key value in the environment, it appears in no log line,
+- [x] [P] [AC7] Failing test: with a planted key value in the environment, it appears in no log line,
       no `worker_status` output, and no crash artifact (ADR-011 §4 already requires the last)
-- [ ] [AC7] Make it pass; verify the daemon works **by consequence** — it answers — never by printing
+      — **NOT done in PR 1.** Ticked here by inference during reconciliation and corrected on
+      measurement: no such test existed, and `features.json`'s AC7 command selected zero tests.
+      Written in PR 2 (`tests/test_credential_never_emitted.py`), which found two real leaks.
+- [x] [AC7] Make it pass; verify the daemon works **by consequence** — it answers — never by printing
       the value
 
 ### Surfaces that go stale on the same commit
 
-- [ ] [AC6] `AGENTS.md`: replace the "Ollama … free, primary" provider list with the NaN-only reality
-- [ ] [AC6] `Makefile`: the `smoke` target's help text reads *"needs Ollama + API key"* — it becomes
+- [x] [AC6] `AGENTS.md`: replace the "Ollama … free, primary" provider list with the NaN-only reality
+- [x] [AC6] `Makefile`: the `smoke` target's help text reads *"needs Ollama + API key"* — it becomes
       NaN and `HIVE_WORKER_API_KEY`. A help string is documentation a human acts on
-- [ ] [AC6] Trim `budget.py` to its surviving half rather than deleting it: `record_request` stays
+- [x] [AC6] Trim `budget.py` to its surviving half rather than deleting it: `record_request` stays
       (usage telemetry — tokens and latency, which the reshaped `worker_status` and `usage.db` both
       read), while `can_spend` / `month_spent` / `month_remaining` / `month_stats` go with the spend
       cap. `cost_usd` becomes moot on a flat subscription
-- [ ] [AC6] Trim `tests/test_budget.py` to the surviving behaviour — not a wholesale delete, which
+- [x] [AC6] Trim `tests/test_budget.py` to the surviving behaviour — not a wholesale delete, which
       would drop coverage of telemetry that is staying
-- [ ] [AC5] Re-point the `@pytest.mark.smoke` tests at NaN and `HIVE_WORKER_API_KEY`; they stay
+- [x] [AC5] Re-point the `@pytest.mark.smoke` tests at NaN and `HIVE_WORKER_API_KEY`; they stay
       excluded from `make check` by the existing `-m 'not smoke'`
-- [ ] [AC5] Reshape `worker_status` to report reachability and the resolved model — the shape the
+- [x] [AC5] Reshape `worker_status` to report reachability and the resolved model — the shape the
       consuming `dotf doctor` check needs — once the open question above is answered
-- [ ] `docs/`: record the provider change where hive keeps build/operate knowledge
+- [x] `docs/`: record the provider change where hive keeps build/operate knowledge
 
 ## Closing
 
@@ -110,7 +119,8 @@ Both land before the release; release-please accumulates them into one `4.0.0`. 
 - [ ] `make check` green (lint + typecheck + test)
 - [ ] Smoke run performed once by hand against a live NaN endpoint, with the output in
       `verification.md` — the criteria that cannot be proved by `make check` alone
-- [ ] Commit is `feat!` so release-please cuts **4.0.0**; the breaking change is named in the body
+- [x] PR 1's commit was `feat!` and release-please cut **4.0.0**; the breaking change is named in
+      the body. PR 2 is a `feat` on top and cuts **4.1.0** — see the corrected note in PR sequence
 - [ ] `verification.md` filled in
 - [ ] PR opened referencing this spec folder
 - [ ] **After the release publishes**: `uv tool upgrade hive-vault` on the consuming machine, then

--- a/specs/HIVE-384-nan-worker-and-delegate-verb/verification.md
+++ b/specs/HIVE-384-nan-worker-and-delegate-verb/verification.md
@@ -9,20 +9,51 @@ created: "2026-08-23"
 
 Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
 
-> **Status as of 2026-08-23: every criterion below is PENDING, and that is the spec's state, not an
-> omission.** This folder was scaffolded by a docs-only PR; no implementation exists yet, so no
-> criterion can carry evidence. Each row's follow-up is the correspondingly tagged `[AC<n>]` task in
-> `tasks.md`. The only result recorded today is the pre-change baseline under Test status, which
-> proves the tree was green *before* the work, not that any criterion is met. `spec archive` must
-> refuse this folder until these rows carry real hashes and test names.
+> **Status as of 2026-08-23, after PR 2.** AC1–AC4 and AC7 carry evidence below. AC5 and AC6 were
+> implemented by PR 1 (`#390`, released as 4.0.0) and their rows now name the tests that actually
+> assert them — the commands recorded for them originally selected **zero** tests, which is why they
+> are restated here rather than trusted.
 
-- [ ] AC1 (hive delegate honours the wire contract) -> commit `<hash>` / test `<name>`
-- [ ] AC2 (exit codes separate pool-unavailable from task-failed) -> commit `<hash>` / test `<name>`
-- [ ] AC3 (timeout kills the worker and returns without waiting) -> commit `<hash>` / test `<name>`
-- [ ] AC4 (routes through the daemon, degrades honestly without one) -> commit `<hash>` / test `<name>`
-- [ ] AC5 (the worker reaches NaN) -> commit `<hash>` / test `<name>`
-- [ ] AC6 (Ollama and OpenRouter gone from every surface) -> commit `<hash>` / test `<name>`
-- [ ] AC7 (the credential never appears in output) -> commit `<hash>` / test `<name>`
+**A finding about this file's own machinery, recorded because it is the point.** Four of the eight
+`features.json` verification commands — AC5, AC6, AC7 and the smoke row — matched nothing when run.
+A recorded proof that never executes is indistinguishable from one that passes, and 4.0.0 shipped
+with those four criteria marked complete on that basis. AC7 turned out to have no test *at all*, not
+merely a broken selector; writing it in PR 2 found two real leaks. Every command in `features.json`
+was re-run under `--collect-only` and confirmed to select a non-zero number of tests.
+
+- [x] AC1 (hive delegate honours the wire contract) -> `tests/test_delegate_verb.py::TestWireContract`,
+      `::TestRequiredArguments` (10 tests). One JSON object on stdout, every log line on stderr,
+      `--model` / `--timeout` / `--prompt` required, a non-positive timeout refused.
+- [x] AC2 (exit codes separate pool-unavailable from task-failed) ->
+      `tests/test_delegate_verb.py::TestExitCodesSeparateTheFailureClasses` +
+      `tests/test_pool_classification.py` (15 tests). **This closed a live defect**: `clients.py`
+      raised `RuntimeError` for every non-2xx, so a 429 classified as *task failed* and a dispatcher
+      would have stopped its chain exactly where it should have advanced. 429/401/403 now raise
+      `PoolUnavailableError`; 4xx-about-the-request and all 5xx stay task failures.
+- [x] AC3 (timeout kills the worker and returns without waiting) ->
+      `tests/test_delegate_deadline_and_route.py::TestTheDeadlineIsTheOneAskedFor` (4 tests).
+      Asserted in both directions — a longer `--timeout` raises the 60s ambient ceiling, a shorter
+      one cuts the call short — plus a wall-clock assertion that the return is inside the deadline
+      rather than deadline + the 2s grace. **Mutation-checked**: pinning `deadline_s` to
+      `ctx.tool_timeout` kills 2 of the 4.
+- [x] AC4 (routes through the daemon, degrades honestly without one) ->
+      `tests/test_delegate_deadline_and_route.py::TestDegradedIsReportedInBothDirections` (4 tests).
+      Both states asserted, per the criterion's own wording, plus the two ways a daemon can be
+      present and unusable: stale state files with nothing listening, and TCP accepted then session
+      failed.
+- [x] AC5 (the worker reaches its configured endpoint) -> `tests/test_config.py::TestWorkerSettings`
+      (3 tests, PR 1) for the settings and fallback; `tests/test_smoke.py::TestWorkerDispatch`
+      (2 tests) for the live inference — **still PENDING as a run**, see Test status.
+- [x] AC6 (the retired providers are gone from every surface) ->
+      `tests/test_config.py::TestRetiredProviderSettings` + `tests/test_provider_neutrality.py`
+      (23 tests). Widened by `#392`: the criterion said "gone from every surface" and the shipped
+      code still named one provider in a hardcoded `provider_name` literal and in an env alias.
+- [x] AC7 (the credential never appears in output) -> `tests/test_credential_never_emitted.py`
+      (6 tests). **Written in PR 2; it did not exist.** Two real leaks found and fixed:
+      `repr(HiveSettings())` rendered `worker_api_key='<the key>'` verbatim (a traceback and a debug
+      log print that unbidden), and `_error_detail` relayed a provider's 401 body without redaction,
+      which matters because some providers echo the `Authorization` header there. Both
+      **mutation-checked**: removing either fix turns the tests red.
 
 ## Test status
 
@@ -33,9 +64,20 @@ Map every acceptance criterion from `proposal.md` to concrete proof (commit hash
   *Caveat worth keeping:* the first attempt failed with 7 mypy errors about missing `types-psutil`
   stubs. That was a fresh worktree whose `.venv` was unsynced, **not** a repo defect —
   `types-psutil>=5.9.0` is declared in `pyproject.toml` and CI runs `uv run mypy src/`.
-- Post-change test suite: `<command> -> <output / coverage %>` — PENDING
-- Manual smoke test against a live NaN endpoint: PENDING. Required for AC5 and AC6; it cannot run in
-  `make check` because it needs a credential, so its output is pasted here by hand.
+- **Post-change, 2026-08-23** — `ruff check`, `ruff format --check`, `mypy --strict` (32 modules)
+  all clean; `pytest tests/` → `934 passed, 2 skipped, 55 deselected in 180.70s, exit 0`.
+  Against the 895-passing baseline that is **+39 tests and zero regressions**. The 55 deselected are
+  the `@pytest.mark.smoke` set, excluded by `-m 'not smoke'`.
+- **Mutation checks**, because passing tests are not evidence that a test would fail:
+  - pinning `deadline_s` to `ctx.tool_timeout` (removing the AC3 override) → 2 of 4 AC3 tests fail.
+  - removing the `_error_detail` redaction → the echoed-key test fails.
+  - removing `repr=False` from `worker_api_key` → 2 AC7 tests fail.
+  Each was reverted immediately and the suite re-confirmed green.
+- **Manual smoke against a live endpoint: PENDING.** Required for AC5's inference row. It cannot run
+  in `make check` because it needs a credential, and this machine has no worker endpoint configured
+  (`HIVE_WORKER_BASE_URL` unset in `environment.d` and in the systemd unit). Stated as an open item
+  rather than quietly omitted: **`dotfiles` CLI-042 AC6 cannot be re-checked until this runs**, and
+  it needs the credential-delivery work that CLI-042's own PR E carries.
 - No regressions in existing test suite: PENDING (compare against the baseline above)
 
 ## Decisions made during implementation

--- a/src/hive/_delegate.py
+++ b/src/hive/_delegate.py
@@ -1,0 +1,234 @@
+"""``hive delegate`` — the dispatch verb (HIVE-384 AC1–AC4).
+
+The consumer is a dispatcher, not a person: `dotf agent run` walks a fallback
+chain declared in `harness/model-map.json` and needs three things from every
+attempt — a machine-readable record, a model it can attribute the answer to,
+and an exit code that says whether to try the next entry.
+
+**Why this lives behind the daemon.** ADR-011 makes the daemon the sole owner of
+``worker.db``, where usage accounting lives. A verb that span up its own server
+would be a second writer to that database — the contention class the daemon
+model exists to eliminate. ADR-011 §3's fallback applies unchanged: with no
+reachable daemon the verb degrades to the in-process stdio path and says so in
+its output rather than failing or pretending.
+
+**Why single-shot.** Choosing among pools is the dispatcher's job. A fallback
+list here would be a second routing authority, and it would make "which model
+answered" unreportable — the drift the routing registry exists to prevent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from typing import Any
+
+_log = logging.getLogger("hive.delegate")
+
+# Exit codes, from HIVE-384's contract table. These are a CROSS-REPO contract:
+# `dotf agent run` advances its chain on EXIT_POOL_UNAVAILABLE and must not on
+# EXIT_TASK_FAILED. Changing one unilaterally turns a bad answer into a silent
+# retry against a different model.
+EXIT_OK = 0
+EXIT_TASK_FAILED = 1
+EXIT_USAGE = 2
+EXIT_POOL_UNAVAILABLE = 3
+EXIT_TIMEOUT = 4
+
+# Only these statuses advance the chain. Anything else — including a status a
+# future version introduces and this one does not know — maps to task-failed,
+# because that is the direction that does NOT retry. Fail-closed here means
+# "do not silently spend another pool's quota on an outcome we cannot classify".
+_STATUS_EXIT = {
+    "ok": EXIT_OK,
+    "pool_unavailable": EXIT_POOL_UNAVAILABLE,
+    "task_failed": EXIT_TASK_FAILED,
+    "timeout": EXIT_TIMEOUT,
+}
+
+_DESCRIPTION = """\
+Run one task against the configured worker and print a JSON result record.
+
+Single-shot by design: this makes exactly one attempt against exactly one
+model. Walking a fallback chain is the caller's job, which is why --model is
+required and why the exit code distinguishes a pool that would not serve the
+request (3, try the next entry) from a worker that answered with a failure
+(1, do not).
+"""
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="hive delegate",
+        description=_DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    # Required on purpose. A defaulted model would let a dispatcher believe it
+    # chose one, and a defaulted timeout would let it believe it set a deadline.
+    p.add_argument("--model", required=True, help="concrete model id to run (no aliases)")
+    p.add_argument(
+        "--timeout",
+        required=True,
+        type=float,
+        help="observable deadline in seconds; overrides the ambient tool timeout",
+    )
+    p.add_argument("--prompt", required=True, help="the task text")
+    p.add_argument("--context", default="", help="optional system context")
+    p.add_argument("--max-tokens", type=int, default=2000, help="cap on the response length")
+    return p
+
+
+def _emit(record: dict[str, Any]) -> None:
+    """Write the result record to stdout as one line of JSON, and only that.
+
+    Everything else this process says goes to stderr. A dispatcher parses
+    stdout, so a stray log line there is not noise — it is a parse error.
+    """
+    json.dump(record, sys.stdout, separators=(",", ":"))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def run_delegate(argv: list[str]) -> int:
+    """Parse ``argv``, dispatch once, emit the record, return the exit code."""
+    parser = _parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit:
+        # argparse exits 2 and has already explained itself on stderr. Return
+        # rather than propagate so a usage error never reaches the emit path:
+        # a record for a call that was never made would be a lie a dispatcher
+        # would happily parse.
+        return EXIT_USAGE
+
+    # argparse's own type check accepts 0 and negatives. A zero deadline is not
+    # a deadline, and rejecting it beats dispatching something that can only
+    # exit 4 immediately.
+    if args.timeout <= 0:
+        print(
+            f"hive delegate: --timeout must be greater than 0 (got {args.timeout})",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
+    record = _dispatch_once(
+        prompt=args.prompt,
+        model=args.model,
+        timeout_s=args.timeout,
+        context=args.context,
+        max_tokens=args.max_tokens,
+    )
+    _emit(record)
+    status = str(record.get("status", ""))
+    if status not in _STATUS_EXIT:
+        _log.warning("unrecognised worker status %r — classifying as task failed", status)
+    return _STATUS_EXIT.get(status, EXIT_TASK_FAILED)
+
+
+def _dispatch_once(
+    *,
+    prompt: str,
+    model: str,
+    timeout_s: float,
+    context: str,
+    max_tokens: int,
+) -> dict[str, Any]:
+    """One attempt against one model; returns the record, never raises.
+
+    Routing is decided here and reported as ``degraded``: false when the call
+    went through the daemon, true when it fell back to the in-process stdio
+    path. The flag is explicit rather than inferred from an absent field,
+    because the fallback path has different concurrency and latency behaviour
+    and a consumer must be able to tell them apart without parsing prose.
+    """
+    return asyncio.run(
+        _dispatch_async(
+            prompt=prompt,
+            model=model,
+            timeout_s=timeout_s,
+            context=context,
+            max_tokens=max_tokens,
+        )
+    )
+
+
+async def _dispatch_async(
+    *,
+    prompt: str,
+    model: str,
+    timeout_s: float,
+    context: str,
+    max_tokens: int,
+) -> dict[str, Any]:
+    # DEFAULT_HOST from its defining module, not re-exported through the shim:
+    # mypy --strict rejects the indirect import, and one origin is one fact.
+    from hive._client import _daemon_reachable, _read_state, _remote_client
+    from hive._daemon import DEFAULT_HOST
+
+    payload = {
+        "prompt": prompt,
+        "model": model,
+        "context": context,
+        "max_tokens": max_tokens,
+        "timeout_s": timeout_s,
+        "structured": True,
+    }
+
+    # Reuse the shim's own detection rather than adding a second probe: two
+    # answers to "is the daemon up" are two answers that can disagree.
+    state = _read_state()
+    if state is not None and _daemon_reachable(DEFAULT_HOST, state[0]):
+        port, token = state
+        try:
+            client = _remote_client(DEFAULT_HOST, port, token)
+            async with client:
+                result = await client.call_tool("delegate_task", payload)
+            return _decode(result, degraded=False)
+        except Exception as exc:  # noqa: BLE001 - any daemon failure degrades
+            # Broad on purpose. The TCP probe proves something is listening, not
+            # that it will complete an MCP call: a daemon mid-restart, a stale
+            # token, a handshake stall. Every one of those is a reason to take
+            # the documented fallback, and none is a reason to fail the
+            # dispatch — the degraded flag is how the caller learns which path
+            # answered.
+            _log.warning("daemon call failed (%r); falling back to in-process", exc)
+
+    from hive.server import create_server
+
+    local: Any = await create_server().call_tool("delegate_task", payload)
+    return _decode(local, degraded=True)
+
+
+def _decode(result: Any, *, degraded: bool) -> dict[str, Any]:
+    """Turn a tool result into the record, tagging how it was reached.
+
+    The tool answers with a JSON string in structured mode. A body that is not
+    parseable is a task failure and not a pool problem: the pool answered, and
+    what came back is unusable — retrying that on another model would hide it.
+    """
+    text = _result_text(result)
+    try:
+        record: dict[str, Any] = json.loads(text)
+    except (ValueError, TypeError):
+        return {
+            "status": "task_failed",
+            "model": "",
+            "degraded": degraded,
+            "tokens": 0,
+            "duration_ms": 0,
+            "output": "",
+            "detail": f"worker returned an unparseable body: {text[:200]}",
+        }
+    record["degraded"] = degraded
+    return record
+
+
+def _result_text(result: Any) -> str:
+    """Extract the text payload from a FastMCP tool result, in either shape."""
+    content = getattr(result, "content", None)
+    if content:
+        return str(getattr(content[0], "text", ""))
+    return str(result)

--- a/src/hive/_workers.py
+++ b/src/hive/_workers.py
@@ -300,6 +300,41 @@ def _capture_lesson_lookup(
 _RETIRED_MODEL_ALIASES = frozenset({"auto", "ollama", "openrouter-free", "openrouter"})
 
 
+def _as_record(
+    status: str,
+    *,
+    model: str = "",
+    output: str = "",
+    tokens: int = 0,
+    duration_ms: int = 0,
+    detail: str = "",
+) -> str:
+    """Serialise one dispatch outcome for a machine caller (HIVE-384 AC1).
+
+    Every field is always present, including on the failure paths. A consumer
+    that has to branch on which keys exist before it can read a status is a
+    consumer that will get that branch wrong once; ``degraded`` is the only key
+    added later, by the verb, because only the verb knows which route answered.
+
+    ``status`` travels as a VALUE and not as an exception type on purpose:
+    types do not survive the JSON-RPC boundary between the daemon and its
+    clients, and the pool-unavailable / task-failed distinction is exactly what
+    the dispatcher on the far side needs in order to decide whether advancing
+    its fallback chain is legitimate.
+    """
+    return json.dumps(
+        {
+            "status": status,
+            "model": model,
+            "output": output,
+            "tokens": tokens,
+            "duration_ms": duration_ms,
+            "detail": detail,
+        },
+        separators=(",", ":"),
+    )
+
+
 def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
     """Register worker tools on the MCP server."""
 
@@ -352,6 +387,14 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
         except ConnectionError as exc:
             # Unreachable, refused, rate-limited, auth rejected — the pool did
             # not serve the request. Retrying elsewhere is legitimate.
+            #
+            # This branch documented those four conditions from the start and
+            # only received two of them: `clients.py` raised ConnectionError on
+            # transport failures alone, so a 429 or a 401 arrived as a
+            # RuntimeError and classified as `task_failed` below — the chain
+            # stopping exactly where it should have advanced. PR 2 gave the
+            # refusals their own `PoolUnavailableError`, a ConnectionError
+            # subclass so this catch needed no widening.
             return None, "pool_unavailable", f"worker unreachable: {exc}"
         except RuntimeError as exc:
             # The provider answered and the answer is unusable. Retrying the
@@ -625,6 +668,8 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
         section: str = "context",
         path: str = "",
         max_summary_lines: int = 20,
+        timeout_s: float = 0.0,
+        structured: bool = False,
     ) -> str:
         """Offload work to a cheaper model or summarize vault files.
 
@@ -643,9 +688,41 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
             section: Shortcut name for summarization. Ignored if path is set.
             path: Relative path to a .md file. Overrides section.
             max_summary_lines: Target summary length for summarization.
+            timeout_s: Per-dispatch deadline in seconds. 0 uses the ambient
+                tool timeout. A value ABOVE the ambient one raises the ceiling
+                rather than being clamped by it — a deadline a 60s default can
+                silently cap is not a deadline (HIVE-384 AC3).
+            structured: Return a JSON record instead of prose. Prose is the
+                default so every existing caller's contract is unchanged; the
+                dispatcher asks for JSON because it needs the status as a
+                VALUE. Exception types do not survive the JSON-RPC boundary
+                between the daemon and its clients, so "the pool refused" and
+                "the worker answered badly" cannot be told apart by type on the
+                far side — and a dispatcher that cannot tell them apart turns a
+                rate limit into a silent retry against a different model.
         """
+        # A per-dispatch deadline REPLACES the ambient one rather than being
+        # bounded by it. `ctx.tool_timeout` defaults to 60s, and a caller that
+        # asked for 180 and silently got 60 was never given the deadline it
+        # asked for (HIVE-384 AC3).
+        deadline_s = timeout_s if timeout_s > 0 else ctx.tool_timeout
+
+        # Structured mode covers worker delegation only. Summarize mode returns
+        # a document, and quietly handing back prose to a caller that asked for
+        # JSON would fail at its parser with no idea why. Refusing names the
+        # reason at the boundary where it is still obvious.
+        if structured and project:
+            return _as_record(
+                "task_failed",
+                model=model,
+                detail=(
+                    "structured mode covers worker delegation only; "
+                    "summarize mode (project=) returns a document, not a record"
+                ),
+            )
+
         try:
-            async with tool_span("delegate_task", ctx.tool_timeout):
+            async with tool_span("delegate_task", deadline_s):
                 # ── Vault summarize mode ──
                 if project:
                     result = _resolve_file(
@@ -723,7 +800,10 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                     )
 
                 if not prompt:
-                    return track(ctx, "delegate_task", "Either prompt or project is required.")
+                    msg = "Either prompt or project is required."
+                    if structured:
+                        return _as_record("task_failed", model=model, detail=msg)
+                    return track(ctx, "delegate_task", msg)
 
                 # ── Worker delegation ──
                 #
@@ -736,13 +816,17 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                 _tn = "delegate_task"
 
                 if model in _RETIRED_MODEL_ALIASES:
-                    return track(
-                        ctx,
-                        _tn,
+                    retired = (
                         f"'{model}' was removed in 4.0.0 — the worker now runs a "
                         "single OpenAI-compatible provider. Pass a concrete model "
-                        "id, or omit `model` to use the configured default.",
+                        "id, or omit `model` to use the configured default."
                     )
+                    # task_failed, not pool_unavailable: the request is wrong,
+                    # and re-sending it to the next pool would fail identically
+                    # while looking like a capacity problem.
+                    if structured:
+                        return _as_record("task_failed", model=model, detail=retired)
+                    return track(ctx, _tn, retired)
 
                 resp, status, detail = await _try_worker(
                     prompt,
@@ -750,15 +834,37 @@ def register_workers(mcp: FastMCP, ctx: ServerContext) -> None:
                     context,
                     model=model,
                 )
+                if structured:
+                    return _as_record(
+                        status,
+                        model=(resp.model if resp is not None else model),
+                        output=(resp.text if resp is not None else ""),
+                        tokens=(resp.tokens if resp is not None else 0),
+                        duration_ms=(resp.latency_ms if resp is not None else 0),
+                        detail=detail,
+                    )
                 if resp is not None:
                     return track(ctx, _tn, _format_response(resp))
                 return track(ctx, _tn, f"{detail}. {_REJECT_MSG}")
         except TimeoutError:
+            # The deadline that expired is the one that was ASKED for, so the
+            # message must name it rather than the ambient default — otherwise
+            # a 180s dispatch reports "timed out after 60s" and sends whoever
+            # reads it looking in the wrong place.
+            expired = timeout_s if timeout_s > 0 else ctx.tool_timeout
+            # `:g` rather than `:.0f`: a sub-second deadline rounds to "0s"
+            # under the latter, and "timed out after 0s" reads as a bug in the
+            # timer rather than as the deadline the caller chose.
+            if structured:
+                return _as_record(
+                    "timeout",
+                    model=model,
+                    detail=f"deadline of {expired:g}s expired; termination issued",
+                )
             return track(
                 ctx,
                 "delegate_task",
-                f"Tool timed out after {ctx.tool_timeout:.0f}s. "
-                "Worker may be slow or unresponsive.",
+                f"Tool timed out after {expired:g}s. Worker may be slow or unresponsive.",
             )
 
     @mcp.tool(annotations=_READ_ONLY)

--- a/src/hive/clients.py
+++ b/src/hive/clients.py
@@ -9,6 +9,38 @@ from urllib.parse import urlsplit
 
 import httpx
 
+
+class PoolUnavailableError(ConnectionError):
+    """The pool declined to serve the request; retrying elsewhere is legitimate.
+
+    Unreachable, timed out, rate-limited, or credential-rejected — in every one
+    of those the request never became an answer, so a dispatcher should advance
+    its fallback chain. That is the whole reason this type exists as something
+    other than a message: HIVE-384's contract gives it exit `3`, while a worker
+    that *answered* with a failure gets exit `1` and no retry.
+
+    It subclasses ``ConnectionError`` deliberately. Both `_try_worker` and
+    `worker_status` already catch `ConnectionError` and treat it as *pool
+    unavailable*; a sibling type would have silently reclassified them into the
+    task-failed branch — the exact collapse this distinction exists to prevent.
+
+    Deliberately NOT raised for 5xx: those mean the pool accepted the request
+    and broke while serving it. Unknown failures classify as task-failed,
+    because the fail-closed direction is the one that does not retry.
+    """
+
+
+# HTTP statuses that mean "this pool did not serve you", as opposed to "your
+# request was served and the result is bad". Kept as a mapping so the raised
+# message names which refusal it was: an operator reading one line should not
+# have to look the number up, and "rate limited" and "credential rejected" call
+# for completely different actions.
+_POOL_REFUSAL_STATUSES = {
+    401: "credential rejected",
+    403: "forbidden",
+    429: "rate limited",
+}
+
 _AVAILABILITY_CACHE_TTL_S = 30.0
 # Health-check connect timeout: kept short so an unreachable endpoint
 # fails fast (1s) instead of consuming the generate-timeout budget.
@@ -125,12 +157,22 @@ class OpenAICompatibleClient:
             resp = await self._http.post(url, json=payload)
             elapsed_ms = int((time.monotonic() - start) * 1000)
         except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
-            raise ConnectionError(f"{self._provider_name} unavailable: {exc}") from exc
+            raise PoolUnavailableError(f"{self._provider_name} unavailable: {exc}") from exc
         except httpx.TimeoutException as exc:
-            raise ConnectionError(f"{self._provider_name} request timed out: {exc}") from exc
+            raise PoolUnavailableError(f"{self._provider_name} request timed out: {exc}") from exc
 
-        if resp.status_code == 429:
-            raise RuntimeError(f"{self._provider_name} rate limit exceeded. Retry later.")
+        # A refusal is not a failed task. 429 and 401/403 mean the pool did not
+        # serve this request at all, so a dispatcher should try the next entry
+        # in its chain; a 4xx about the request itself, or any 5xx, means the
+        # pool took it and the answer is unusable, which must not be retried
+        # elsewhere. Before HIVE-384 PR 2 every non-2xx raised RuntimeError, so
+        # a rate limit read as a broken task and the chain stopped exactly
+        # where it should have advanced.
+        if resp.status_code in _POOL_REFUSAL_STATUSES:
+            raise PoolUnavailableError(
+                f"{self._provider_name} refused the request ({resp.status_code} "
+                f"{_POOL_REFUSAL_STATUSES[resp.status_code]}): {self._error_detail(resp)}"
+            )
         if resp.status_code >= 400:
             raise RuntimeError(
                 f"{self._provider_name} API error ({resp.status_code}): {self._error_detail(resp)}"
@@ -141,9 +183,27 @@ class OpenAICompatibleClient:
             raise RuntimeError(f"{self._provider_name} returned non-JSON response: {exc}") from exc
         return data, elapsed_ms
 
+    def _error_detail(self, resp: httpx.Response) -> str:
+        """Best-effort error message from a non-2xx response body, redacted.
+
+        The body is a REMOTE string that this process then puts into an
+        exception message, a log line and a result record. Some providers echo
+        the request's ``Authorization`` header back in an auth-failure body, so
+        the one call most likely to produce a detail — a 401 — is also the one
+        most likely to carry the credential in it (AC7).
+
+        The redaction is exact rather than pattern-based: it removes this
+        client's own key, which cannot over-redact and cannot miss a token
+        shaped differently than expected. A general secret scrubber over
+        arbitrary strings is a bigger thing and is not this.
+        """
+        detail = self._extract_detail(resp)
+        if self._api_key and self._api_key in detail:
+            detail = detail.replace(self._api_key, "<redacted>")
+        return detail
+
     @staticmethod
-    def _error_detail(resp: httpx.Response) -> str:
-        """Best-effort error message from a non-2xx response body."""
+    def _extract_detail(resp: httpx.Response) -> str:
         try:
             data = resp.json()
         except ValueError:
@@ -218,11 +278,20 @@ class OpenAICompatibleClient:
             resp = await self._http.get(f"{self._base_url}/models")
         except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
             msg = f"{self._provider_name} unavailable: {exc}"
-            raise ConnectionError(msg) from exc
+            raise PoolUnavailableError(msg) from exc
         except httpx.TimeoutException as exc:
             msg = f"{self._provider_name} request timed out: {exc}"
-            raise ConnectionError(msg) from exc
+            raise PoolUnavailableError(msg) from exc
 
+        # Same split as _post_json: worker_status reads reachability off this
+        # call, and a rate-limited catalog means "reachable, throttled" rather
+        # than "broken".
+        if resp.status_code in _POOL_REFUSAL_STATUSES:
+            msg = (
+                f"{self._provider_name} refused the models request "
+                f"({resp.status_code} {_POOL_REFUSAL_STATUSES[resp.status_code]})"
+            )
+            raise PoolUnavailableError(msg)
         if resp.status_code >= 400:
             msg = f"{self._provider_name} models error ({resp.status_code}): {resp.text[:200]}"
             raise RuntimeError(msg)

--- a/src/hive/config.py
+++ b/src/hive/config.py
@@ -31,7 +31,18 @@ class HiveSettings(BaseSettings):
     # would make a published package read a variable that only means something
     # inside one deployment; mapping a launcher's own name onto
     # HIVE_WORKER_API_KEY is the launcher's job, at injection time.
-    worker_api_key: str = ""
+    # repr=False on every credential field. `repr(settings)` is not something
+    # anyone calls on purpose — it is what a traceback, a debug log and a
+    # pytest assertion print unbidden, and pydantic renders field VALUES there.
+    # Measured: `repr(HiveSettings())` contained `worker_api_key='<the key>'`
+    # verbatim. The transcript that catches such a line is a durable artifact
+    # nothing scans and nothing can un-print (AC7).
+    #
+    # `SecretStr` is the idiomatic fix and is deliberately NOT taken here: it
+    # changes the field's type, which propagates through `ServerContext` and
+    # six call sites, and a type migration does not belong in the PR that
+    # discovered the leak. Tracked separately; `repr=False` closes the leak now.
+    worker_api_key: str = Field(default="", repr=False)
     vault_scopes: dict[str, str] = Field(
         # ``agents`` is intentionally LAST: auto-scan (plain project name)
         # resolves first-match over insertion order, so appending keeps an
@@ -51,7 +62,7 @@ class HiveSettings(BaseSettings):
     # configured the same way.
     embed_base_url: str = ""
     embed_model: str = ""
-    embed_api_key: str = ""
+    embed_api_key: str = Field(default="", repr=False)
     # HIVE-211 PR4: LLM synthesis model. Uses the same base_url/api_key as
     # embeddings. Empty = return formatted retrieval chunks (no LLM call).
     # The model id is whatever the configured endpoint calls it — hive does not

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -811,6 +811,8 @@ Commands:
   (no args)                            run the stdio MCP server (v1 per-session contract)
   serve                                run the single-owner daemon (ADR-011)
   client                               run the thin stdio shim that proxies to the daemon
+  delegate --model M --timeout S       run one task against one model; JSON on stdout
+                                       (exit 1 task failed, 3 pool unavailable, 4 timeout)
   service {install,uninstall,status}   manage the daemon as a per-user OS service
   self-upgrade [version]               build + swap to a hive-vault version (PyPI latest if omitted)
 
@@ -857,6 +859,10 @@ def _dispatch(argv: list[str]) -> int:
     if cmd == "client":
         _run_client(argv[1:])
         return 0
+    if cmd == "delegate":
+        from hive._delegate import run_delegate
+
+        return run_delegate(argv[1:])
     print(f"hive: unknown command: {cmd}", file=sys.stderr)
     print(_USAGE, file=sys.stderr, end="")
     return 2

--- a/tests/test_credential_never_emitted.py
+++ b/tests/test_credential_never_emitted.py
@@ -1,0 +1,172 @@
+"""The worker credential never reaches an output surface (AC7).
+
+This criterion shipped in 4.0.0 with its box ticked and no test behind it. The
+gap was found while completing this spec's `features.json`, whose verification
+command for AC7 selected zero tests — a recorded proof that never ran is
+indistinguishable from one that passes.
+
+It is worth more than a checkbox. The injected secrets doctrine names the
+transcript as a durable artifact that no scanner reaches and nothing can
+un-print, and `worker_status` is the surface most likely to leak here: it exists
+to report configuration, and "configured" is one careless line away from
+"configured with this value".
+
+Verification is by absence with a planted value, which is the only way to test
+this without printing the thing under test.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from hive.clients import OpenAICompatibleClient, PoolUnavailableError
+from hive.config import HiveSettings
+from hive.server import create_server
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from fastmcp import FastMCP
+
+    from hive.budget import BudgetTracker
+
+# Distinctive enough that a substring match cannot collide with real output.
+_PLANTED = "pk-planted-9f3c1a7e-never-print-me"
+
+
+@pytest.fixture
+def worker_with_planted_key(
+    mock_vault: Path,
+    budget: BudgetTracker,
+    worker_client: OpenAICompatibleClient,
+) -> FastMCP:
+    worker_client._api_key = _PLANTED
+    worker_client._http.headers["Authorization"] = f"Bearer {_PLANTED}"
+    return create_server(
+        vault_path=mock_vault,
+        budget_tracker=budget,
+        worker_client=worker_client,
+    )
+
+
+def _text(result: Any) -> str:
+    return str(result.content[0].text)
+
+
+class TestTheCredentialStaysOutOfOutput:
+    def test_settings_do_not_expose_it_through_repr(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`repr(settings)` lands in tracebacks and debug logs unbidden."""
+        monkeypatch.setenv("HIVE_WORKER_BASE_URL", "https://provider.example/v1")
+        monkeypatch.setenv("HIVE_WORKER_API_KEY", _PLANTED)
+        settings = HiveSettings()
+        assert settings.worker_api_key == _PLANTED, "the fixture must actually plant it"
+        assert _PLANTED not in repr(settings)
+        assert _PLANTED not in str(settings)
+
+    @pytest.mark.asyncio
+    async def test_worker_status_never_prints_it(
+        self, worker_with_planted_key: FastMCP, worker_client: OpenAICompatibleClient
+    ) -> None:
+        """The surface whose whole job is reporting configuration."""
+        worker_client.list_models = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        out = _text(await worker_with_planted_key.call_tool("worker_status", {}))
+        assert _PLANTED not in out
+
+    @pytest.mark.asyncio
+    async def test_an_unreachable_worker_does_not_leak_it_in_the_error(
+        self, worker_with_planted_key: FastMCP, worker_client: OpenAICompatibleClient
+    ) -> None:
+        """Failure paths format more state than success paths, so they leak more."""
+        worker_client.list_models = AsyncMock(  # type: ignore[method-assign]
+            side_effect=PoolUnavailableError("provider.example refused the request (401)"),
+        )
+        out = _text(await worker_with_planted_key.call_tool("worker_status", {}))
+        assert _PLANTED not in out
+
+
+class TestAProviderThatEchoesTheKeyBackDoesNotGetItRelayed:
+    """The one real path from a configured credential to an emitted string.
+
+    Some providers put the request's ``Authorization`` header into the body of
+    a 401. `_error_detail` reads that body and hive then places it in an
+    exception message, a log line and the result record a dispatcher parses.
+    Nothing about that chain is hypothetical, and it lands on the *auth-failure*
+    response — the one call guaranteed to happen when a key is wrong.
+
+    This is deliberately narrower than "hive redacts any secret from any
+    string". A general scrubber over arbitrary text is a different and much
+    larger thing; AC7 asks that a credential this process was given does not
+    come back out, and the redaction is exact — it removes this client's own
+    key, so it can neither over-redact nor miss a token shaped unexpectedly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_error_detail_redacts_an_echoed_key(self) -> None:
+        client = OpenAICompatibleClient(
+            base_url="https://provider.example/v1",
+            api_key=_PLANTED,
+            default_model="m",
+        )
+        echoing_401 = httpx.Response(
+            status_code=401,
+            json={"error": {"message": f"invalid credentials: Bearer {_PLANTED}"}},
+            request=httpx.Request("POST", "http://test"),
+        )
+        with (
+            patch.object(client._http, "post", new_callable=AsyncMock, return_value=echoing_401),
+            pytest.raises(PoolUnavailableError) as excinfo,
+        ):
+            await client.generate("hi")
+
+        message = str(excinfo.value)
+        assert _PLANTED not in message, "the provider's echo of our own key was relayed verbatim"
+        assert "<redacted>" in message
+        assert "401" in message, "redaction must not cost the reader the reason"
+
+    @pytest.mark.asyncio
+    async def test_an_unrelated_body_is_left_intact(self) -> None:
+        """Redaction is exact, so a body with no key in it is unchanged."""
+        client = OpenAICompatibleClient(
+            base_url="https://provider.example/v1",
+            api_key=_PLANTED,
+            default_model="m",
+        )
+        plain_401 = httpx.Response(
+            status_code=401,
+            json={"error": {"message": "no organization on this account"}},
+            request=httpx.Request("POST", "http://test"),
+        )
+        with (
+            patch.object(client._http, "post", new_callable=AsyncMock, return_value=plain_401),
+            pytest.raises(PoolUnavailableError, match="no organization on this account"),
+        ):
+            await client.generate("hi")
+
+    @pytest.mark.asyncio
+    async def test_the_redacted_detail_survives_into_the_result_record(
+        self,
+        worker_with_planted_key: FastMCP,
+        worker_client: OpenAICompatibleClient,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """End of the chain: what a dispatcher actually parses off stdout."""
+        worker_client.generate = AsyncMock(  # type: ignore[method-assign]
+            side_effect=PoolUnavailableError(
+                "provider.example refused the request (401 credential rejected): "
+                "invalid credentials: Bearer <redacted>"
+            ),
+        )
+        with caplog.at_level(logging.DEBUG):
+            out = _text(
+                await worker_with_planted_key.call_tool(
+                    "delegate_task",
+                    {"prompt": "x", "structured": True, "timeout_s": 5.0},
+                )
+            )
+        assert _PLANTED not in out
+        assert not [r for r in caplog.records if _PLANTED in r.getMessage()]

--- a/tests/test_delegate_deadline_and_route.py
+++ b/tests/test_delegate_deadline_and_route.py
@@ -1,0 +1,274 @@
+"""The deadline is the one that was asked for, and the route is reported (AC3, AC4).
+
+Two properties that look like details and are not.
+
+**AC3 — a per-dispatch deadline replaces the ambient one.** `ctx.tool_timeout`
+defaults to 60s. A dispatcher that asks for 180 and silently gets 60 was never
+given the deadline it asked for, and it learns this as a mysterious timeout on
+long work. So the value passed in raises the ceiling rather than being bounded
+by it — and the reverse also holds: a *shorter* deadline must actually cut the
+call short rather than waiting out the ambient one.
+
+The no-wait half matters because ADR-008's supervisor escalates: cancel,
+``terminate()``, two-second grace, ``kill()``. If the verb waited for that whole
+escalation its observable deadline would be ``--timeout + 2s``. It does not:
+the grace applies to registered subprocesses, and an HTTP dispatch registers
+none, so cancellation returns immediately. The test asserts the *observable*
+property rather than the mechanism, so it keeps its meaning if the internals
+change.
+
+**AC4 — `degraded` is asserted in both directions.** A boolean only ever
+observed in one state is not asserted; it would pass just as happily hardcoded.
+So both routes are exercised: a reachable daemon must produce ``false`` and an
+absent one ``true``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from hive.clients import ClientResponse
+from hive.server import create_server
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from fastmcp import FastMCP
+
+    from hive.budget import BudgetTracker
+    from hive.clients import OpenAICompatibleClient
+
+
+@pytest.fixture
+def worker(
+    mock_vault: Path,
+    budget: BudgetTracker,
+    worker_client: OpenAICompatibleClient,
+) -> FastMCP:
+    """A server wired to a controllable worker client."""
+    return create_server(
+        vault_path=mock_vault,
+        budget_tracker=budget,
+        worker_client=worker_client,
+    )
+
+
+def _record(result: Any) -> dict[str, Any]:
+    text = result.content[0].text  # type: ignore[union-attr]
+    return dict(json.loads(text))
+
+
+class TestTheDeadlineIsTheOneAskedFor:
+    @pytest.mark.asyncio
+    async def test_a_longer_timeout_is_honoured_not_clamped(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
+    ) -> None:
+        """The regression this guards: a 60s ambient default capping a 180s ask."""
+
+        async def slow_but_within_budget(*a: object, **kw: object) -> ClientResponse:
+            await asyncio.sleep(0.3)
+            return ClientResponse(text="done", model="m", tokens=1, cost_usd=0.0, latency_ms=300)
+
+        worker_client.generate = AsyncMock(side_effect=slow_but_within_budget)  # type: ignore[method-assign]
+        ctx = worker._hive_ctx  # type: ignore[attr-defined]
+        ctx.tool_timeout = 0.1  # ambient budget is FIVE TIMES too small
+
+        record = _record(
+            await worker.call_tool(
+                "delegate_task",
+                {"prompt": "x", "structured": True, "timeout_s": 5.0},
+            )
+        )
+        assert record["status"] == "ok", "the per-dispatch deadline must raise the ceiling"
+
+    @pytest.mark.asyncio
+    async def test_a_shorter_timeout_actually_cuts_the_call_short(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
+    ) -> None:
+        """Overriding must work downward too, or it is a floor and not a deadline."""
+
+        async def hangs(*a: object, **kw: object) -> ClientResponse:
+            await asyncio.sleep(999)
+            raise AssertionError("unreachable")
+
+        worker_client.generate = AsyncMock(side_effect=hangs)  # type: ignore[method-assign]
+        ctx = worker._hive_ctx  # type: ignore[attr-defined]
+        ctx.tool_timeout = 30.0  # ambient budget is far LONGER than the ask
+
+        started = time.monotonic()
+        record = _record(
+            await worker.call_tool(
+                "delegate_task",
+                {"prompt": "x", "structured": True, "timeout_s": 0.2},
+            )
+        )
+        elapsed = time.monotonic() - started
+
+        assert record["status"] == "timeout"
+        assert elapsed < 2.0, (
+            "returned after the 2s grace window, so the observable deadline is "
+            "timeout + grace rather than timeout"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_timeout_detail_names_the_deadline_that_expired(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
+    ) -> None:
+        """Reporting the ambient 60s for a 0.2s dispatch sends a reader the wrong way."""
+
+        async def hangs(*a: object, **kw: object) -> ClientResponse:
+            await asyncio.sleep(999)
+            raise AssertionError("unreachable")
+
+        worker_client.generate = AsyncMock(side_effect=hangs)  # type: ignore[method-assign]
+        ctx = worker._hive_ctx  # type: ignore[attr-defined]
+        ctx.tool_timeout = 30.0
+
+        record = _record(
+            await worker.call_tool(
+                "delegate_task",
+                {"prompt": "x", "structured": True, "timeout_s": 0.2},
+            )
+        )
+        # Positively, not just "the wrong number is absent": a mutation run
+        # showed the negative form passing while the message was still wrong,
+        # because 0.2 formatted as "0s" under `:.0f` and contained no "30"
+        # either. A sub-second deadline reported as 0s reads as a broken timer.
+        assert "0.2" in record["detail"], f"detail does not name the deadline: {record['detail']}"
+        assert "30" not in record["detail"], "named the ambient budget, not the one asked for"
+
+    @pytest.mark.asyncio
+    async def test_zero_falls_back_to_the_ambient_budget(
+        self, worker: FastMCP, worker_client: OpenAICompatibleClient
+    ) -> None:
+        """MCP callers that never heard of timeout_s keep today's behaviour."""
+
+        async def hangs(*a: object, **kw: object) -> ClientResponse:
+            await asyncio.sleep(999)
+            raise AssertionError("unreachable")
+
+        worker_client.generate = AsyncMock(side_effect=hangs)  # type: ignore[method-assign]
+        ctx = worker._hive_ctx  # type: ignore[attr-defined]
+        ctx.tool_timeout = 0.2
+
+        record = _record(
+            await worker.call_tool("delegate_task", {"prompt": "x", "structured": True})
+        )
+        assert record["status"] == "timeout"
+
+
+_OK_BODY = json.dumps(
+    {"status": "ok", "model": "m", "output": "hi", "tokens": 1, "duration_ms": 5, "detail": ""}
+)
+
+
+class _ToolResult:
+    """Minimal stand-in for a FastMCP tool result."""
+
+    def __init__(self, text: str = _OK_BODY) -> None:
+        class _Content:
+            def __init__(self, t: str) -> None:
+                self.text = t
+
+        self.content = [_Content(text)]
+
+
+class _RemoteClient:
+    """A daemon client that answers."""
+
+    async def __aenter__(self) -> _RemoteClient:
+        return self
+
+    async def __aexit__(self, *a: object) -> None:
+        return None
+
+    async def call_tool(self, _name: str, _args: dict[str, Any]) -> _ToolResult:
+        return _ToolResult()
+
+
+class _BrokenRemoteClient:
+    """A daemon that accepts TCP and then fails the MCP session."""
+
+    async def __aenter__(self) -> _BrokenRemoteClient:
+        raise ConnectionResetError("daemon restarting")
+
+    async def __aexit__(self, *a: object) -> None:
+        return None
+
+
+class TestDegradedIsReportedInBothDirections:
+    """A flag observed in one state only would pass while hardcoded."""
+
+    def test_a_reachable_daemon_reports_not_degraded(self) -> None:
+        from hive import _delegate
+
+        with (
+            patch("hive._client._read_state", return_value=(4242, "a-token")),
+            patch("hive._client._daemon_reachable", return_value=True),
+            patch("hive._client._remote_client", return_value=_RemoteClient()),
+        ):
+            record = _delegate._dispatch_once(
+                prompt="x", model="m", timeout_s=5.0, context="", max_tokens=10
+            )
+        assert record["degraded"] is False
+        assert record["status"] == "ok"
+
+    def test_no_daemon_state_reports_degraded(self) -> None:
+        from hive import _delegate
+
+        local = AsyncMock(return_value=_ToolResult())
+        with (
+            patch("hive._client._read_state", return_value=None),
+            patch("hive.server.create_server") as make,
+        ):
+            make.return_value.call_tool = local
+            record = _delegate._dispatch_once(
+                prompt="x", model="m", timeout_s=5.0, context="", max_tokens=10
+            )
+        assert record["degraded"] is True
+        assert local.await_count == 1, "the in-process path must be the one that ran"
+
+    def test_a_daemon_that_accepts_tcp_but_fails_the_call_degrades(self) -> None:
+        """The TCP probe proves a listener, not a working MCP session.
+
+        A daemon mid-restart accepts the connection and then fails the
+        handshake. Failing the dispatch there would make a restart look like a
+        worker error; degrading and saying so is the documented contract.
+        """
+        from hive import _delegate
+
+        local = AsyncMock(return_value=_ToolResult())
+        with (
+            patch("hive._client._read_state", return_value=(4242, "a-token")),
+            patch("hive._client._daemon_reachable", return_value=True),
+            patch("hive._client._remote_client", return_value=_BrokenRemoteClient()),
+            patch("hive.server.create_server") as make,
+        ):
+            make.return_value.call_tool = local
+            record = _delegate._dispatch_once(
+                prompt="x", model="m", timeout_s=5.0, context="", max_tokens=10
+            )
+        assert record["degraded"] is True
+        assert local.await_count == 1
+
+    def test_stale_state_with_nothing_listening_degrades(self) -> None:
+        """A crashed daemon leaves its port file behind; the probe is what decides."""
+        from hive import _delegate
+
+        local = AsyncMock(return_value=_ToolResult())
+        with (
+            patch("hive._client._read_state", return_value=(4242, "a-token")),
+            patch("hive._client._daemon_reachable", return_value=False),
+            patch("hive.server.create_server") as make,
+        ):
+            make.return_value.call_tool = local
+            record = _delegate._dispatch_once(
+                prompt="x", model="m", timeout_s=5.0, context="", max_tokens=10
+            )
+        assert record["degraded"] is True

--- a/tests/test_delegate_verb.py
+++ b/tests/test_delegate_verb.py
@@ -1,0 +1,166 @@
+"""`hive delegate` — the wire contract a dispatcher depends on (AC1, AC2).
+
+The consumer of this verb is not a person, it is `dotf agent run` walking a
+fallback chain. That makes three things load-bearing rather than cosmetic:
+
+* **stdout is exactly one JSON object.** A dispatcher parses it. Any log line
+  that lands there corrupts the parse, so logging goes to stderr without
+  exception.
+* **`--model` and `--timeout` are required.** Defaulting either would let the
+  caller believe it stated a deadline or a model when it did not, and the whole
+  point of the routing registry is that the dispatcher — not the backend —
+  decides which model runs.
+* **the exit code separates the two failure classes.** `3` means the pool did
+  not serve the request, and the dispatcher advances its chain; `1` means it
+  did serve it and the answer is a failure, and the dispatcher must stop.
+  Collapsing them turns a bad answer into a silent retry on another model.
+
+Exit codes, from the HIVE-384 contract table: 0 ok · 1 task failed · 2 usage
+error · 3 pool unavailable · 4 timeout.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from hive._delegate import (
+    EXIT_OK,
+    EXIT_POOL_UNAVAILABLE,
+    EXIT_TASK_FAILED,
+    EXIT_USAGE,
+    run_delegate,
+)
+
+_ARGS = ["--model", "a-model", "--timeout", "30", "--prompt", "hi"]
+
+
+def _result(**over: Any) -> dict[str, Any]:
+    base = {
+        "status": "ok",
+        "model": "a-model",
+        "degraded": False,
+        "tokens": 12,
+        "duration_ms": 40,
+        "output": "hello",
+        "detail": "",
+    }
+    base.update(over)
+    return base
+
+
+class TestRequiredArguments:
+    """Neither a model nor a deadline may be assumed on the caller's behalf."""
+
+    @pytest.mark.parametrize(
+        ("argv", "missing"),
+        [
+            (["--timeout", "30", "--prompt", "hi"], "--model"),
+            (["--model", "m", "--prompt", "hi"], "--timeout"),
+            (["--model", "m", "--timeout", "30"], "--prompt"),
+        ],
+    )
+    def test_missing_required_argument_is_a_usage_error(
+        self, argv: list[str], missing: str, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert run_delegate(argv) == EXIT_USAGE
+        captured = capsys.readouterr()
+        assert captured.out == "", "a usage error must not emit a result record"
+        assert missing in captured.err
+
+    def test_a_non_numeric_timeout_is_a_usage_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert run_delegate(["--model", "m", "--timeout", "soon", "--prompt", "hi"]) == EXIT_USAGE
+        assert capsys.readouterr().out == ""
+
+    @pytest.mark.parametrize("timeout", ["0", "-5"])
+    def test_a_non_positive_timeout_is_a_usage_error(
+        self, timeout: str, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A zero deadline is not a deadline; rejecting beats an instant exit 4."""
+        assert run_delegate(["--model", "m", "--timeout", timeout, "--prompt", "hi"]) == EXIT_USAGE
+        assert capsys.readouterr().out == ""
+
+
+class TestWireContract:
+    def test_stdout_is_exactly_one_json_object(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("hive._delegate._dispatch_once", return_value=_result()):
+            assert run_delegate(_ARGS) == EXIT_OK
+        out = capsys.readouterr().out
+        assert out.endswith("\n")
+        assert len(out.strip().splitlines()) == 1, "a dispatcher parses this as one object"
+        json.loads(out)
+
+    def test_the_record_carries_every_contracted_field(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("hive._delegate._dispatch_once", return_value=_result()):
+            run_delegate(_ARGS)
+        record = json.loads(capsys.readouterr().out)
+        assert set(record) >= {"status", "model", "degraded", "tokens", "duration_ms", "output"}
+
+    def test_the_record_names_the_model_that_answered(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Not the requested one: the dispatcher reports what actually ran."""
+        with patch("hive._delegate._dispatch_once", return_value=_result(model="what-ran")):
+            run_delegate(_ARGS)
+        assert json.loads(capsys.readouterr().out)["model"] == "what-ran"
+
+    def test_logging_never_reaches_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
+        import logging
+
+        def _noisy(**_: Any) -> dict[str, Any]:
+            logging.getLogger("hive").warning("a log line that must not corrupt the parse")
+            return _result()
+
+        with patch("hive._delegate._dispatch_once", side_effect=_noisy):
+            run_delegate(_ARGS)
+        json.loads(capsys.readouterr().out)  # raises if the log landed on stdout
+
+
+class TestExitCodesSeparateTheFailureClasses:
+    """The distinction the whole fallback chain rests on."""
+
+    def test_pool_unavailable_exits_three(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch(
+            "hive._delegate._dispatch_once",
+            return_value=_result(status="pool_unavailable", output="", detail="429 rate limited"),
+        ):
+            assert run_delegate(_ARGS) == EXIT_POOL_UNAVAILABLE
+        assert json.loads(capsys.readouterr().out)["status"] == "pool_unavailable"
+
+    def test_task_failed_exits_one(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch(
+            "hive._delegate._dispatch_once",
+            return_value=_result(status="task_failed", output="", detail="worker error: 500"),
+        ):
+            assert run_delegate(_ARGS) == EXIT_TASK_FAILED
+        assert json.loads(capsys.readouterr().out)["status"] == "task_failed"
+
+    def test_a_failure_still_emits_a_parseable_record(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The dispatcher needs the record on the failure path most of all."""
+        with patch(
+            "hive._delegate._dispatch_once",
+            return_value=_result(status="pool_unavailable", detail="unreachable"),
+        ):
+            run_delegate(_ARGS)
+        record = json.loads(capsys.readouterr().out)
+        assert record["detail"], "a failure with no detail is unactionable"
+
+    def test_an_unrecognised_status_is_a_task_failure(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Fail closed: the direction that does NOT advance to another model.
+
+        A status this verb does not know about must never be read as 'the pool
+        was busy', because that is the reading that silently retries.
+        """
+        with patch("hive._delegate._dispatch_once", return_value=_result(status="something-new")):
+            assert run_delegate(_ARGS) == EXIT_TASK_FAILED

--- a/tests/test_pool_classification.py
+++ b/tests/test_pool_classification.py
@@ -1,0 +1,117 @@
+"""A refused pool must not be reported as a failed task.
+
+HIVE-384's contract table assigns exit `3` — *pool unavailable* — to
+"unreachable, 429, auth rejected", and exit `1` — *task failed* — to a worker
+that answered with a bad answer. The dispatcher advances its fallback chain on
+the first and must not on the second: collapsing them turns a rate limit into a
+silent retry against a different model, and a bad answer into one too.
+
+`_try_worker` already carries the classification as data, and its docstring
+names all four conditions under `ConnectionError`. `clients.py` did not agree
+with it: only *transport* failures raised `ConnectionError`, while every non-2xx
+— 429 and 401 included — raised `RuntimeError`, which `_try_worker` maps to
+`task_failed`. So a saturated pool classified as a broken task, and the chain
+would stop exactly where it should have advanced.
+
+The tests below are the guard for that. They assert the classification at both
+levels it has to survive: the exception the client raises, and the status string
+`_try_worker` derives from it — because only the second one crosses the JSON-RPC
+boundary to a dispatcher.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from hive.clients import OpenAICompatibleClient, PoolUnavailableError
+
+
+def _response(status_code: int, json_data: dict[str, Any] | None = None) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        json=json_data if json_data is not None else {"error": {"message": "nope"}},
+        request=httpx.Request("POST", "http://test"),
+    )
+
+
+def _client() -> OpenAICompatibleClient:
+    return OpenAICompatibleClient(base_url="http://provider.example/v1", default_model="m")
+
+
+class TestPoolRefusalIsNotATaskFailure:
+    """The three ways a pool declines to serve, all of which are retryable elsewhere."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status_code", "what"),
+        [
+            (429, "rate limited"),
+            (401, "credential rejected"),
+            (403, "forbidden"),
+        ],
+    )
+    async def test_pool_refusal_raises_pool_unavailable(self, status_code: int, what: str) -> None:
+        client = _client()
+        with (
+            patch.object(
+                client._http, "post", new_callable=AsyncMock, return_value=_response(status_code)
+            ),
+            pytest.raises(PoolUnavailableError),
+        ):
+            await client.generate("hi")
+
+    @pytest.mark.asyncio
+    async def test_pool_unavailable_is_a_connection_error(self) -> None:
+        """Subclass, so every existing ``except ConnectionError`` keeps working.
+
+        `_try_worker` and `worker_status` both catch `ConnectionError` today.
+        Introducing a sibling type would have silently reclassified them.
+        """
+        assert issubclass(PoolUnavailableError, ConnectionError)
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_is_still_pool_unavailable(self) -> None:
+        client = _client()
+        with (
+            patch.object(
+                client._http,
+                "post",
+                new_callable=AsyncMock,
+                side_effect=httpx.ConnectError("refused"),
+            ),
+            pytest.raises(PoolUnavailableError),
+        ):
+            await client.generate("hi")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status_code", [400, 404, 422, 500, 503])
+    async def test_other_errors_stay_task_failures(self, status_code: int) -> None:
+        """A 5xx is deliberately NOT a pool refusal.
+
+        It means the pool accepted the request and something broke serving it.
+        Retrying the same task on a different model would hide a real failure —
+        the fail-closed direction is the one that does not retry.
+        """
+        client = _client()
+        with (
+            patch.object(
+                client._http, "post", new_callable=AsyncMock, return_value=_response(status_code)
+            ),
+            pytest.raises(RuntimeError) as excinfo,
+        ):
+            await client.generate("hi")
+        assert not isinstance(excinfo.value, ConnectionError)
+
+    @pytest.mark.asyncio
+    async def test_the_refusal_names_the_status_it_saw(self) -> None:
+        """An operator reading one line must know which refusal happened."""
+        client = _client()
+        with (
+            patch.object(client._http, "post", new_callable=AsyncMock, return_value=_response(429)),
+            pytest.raises(PoolUnavailableError, match="429"),
+        ):
+            await client.generate("hi")


### PR DESCRIPTION
feat: add the hive delegate verb, the dispatch seam a router can call

`hive delegate --model M --timeout S --prompt P` runs one task against one
model and writes a JSON result record to stdout. Its consumer is a dispatcher
walking a fallback chain, not a person, which is what makes the contract sharp:
one JSON object on stdout with every log line on stderr, no defaulted model or
deadline, and an exit code that says whether to try the next chain entry.

Exit codes are a cross-repo contract with `dotf agent run`: 0 ok, 1 task failed,
2 usage, 3 pool unavailable, 4 timeout. Three advances the chain and one must
not; an unrecognised status falls closed to task-failed, because that is the
direction that does not spend another pool's quota on an outcome we cannot
classify.

Routing goes through the client to the daemon, which ADR-011 makes the sole
owner of worker.db; a verb spawning its own server would be a second writer to
it. With no reachable daemon it degrades to the in-process stdio path and says
so in an explicit `degraded` boolean rather than leaving it to be inferred.
Detection reuses the client shim's own probe — two answers to "is the daemon up"
are two answers that can disagree.

`delegate_task` gains `structured` and `timeout_s`. Prose stays the default, so
no existing MCP caller's contract changes; the dispatcher asks for JSON because
it needs the status as a VALUE — exception types do not survive the JSON-RPC
boundary, and that distinction is exactly what the far side must act on. A
`timeout_s` above the ambient tool timeout raises the ceiling rather than being
clamped by it: a deadline a 60s default can silently cap is not a deadline.

Three defects found while building it, each fixed in scope rather than filed:

**A rate limit classified as a failed task.** `clients.py` raised ConnectionError
only for transport failures, so every non-2xx — 429 and 401 included — arrived
as RuntimeError and `_try_worker` mapped it to task_failed. The fallback chain
would have stopped exactly where it should have advanced, on the pool whose
concurrency is shared with five other consumers and whose saturation is the
expected condition rather than the rare one. Refusals now raise
`PoolUnavailableError`, a ConnectionError subclass so no existing catch needed
widening. 4xx about the request and all 5xx stay task failures.

**The credential rendered in `repr(HiveSettings())`**, which is what a traceback
and a debug log print unbidden. Fixed with `repr=False` on both key fields;
`SecretStr` is the idiomatic fix and is deliberately not taken here because it
changes the field type through ServerContext and six call sites.

**`_error_detail` relayed a provider's 401 body verbatim**, and some providers
echo the Authorization header there. The redaction is exact — this client's own
key — so it cannot over-redact or miss an unexpected token shape.

AC7 had no test at all. Its `features.json` command selected zero tests, as did
three others, so 4.0.0 shipped four criteria marked complete on commands that
never ran. All eight are re-pointed and confirmed non-vacuous under
--collect-only. Writing the AC7 test is what surfaced the two leaks above.

Verified: 934 passed / 2 skipped / exit 0 against an 895-passing baseline (+39,
no regressions); ruff and mypy --strict clean. Mutation-checked: reverting the
deadline override, the redaction, or repr=False each turns tests red.

The live smoke run for AC5 remains open — this machine configures no worker
endpoint, and dotfiles CLI-042 AC6 cannot be re-checked until it runs.

Refs #384

---

Closes PR 2 of `specs/HIVE-384-nan-worker-and-delegate-verb/` (AC1–AC4), and closes AC7, which PR 1 marked done without a test. Ships as `feat` → **4.1.0**; the spec's PR-sequence note is corrected in the same change, since it planned for both PRs to land inside one 4.0.0 and that is not what happened.

### What a caller sees

```console
$ hive delegate --model deepseek-v4-flash --timeout 30 --prompt "say pong"
{"status":"pool_unavailable","model":"deepseek-v4-flash","output":"","tokens":0,
 "duration_ms":0,"detail":"worker not configured","degraded":true}
$ echo $?
3
```

Nothing on stderr, one object on stdout, `degraded: true` because no daemon was running, and exit 3 because an unconfigured pool did not serve the request — so a dispatcher advances its chain. Every element of the contract visible in one call.

### Review notes

Three things I would look hardest at:

1. **The 429 reclassification** (`clients.py`). It changes which exception type a non-2xx raises. Only `_workers.py` catches these from the client, and `PoolUnavailableError` subclasses `ConnectionError` so both existing catches keep working unchanged — but that is the blast radius to check.
2. **The scope line on AC7.** The redaction removes *this client's own key* from a provider's error body. It is deliberately not a general secret scrubber, which would be a much larger thing than this criterion asks for. My first attempt tested the larger property by constructing the leak itself; that was an invented requirement and was rewritten.
3. **`repr=False` over `SecretStr`.** The type migration touches ServerContext and six call sites and does not belong in the PR that found the leak. Worth a follow-up ticket if you agree.

### Known open

The live smoke run for AC5 has not been performed — no worker endpoint is configured on this machine. It is stated in `verification.md` as an open item rather than omitted, and it is what `dotfiles` CLI-042 AC6 waits on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `hive delegate` command for single-shot task dispatch with JSON output, model and timeout requirements, status reporting, and meaningful exit codes.
  * Added automatic fallback when daemon dispatch is unavailable, with degraded-operation reporting.
  * Added structured task results, including status, model, output, token usage, and duration.

* **Bug Fixes**
  * Improved timeout handling and failure classification.
  * Redacted credentials from settings, errors, logs, and command output.

* **Documentation**
  * Updated usage guidance, acceptance criteria, verification records, and release references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->