### PR TITLE
fix: never retry a dispatch whose outcome is ambiguous, and four review findings

### DIFF
--- a/specs/HIVE-384-nan-worker-and-delegate-verb/tasks.md
+++ b/specs/HIVE-384-nan-worker-and-delegate-verb/tasks.md
@@ -16,8 +16,8 @@ Declared here so no PR silently absorbs the next:
 
 | PR | Lands | Criteria |
 |---|---|---|
-| **1** | the provider layer: `HIVE_WORKER_*` settings with the `HIVE_EMBED_*` fallback and the `NAN_API_KEY` alias, Ollama and OpenRouter removed, the three `_try_worker` call sites re-routed, `budget.py` trimmed, `worker_status` reshaped, and the stale surfaces (`AGENTS.md`, `Makefile`, tests) | AC5, AC6, AC7 |
-| **2** | the verb: `hive delegate`, the result-carried status classification, `delegate_task`'s `timeout_s` and `model` migration, exit-code mapping, daemon routing and the degraded flag | AC1, AC2, AC3, AC4 |
+| **1** | the provider layer: `HIVE_WORKER_*` settings with the `HIVE_EMBED_*` fallback and the `NAN_API_KEY` alias, Ollama and OpenRouter removed, the three `_try_worker` call sites re-routed, `budget.py` trimmed, `worker_status` reshaped, and the stale surfaces (`AGENTS.md`, `Makefile`, tests) | AC5, AC6, ~~AC7~~ |
+| **2** | the verb: `hive delegate`, the result-carried status classification, `delegate_task`'s `timeout_s` and `model` migration, exit-code mapping, daemon routing and the degraded flag | AC1, AC2, AC3, AC4, **AC7** |
 
 **PR 1 carries the `feat!`** — it is where the providers and the MCP parameters actually disappear.
 
@@ -27,6 +27,11 @@ release-please accumulating them into a single `4.0.0`. That is not what happene
 "after the release publishes, `uv tool upgrade`" step in Closing runs a second time before CLI-042's
 AC6 can be re-checked. Two follow-ups also landed between them, both `fix` on the same release line:
 `#392` (no provider named in shipped surfaces) and `#394` (its review findings).
+
+**AC7 moved from PR 1 to PR 2, struck through above.** PR 1 marked it complete; it had no test,
+and its `features.json` command selected zero tests. Writing that test in PR 2 found two real
+leaks. Ownership is recorded where the work happened rather than where it was planned — the
+release evidence has to match the acceptance matrix or neither can be trusted.
 
 ## Setup
 

--- a/src/hive/_delegate.py
+++ b/src/hive/_delegate.py
@@ -49,6 +49,11 @@ _STATUS_EXIT = {
     "timeout": EXIT_TIMEOUT,
 }
 
+# What a worker body must carry before this verb will pass it on. `degraded` is
+# absent deliberately: only the verb knows which route answered, so it is added
+# here rather than expected from the far side.
+_REQUIRED_FIELDS = frozenset({"status", "model", "output", "tokens", "duration_ms", "detail"})
+
 _DESCRIPTION = """\
 Run one task against the configured worker and print a JSON result record.
 
@@ -97,12 +102,16 @@ def run_delegate(argv: list[str]) -> int:
     parser = _parser()
     try:
         args = parser.parse_args(argv)
-    except SystemExit:
-        # argparse exits 2 and has already explained itself on stderr. Return
-        # rather than propagate so a usage error never reaches the emit path:
-        # a record for a call that was never made would be a lie a dispatcher
-        # would happily parse.
-        return EXIT_USAGE
+    except SystemExit as exc:
+        # argparse has already explained itself on stderr. Return rather than
+        # propagate so neither path reaches the emit path: a record for a call
+        # that was never made would be a lie a dispatcher would happily parse.
+        #
+        # `--help` and `--version` raise SystemExit(0) through this same branch,
+        # so the code has to be read rather than assumed: collapsing everything
+        # to EXIT_USAGE made `hive delegate --help` exit 2, which is a script
+        # asking for usage and being told it got the usage wrong.
+        return EXIT_OK if exc.code == 0 else EXIT_USAGE
 
     # argparse's own type check accepts 0 and negatives. A zero deadline is not
     # a deadline, and rejecting it beats dispatching something that can only
@@ -182,19 +191,46 @@ async def _dispatch_async(
     state = _read_state()
     if state is not None and _daemon_reachable(DEFAULT_HOST, state[0]):
         port, token = state
+        # The fallback is PRE-SUBMISSION ONLY, and the flag is what enforces it.
+        #
+        # The daemon records usage as soon as the worker answers, before it
+        # serialises the response. So a connection that dies after the request
+        # went out leaves an *ambiguous* outcome: the inference may have run and
+        # been paid for. Falling back there would run a second one — double
+        # cost, and a second slot out of a pool whose concurrency is the binding
+        # constraint. Retrying is only free before the request was submitted.
+        #
+        # Failing to open the session (daemon mid-restart, stale token,
+        # handshake stall) is unambiguous: nothing ran, so the documented
+        # ADR-011 §3 fallback applies and `degraded` reports which path answered.
+        submitted = False
         try:
             client = _remote_client(DEFAULT_HOST, port, token)
             async with client:
+                submitted = True
                 result = await client.call_tool("delegate_task", payload)
-            return _decode(result, degraded=False)
-        except Exception as exc:  # noqa: BLE001 - any daemon failure degrades
-            # Broad on purpose. The TCP probe proves something is listening, not
-            # that it will complete an MCP call: a daemon mid-restart, a stale
-            # token, a handshake stall. Every one of those is a reason to take
-            # the documented fallback, and none is a reason to fail the
-            # dispatch — the degraded flag is how the caller learns which path
-            # answered.
-            _log.warning("daemon call failed (%r); falling back to in-process", exc)
+                return _decode(result, degraded=False)
+        except Exception as exc:  # noqa: BLE001 - classified by `submitted`
+            if submitted:
+                _log.warning("daemon connection lost after submission (%r); NOT retrying", exc)
+                # task_failed, not pool_unavailable: exit 3 would advance the
+                # dispatcher's chain and spend a second pool on a task that may
+                # already have been served. Fail closed is the direction that
+                # does not retry, and a human reading the detail can decide.
+                return {
+                    "status": "task_failed",
+                    "model": model,
+                    "degraded": False,
+                    "tokens": 0,
+                    "duration_ms": 0,
+                    "output": "",
+                    "detail": (
+                        "the daemon connection failed after the request was submitted, so the "
+                        f"worker may have run and been billed ({exc!r}). Not retried locally or "
+                        "elsewhere: a second dispatch could pay for the same task twice."
+                    ),
+                }
+            _log.warning("daemon session could not be opened (%r); falling back", exc)
 
     from hive.server import create_server
 
@@ -211,19 +247,40 @@ def _decode(result: Any, *, degraded: bool) -> dict[str, Any]:
     """
     text = _result_text(result)
     try:
-        record: dict[str, Any] = json.loads(text)
+        parsed = json.loads(text)
     except (ValueError, TypeError):
-        return {
-            "status": "task_failed",
-            "model": "",
-            "degraded": degraded,
-            "tokens": 0,
-            "duration_ms": 0,
-            "output": "",
-            "detail": f"worker returned an unparseable body: {text[:200]}",
-        }
+        return _unusable(text, degraded, "unparseable")
+    # Parseable is not the same as usable. `[]`, `null` and `"text"` are all
+    # valid JSON and none is a record: assigning `degraded` into them raised
+    # TypeError straight out of the verb, so a malformed worker body produced a
+    # traceback on stderr and NOTHING on stdout — the one thing a dispatcher
+    # cannot handle. An object missing contracted keys is the quieter version of
+    # the same problem, and is rejected for the same reason.
+    if not isinstance(parsed, dict):
+        return _unusable(text, degraded, f"not a JSON object ({type(parsed).__name__})")
+    missing = _REQUIRED_FIELDS - set(parsed)
+    if missing:
+        return _unusable(text, degraded, f"missing {', '.join(sorted(missing))}")
+    record: dict[str, Any] = dict(parsed)
     record["degraded"] = degraded
     return record
+
+
+def _unusable(text: str, degraded: bool, why: str) -> dict[str, Any]:
+    """The canonical record for a body this verb cannot act on.
+
+    task_failed rather than pool_unavailable: the pool answered, and what came
+    back is unusable. Retrying that on a different model would hide it.
+    """
+    return {
+        "status": "task_failed",
+        "model": "",
+        "degraded": degraded,
+        "tokens": 0,
+        "duration_ms": 0,
+        "output": "",
+        "detail": f"worker returned a body this verb cannot use — {why}: {text[:200]}",
+    }
 
 
 def _result_text(result: Any) -> str:

--- a/src/hive/clients.py
+++ b/src/hive/clients.py
@@ -293,7 +293,13 @@ class OpenAICompatibleClient:
             )
             raise PoolUnavailableError(msg)
         if resp.status_code >= 400:
-            msg = f"{self._provider_name} models error ({resp.status_code}): {resp.text[:200]}"
+            # Through _error_detail, not raw resp.text: `worker_status` renders
+            # this exception, and a provider that echoes the Authorization value
+            # in a 500 body would put the credential on a status surface. The
+            # 401 path was redacted and this one was not, which is the half of
+            # a fix that leaves the leak reachable by a different status code.
+            detail = self._error_detail(resp)
+            msg = f"{self._provider_name} models error ({resp.status_code}): {detail}"
             raise RuntimeError(msg)
 
         try:

--- a/src/hive/config.py
+++ b/src/hive/config.py
@@ -41,7 +41,7 @@ class HiveSettings(BaseSettings):
     # `SecretStr` is the idiomatic fix and is deliberately NOT taken here: it
     # changes the field's type, which propagates through `ServerContext` and
     # six call sites, and a type migration does not belong in the PR that
-    # discovered the leak. Tracked separately; `repr=False` closes the leak now.
+    # discovered the leak. Tracked as #397; `repr=False` closes the leak now.
     worker_api_key: str = Field(default="", repr=False)
     vault_scopes: dict[str, str] = Field(
         # ``agents`` is intentionally LAST: auto-scan (plain project name)

--- a/tests/test_delegate_review_findings.py
+++ b/tests/test_delegate_review_findings.py
@@ -1,0 +1,221 @@
+"""Guards for the four code findings raised in review of PR 2 (hive#395).
+
+Each was verified against the running code before being fixed, and each is
+guarded here so the fix cannot regress silently.
+
+The one worth reading twice is the ambiguous-failure case. It is the only one
+that costs money when it goes wrong, and it is the only one whose correct
+behaviour is to do *less* than the obvious thing.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from hive._delegate import EXIT_OK, EXIT_TASK_FAILED, EXIT_USAGE, _decode, run_delegate
+from hive.clients import OpenAICompatibleClient
+
+_KEY = "pk-echoed-back-4b21d0"
+
+
+class _Body:
+    """A tool result carrying an arbitrary text body."""
+
+    def __init__(self, text: str) -> None:
+        class _C:
+            def __init__(self, t: str) -> None:
+                self.text = t
+
+        self.content = [_C(text)]
+
+
+class TestHelpIsNotAUsageError:
+    @pytest.mark.parametrize("flag", ["--help", "-h"])
+    def test_asking_for_usage_exits_zero(
+        self, flag: str, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A script asking how to call this was being told it called it wrong.
+
+        `argparse` raises SystemExit(0) for --help through the same branch that
+        handles a genuine parse failure, so collapsing both to EXIT_USAGE made
+        `hive delegate --help` exit 2.
+        """
+        assert run_delegate([flag]) == EXIT_OK
+        assert "--model" in capsys.readouterr().out
+
+    def test_a_real_parse_failure_still_exits_two(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert run_delegate(["--model", "m"]) == EXIT_USAGE
+        assert capsys.readouterr().out == ""
+
+
+class TestAnUnusableBodyStillProducesARecord:
+    """stdout must stay parseable even when the worker's body is not.
+
+    Before the fix, `[]`, `null` and `"text"` all parsed as valid JSON and then
+    raised TypeError on the `degraded` assignment — straight out of the verb, so
+    the dispatcher got a traceback on stderr and NOTHING on stdout.
+    """
+
+    @pytest.mark.parametrize(
+        ("body", "why"),
+        [
+            ("[]", "a list is not a record"),
+            ("null", "null is not a record"),
+            ('"text"', "a bare string is not a record"),
+            ("3", "a number is not a record"),
+            ("{}", "an empty object carries no status"),
+            ('{"status": "ok"}', "an object missing the contracted keys"),
+        ],
+    )
+    def test_it_becomes_a_task_failure_rather_than_a_crash(self, body: str, why: str) -> None:
+        record = _decode(_Body(body), degraded=True)
+        assert record["status"] == "task_failed", why
+        assert record["degraded"] is True
+        assert record["detail"], "an unusable body with no explanation is unactionable"
+
+    def test_a_complete_record_passes_through_untouched(self) -> None:
+        good = {
+            "status": "ok",
+            "model": "m",
+            "output": "hi",
+            "tokens": 3,
+            "duration_ms": 7,
+            "detail": "",
+        }
+        record = _decode(_Body(json.dumps(good)), degraded=False)
+        assert record["status"] == "ok"
+        assert record["output"] == "hi"
+        assert record["degraded"] is False
+
+    def test_the_verb_emits_it_and_exits_one(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """End to end: the contract holds even on the malformed path."""
+        with patch(
+            "hive._delegate._dispatch_once", return_value=_decode(_Body("[]"), degraded=True)
+        ):
+            code = run_delegate(["--model", "m", "--timeout", "5", "--prompt", "hi"])
+        assert code == EXIT_TASK_FAILED
+        json.loads(capsys.readouterr().out)
+
+
+class TestAnAmbiguousDaemonFailureIsNeverRetried:
+    """The finding that costs money when it is wrong.
+
+    The daemon records usage as soon as the worker answers, before serialising
+    the response. A connection that dies after the request went out therefore
+    leaves an outcome nobody can classify: the inference may have run and been
+    billed. Falling back locally there runs a SECOND one — double cost, and a
+    second slot out of a pool whose concurrency is the binding constraint.
+
+    So the fallback is pre-submission only. Failing to open the session is
+    unambiguous and degrades as documented; failing after `call_tool` was
+    invoked returns a task failure that names the ambiguity, and deliberately
+    NOT exit 3, which would advance the dispatcher's chain and spend a second
+    pool on a task that may already have been served.
+    """
+
+    def _local(self) -> AsyncMock:
+        return AsyncMock(
+            return_value=_Body(
+                json.dumps(
+                    {
+                        "status": "ok",
+                        "model": "local",
+                        "output": "second inference!",
+                        "tokens": 1,
+                        "duration_ms": 1,
+                        "detail": "",
+                    }
+                )
+            )
+        )
+
+    def test_a_failure_after_submission_does_not_run_a_second_inference(self) -> None:
+        from hive import _delegate
+
+        class _DiesAfterSubmit:
+            async def __aenter__(self) -> Any:
+                return self
+
+            async def __aexit__(self, *a: object) -> None:
+                return None
+
+            async def call_tool(self, _n: str, _a: dict[str, Any]) -> Any:
+                raise ConnectionResetError("response lost in flight")
+
+        local = self._local()
+        with (
+            patch("hive._client._read_state", return_value=(4242, "t")),
+            patch("hive._client._daemon_reachable", return_value=True),
+            patch("hive._client._remote_client", return_value=_DiesAfterSubmit()),
+            patch("hive.server.create_server") as make,
+        ):
+            make.return_value.call_tool = local
+            record = _delegate._dispatch_once(
+                prompt="x", model="m", timeout_s=5.0, context="", max_tokens=10
+            )
+
+        assert local.await_count == 0, "a second inference was dispatched for the same task"
+        assert record["status"] == "task_failed"
+        assert record["status"] != "pool_unavailable", "exit 3 would advance the chain"
+        assert "billed" in record["detail"] or "twice" in record["detail"]
+
+    def test_a_failure_before_submission_still_degrades(self) -> None:
+        """The unambiguous half must keep working, or the fix broke the fallback."""
+        from hive import _delegate
+
+        class _DiesOnHandshake:
+            async def __aenter__(self) -> Any:
+                raise ConnectionRefusedError("daemon mid-restart")
+
+            async def __aexit__(self, *a: object) -> None:
+                return None
+
+        local = self._local()
+        with (
+            patch("hive._client._read_state", return_value=(4242, "t")),
+            patch("hive._client._daemon_reachable", return_value=True),
+            patch("hive._client._remote_client", return_value=_DiesOnHandshake()),
+            patch("hive.server.create_server") as make,
+        ):
+            make.return_value.call_tool = local
+            record = _delegate._dispatch_once(
+                prompt="x", model="m", timeout_s=5.0, context="", max_tokens=10
+            )
+
+        assert local.await_count == 1, "nothing ran remotely, so the fallback should have"
+        assert record["degraded"] is True
+        assert record["status"] == "ok"
+
+
+class TestTheCatalogErrorIsRedactedToo:
+    """AC7's fix covered the 401 path and left the catalog path raw.
+
+    `worker_status` renders this exception, so a provider echoing the
+    Authorization value in a 500 body put the credential on a status surface —
+    reachable by a different status code than the one that was fixed.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status_code", [500, 400, 503])
+    async def test_an_echoed_key_is_redacted_in_a_catalog_error(self, status_code: int) -> None:
+        client = OpenAICompatibleClient(
+            base_url="https://provider.example/v1", api_key=_KEY, default_model="m"
+        )
+        echoing = httpx.Response(
+            status_code=status_code,
+            json={"error": {"message": f"upstream failure for Bearer {_KEY}"}},
+            request=httpx.Request("GET", "http://test"),
+        )
+        with (
+            patch.object(client._http, "get", new_callable=AsyncMock, return_value=echoing),
+            pytest.raises(RuntimeError) as excinfo,
+        ):
+            await client.list_models()
+
+        assert _KEY not in str(excinfo.value)
+        assert "<redacted>" in str(excinfo.value)


### PR DESCRIPTION
fix: never retry a dispatch whose outcome is ambiguous, and four review findings

Applies every finding from the review of #395. Three were reproduced by running
the code before being fixed, not judged by reading it.

**The daemon fallback could pay for the same task twice.** `_dispatch_async`
caught every exception from `call_tool` and fell back to the in-process path.
But the daemon records usage as soon as the worker answers, before it serialises
the response, so a connection that dies after the request went out leaves an
outcome nobody can classify: the inference may have run and been billed. The
fallback then ran a second one — double cost, and a second slot out of a pool
whose concurrency is the binding constraint.

The comment justifying that broad catch listed three PRE-submission failures
(daemon mid-restart, stale token, handshake stall) and the ambiguous
post-submission case had been folded in with them without noticing it does not
belong. The fallback is now pre-submission only, separated by an explicit flag.
Failing to open the session is unambiguous and degrades as ADR-011 §3 documents;
failing after `call_tool` was invoked returns a task failure naming the
ambiguity — deliberately NOT exit 3, which would advance the dispatcher's chain
and spend a second pool on a task that may already have been served. Fail closed
is the direction that does not retry.

**A valid JSON body that is not an object crashed the verb.** `[]`, `null` and
`"text"` all parse, and the `degraded` assignment then raised TypeError out of
the verb: a traceback on stderr and nothing on stdout, which is the one outcome
a dispatcher cannot handle. Bodies are now shape-checked and an unusable one
becomes the canonical task_failed record. An object missing contracted keys is
rejected for the same reason.

**`hive delegate --help` exited 2.** argparse raises SystemExit(0) for help
through the same branch as a parse failure, and collapsing both to EXIT_USAGE
told a script asking for usage that it had got the usage wrong.

**The catalog error path was not redacted.** The previous commit covered the 401
in `_post_json` and left `list_models` interpolating raw `resp.text`, which
`worker_status` renders — the same leak, reachable by a different status code.

**The acceptance matrix assigned AC7 to PR 1**, which is where it was planned and
not where it happened. Struck through with the reason, so the release evidence
and the matrix agree.

Verified: 950 passed / 2 skipped / exit 0, +16 tests over the previous commit,
no regressions. One of the new tests asserts `await_count == 0` on the local
path — that no second inference was dispatched — rather than asserting only the
returned status, which would pass while the money was already spent.

Refs #384

---

Follow-up to **#395**, which merged at 08:51Z before these findings were applied. **All four code defects are live on `master` right now**, so this is not cosmetic follow-up: the double-billing path and the credential leak are both reachable today.

## Review triage — #395

| Finding | Severity | Disposition |
|---|---|---|
| Do not retry `delegate_task` after an ambiguous daemon failure | Major | **Applied.** Reproduced by reading the ordering: the daemon calls `_record(resp)` as soon as the worker answers, before serialising. Fallback is now pre-submission only. |
| Validate the decoded result schema before mutating it | Major | **Applied.** Reproduced: `[]` → `TypeError: list indices must be integers`, `null` and `"text"` → `TypeError: does not support item assignment`, `{}` → a record with only `degraded`. |
| Redact catalog error details before rendering them | Major | **Applied.** My own AC7 fix covered `_post_json` and left `list_models` interpolating raw `resp.text`. Same leak, different status code. |
| Preserve the successful help exit code | Minor | **Applied.** Reproduced: `hive delegate --help; echo $?` → `2`. |
| Update the PR acceptance matrix for AC7 | Minor | **Applied.** AC7 struck through on PR 1's row with the reason. |

Nothing was declined. CI on #395: `check (3.12)`, `check (3.13)`, `cross_worker_lock` (ubuntu + windows), `docker`, `add-to-project` and GitGuardian all green.

## The one worth reviewing carefully

The ambiguous-failure fix changes **semantics**, not just error handling: an outcome that used to produce an answer now produces a failure. That is deliberate — an answer obtained by running the task a second time is not the same answer, and the caller cannot tell. If you would rather pay twice than fail, the alternative is an idempotency key on `delegate_task`, which the reviewer also named and which is a genuinely larger change.

The new test asserts `local.await_count == 0` rather than only the returned status. A status-only assertion would pass while the second inference had already been dispatched and billed.