### PR TITLE
chore: refresh hygiene guards and the PR-Agent guard from canon

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -225,13 +225,17 @@ jobs:
             HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null || true)
           fi
           if [ -z "$marker" ] && [ -n "${HEAD_SHA:-}" ]; then
-            # The base has no registry (or no github-actions entry) yet: this is the PR
-            # that introduces it. Reading the marker from the PR head is safe because the
-            # comment must still be AUTHORED by github-actions[bot] after this run's
-            # start, which a PR cannot forge. Without this fallback the bootstrap PR of
-            # every repository failed with a bare "exit code 1" (gh 404 under pipefail).
-            marker=$(read_marker "${HEAD_SHA}")
-            [ -n "$marker" ] && echo "::notice::review marker read from the PR head: the base ref has no reviewer registry yet"
+            # The default branch has no github-actions entry yet: this is the PR that
+            # introduces it. The head registry only proves the entry EXISTS; the marker
+            # itself is PR-Agent's own heading, never text a PR could choose (a head-
+            # supplied marker such as "#" would match any bot comment, CWE-345). Author
+            # and start-stamp binding below still apply. Without this fallback the
+            # bootstrap PR of every repository failed with a bare "exit code 1".
+            if [ -n "$(read_marker "${HEAD_SHA}")" ]; then
+              marker="PR Reviewer Guide"
+              echo "::notice::reviewer registry entry found only on the PR head;" \
+                "using PR-Agent's own heading as the marker"
+            fi
           fi
           if [ -z "$marker" ] || [ "$marker" = "null" ]; then
             echo "::error::no review marker declared for github-actions in" \

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -206,7 +206,10 @@ jobs:
           # "exactly one secret" guard keeps counting what it was written to count.
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
+          # The repository's OWN default branch, never `pull_request.base.ref`: the base
+          # is chosen by the PR author, and this reads the file that decides what counts
+          # as a review. kubelab's port made this call first (its tests pin it).
+          BASE_REF: ${{ github.event.repository.default_branch }}
           STARTED: ${{ steps.start.outputs.started }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -217,6 +217,10 @@ jobs:
               | jq -r '.reviewers[] | select(.login == "github-actions") | .review_markers[0] // empty' 2>/dev/null || true
           }
           marker=$(read_marker "${BASE_REF}")
+          if [ -z "$marker" ] && [ -z "${HEAD_SHA:-}" ]; then
+            # issue_comment events carry no pull_request payload; ask the API for the head.
+            HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null || true)
+          fi
           if [ -z "$marker" ] && [ -n "${HEAD_SHA:-}" ]; then
             # The base has no registry (or no github-actions entry) yet: this is the PR
             # that introduces it. Reading the marker from the PR head is safe because the

--- a/scripts/check-actions-pinned.sh
+++ b/scripts/check-actions-pinned.sh
@@ -20,7 +20,8 @@ while IFS= read -r -d '' f; do files+=("$f"); done < <(
 
 # A `uses` key: optional indentation, optional "- ", the key, then the reference.
 # The reference is captured up to whitespace, a quote or a comment.
-bad="$(grep -nE '^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]+' "${files[@]}" \
+# -H: with a single file grep would omit the filename and the sed below would misparse.
+bad="$(grep -nHE '^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]+' "${files[@]}" \
   | sed -E 's/^([^:]+:[0-9]+:)[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]+["'"'"']?([^"'"'"'[:space:]#]+).*/\1\3/' \
   | grep -vE ':(\./|docker://)' \
   | grep -vE '@[0-9a-fA-F]{40}$' || true)"

--- a/scripts/check-actions-pinned.sh
+++ b/scripts/check-actions-pinned.sh
@@ -2,20 +2,28 @@
 # Guard: every third-party action is pinned to a commit SHA (mutable tags can be moved;
 # several steps here receive repository secrets). Companion of scripts/pin-actions.sh,
 # which performs the rewrite. Fails listing each offending line.
-# Covers .github/workflows and .gitea/workflows, .yml and .yaml, quoted and unquoted refs,
-# and refs followed by an inline comment. Local actions (uses: ./path) and docker:// refs
-# are out of scope.
+# Scope: .github/workflows and .gitea/workflows (.yml/.yaml) plus local composite action
+# manifests (.github/actions/*/action.yml), which can themselves invoke third-party
+# actions. Only YAML `uses:` mapping keys count (comments and scalar values that happen
+# to contain "uses:" do not), and the SHA is validated on the reference itself, never on
+# text elsewhere in the line. Local (./) and docker:// references are out of scope.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 files=()
 while IFS= read -r -d '' f; do files+=("$f"); done < <(
-  find "$ROOT/.github/workflows" "$ROOT/.gitea/workflows" -maxdepth 1 -type f \
-    \( -name '*.yml' -o -name '*.yaml' \) -print0 2>/dev/null
+  { find "$ROOT/.github/workflows" "$ROOT/.gitea/workflows" -maxdepth 1 -type f \
+      \( -name '*.yml' -o -name '*.yaml' \) -print0 2>/dev/null
+    find "$ROOT/.github/actions" -mindepth 2 -maxdepth 2 -type f \
+      \( -name 'action.yml' -o -name 'action.yaml' \) -print0 2>/dev/null; } || true
 )
 [ "${#files[@]}" -gt 0 ] || { echo "check-actions-pinned: no workflows"; exit 0; }
-bad="$(grep -nE 'uses:[[:space:]]+["'"'"']?[A-Za-z0-9_.-]+/[A-Za-z0-9_./-]+@' "${files[@]}" \
-  | grep -vE '@[0-9a-f]{40}["'"'"']?([[:space:]]|$)' \
-  | grep -vE 'uses:[[:space:]]+["'"'"']?(\./|docker://)' || true)"
+
+# A `uses` key: optional indentation, optional "- ", the key, then the reference.
+# The reference is captured up to whitespace, a quote or a comment.
+bad="$(grep -nE '^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]+' "${files[@]}" \
+  | sed -E 's/^([^:]+:[0-9]+:)[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]+["'"'"']?([^"'"'"'[:space:]#]+).*/\1\3/' \
+  | grep -vE ':(\./|docker://)' \
+  | grep -vE '@[0-9a-fA-F]{40}$' || true)"
 if [ -n "$bad" ]; then
   echo "check-actions-pinned: actions not pinned to a commit SHA (run scripts/pin-actions.sh):"
   printf '%s\n' "$bad" | sed 's/^/  /'

--- a/scripts/check-lessons.sh
+++ b/scripts/check-lessons.sh
@@ -2,10 +2,12 @@
 # Guard: docs/lessons/ numbering and index integrity.
 # 1. No two lesson files share a number (the collision that hit web#326, dotfiles#1519, kubelab).
 # 2. Every lesson file is listed in its _index.md and every indexed file exists.
+# 3. When lessons live in category directories, docs/lessons/_index.md (the root index the
+#    pointer stub links) must still exist.
 # Lessons may live flat in docs/lessons/ or one level down in category directories
 # (docs/lessons/<category>/ with a per-category _index.md); both layouts are checked.
-# Runs under bash and zsh; no globs (an unmatched glob aborts under zsh NOMATCH), and
-# filenames are handled NUL-separated so spaces cannot split them.
+# Portable: bash and zsh, GNU and BSD find (no -printf), filenames compared as literal
+# tokens (no regex built from a filename), NUL-separated so spaces cannot split them.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 LESSONS_DIR="$ROOT/docs/lessons"
@@ -13,13 +15,26 @@ LESSONS_DIR="$ROOT/docs/lessons"
 rc=0
 total=0
 
+# Link targets an index may name: everything between a '(' or a '[[' and the closing
+# ')' / '|' / ']]' that ends in .md, path stripped. Printed one per line; spaces allowed.
+index_targets() {
+  # perl, not grep: a markdown target may contain escaped or %-encoded parens and spaces,
+  # which no single ERE handles; the targets come back decoded, path stripped, one per line.
+  perl -ne '
+    while (/\]\(\s*((?:[^()\\\s]|\\.|%[0-9A-Fa-f]{2})*?lesson-\d+(?:[^()\\\s]|\\.|%[0-9A-Fa-f]{2})*?\.md)\s*\)/g) { print "$1\n" }
+    # Obsidian wikilinks may omit the .md extension; add it back so the token compares.
+    while (/\[\[([^\]|\\]*?lesson-\d+[^\]|\\]*?)(?:\\?\||\]\])/g) { my $t = $1; $t .= ".md" unless $t =~ /\.md$/; print "$t\n" }
+  ' "$1" 2>/dev/null \
+    | perl -pe 's/\\([()])/$1/g; s/%([0-9A-Fa-f]{2})/chr(hex($1))/ge; s#.*/##' | sort -u
+}
+
 # --- 1. duplicate numbers across the whole tree (a number is unique per repo) ---
-dupes="$(find "$LESSONS_DIR" -maxdepth 2 -type f -name 'lesson-[0-9]*.md' -printf '%f\n' \
+dupes="$(find "$LESSONS_DIR" -maxdepth 2 -type f -name 'lesson-[0-9]*.md' -exec basename {} \; \
   | grep -oE '^lesson-[0-9]+' | sort | uniq -d || true)"
 if [ -n "$dupes" ]; then
   echo "check-lessons: lesson numbers used more than once:"
   while IFS= read -r n; do
-    find "$LESSONS_DIR" -maxdepth 2 -type f -name "${n}-*.md" -printf '  %P\n'
+    find "$LESSONS_DIR" -maxdepth 2 -type f -name "${n}-*.md" | sed "s#^$LESSONS_DIR/#  #"
   done <<< "$dupes"
   rc=1
 fi
@@ -28,27 +43,36 @@ fi
 while IFS= read -r -d '' dir; do
   index="$dir/_index.md"
   count=0
+  targets=""
+  [ -f "$index" ] && targets="$(index_targets "$index")"
   while IFS= read -r -d '' f; do
     count=$((count + 1))
     name="$(basename "$f")"
     if [ -f "$index" ]; then
-      # Match the filename as a whole token (followed by ) | ] or end), not as a substring,
-      # so lesson-12.md.bak cannot satisfy lesson-12.md.
-      grep -qE "(^|[^A-Za-z0-9._-])$(printf '%s' "$name" | sed 's/[.[\*^$]/\\&/g')([^A-Za-z0-9._-]|$)" "$index" \
+      # Literal, whole-line comparison against the extracted targets: no regex is built
+      # from the filename, so '+', '(' or a space in a name cannot change the match.
+      printf '%s\n' "$targets" | grep -qxF -- "$name" \
         || { echo "check-lessons: not in ${index#"$ROOT"/}: $name"; rc=1; }
     fi
   done < <(find "$dir" -maxdepth 1 -type f -name 'lesson-[0-9]*.md' -print0)
   [ "$count" -gt 0 ] || continue
   total=$((total + count))
   if [ -f "$index" ]; then
-    while IFS= read -r f; do
-      [ -f "$dir/$f" ] || { echo "check-lessons: indexed in ${index#"$ROOT"/} but missing: $f"; rc=1; }
-    done < <(grep -oE 'lesson-[0-9]+[A-Za-z0-9._-]*\.md' "$index" | sort -u)
+    while IFS= read -r t; do
+      [ -n "$t" ] || continue
+      [ -f "$dir/$t" ] || { echo "check-lessons: indexed in ${index#"$ROOT"/} but missing: $t"; rc=1; }
+    done <<< "$targets"
   else
     echo "check-lessons: ${dir#"$ROOT"/} has lessons but no _index.md"
     rc=1
   fi
 done < <(find "$LESSONS_DIR" -maxdepth 1 -type d -print0)
+
+# --- 3. the root index must exist whenever any lesson exists anywhere ---
+if [ "$total" -gt 0 ] && [ ! -f "$LESSONS_DIR/_index.md" ]; then
+  echo "check-lessons: docs/lessons/_index.md is missing (the canonical index the pointer stub links)"
+  rc=1
+fi
 
 [ "$rc" -eq 0 ] && echo "check-lessons: OK ($total lessons)"
 exit $rc

--- a/scripts/check-lessons.sh
+++ b/scripts/check-lessons.sh
@@ -21,11 +21,11 @@ index_targets() {
   # perl, not grep: a markdown target may contain escaped or %-encoded parens and spaces,
   # which no single ERE handles; the targets come back decoded, path stripped, one per line.
   perl -ne '
-    while (/\]\(\s*((?:[^()\\\s]|\\.|%[0-9A-Fa-f]{2})*?lesson-\d+(?:[^()\\\s]|\\.|%[0-9A-Fa-f]{2})*?\.md)\s*\)/g) { print "$1\n" }
+    while (/\]\(\s*((?:[^()\\\s#]|\\.|%[0-9A-Fa-f]{2})*?lesson-\d+(?:[^()\\\s#]|\\.|%[0-9A-Fa-f]{2})*?\.md)(?:#[^)\s]*)?\s*\)/g) { print "$1\n" }
     # Obsidian wikilinks may omit the .md extension; add it back so the token compares.
     while (/\[\[([^\]|\\]*?lesson-\d+[^\]|\\]*?)(?:\\?\||\]\])/g) { my $t = $1; $t .= ".md" unless $t =~ /\.md$/; print "$t\n" }
   ' "$1" 2>/dev/null \
-    | perl -pe 's/\\([()])/$1/g; s/%([0-9A-Fa-f]{2})/chr(hex($1))/ge; s#.*/##' | sort -u
+    | perl -pe 's/#[^\n]*$//; s/\\(.)/$1/g; s/%([0-9A-Fa-f]{2})/chr(hex($1))/ge; s#.*/##' | sort -u
 }
 
 # --- 1. duplicate numbers across the whole tree (a number is unique per repo) ---

--- a/scripts/pin-actions.sh
+++ b/scripts/pin-actions.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
-# Rewrite `uses: owner/repo@<tag>` to `uses: owner/repo@<commit-sha> # <tag>` for every
-# workflow under .github/workflows and .gitea/workflows (.yml and .yaml). Resolves each
-# tag through the GitHub API and dereferences annotated tags to the commit; a ref that is
-# a branch (e.g. release/v1) is resolved to the branch head and marked as such in the
-# trailer. Idempotent: lines already carrying a 40-hex SHA are left alone. Quoted refs and
-# inline comments are preserved. Resolutions are cached for the run (one API call per
-# distinct owner/repo@tag, not per occurrence). Prints each rewrite.
+# Rewrite `uses: owner/repo@<tag>` to `uses: owner/repo@<commit-sha>  # <tag>` for every
+# workflow under .github/workflows and .gitea/workflows (.yml and .yaml) and every local
+# composite action manifest (.github/actions/*/action.yml). Resolves each tag through the
+# GitHub API and dereferences annotated tags to the commit; a ref that is a branch (e.g.
+# release/v1) is resolved to the branch head and marked as such in the trailer.
+# Idempotent: references already carrying a 40-hex SHA are left alone. Only YAML `uses:`
+# mapping keys are rewritten (comments and scalar values containing "uses:" are not).
+# Quoted refs and inline comments are preserved. Resolutions are cached for the run.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 files=()
 while IFS= read -r -d '' f; do files+=("$f"); done < <(
-  find "$ROOT/.github/workflows" "$ROOT/.gitea/workflows" -maxdepth 1 -type f \
-    \( -name '*.yml' -o -name '*.yaml' \) -print0 2>/dev/null
+  { find "$ROOT/.github/workflows" "$ROOT/.gitea/workflows" -maxdepth 1 -type f \
+      \( -name '*.yml' -o -name '*.yaml' \) -print0 2>/dev/null
+    find "$ROOT/.github/actions" -mindepth 2 -maxdepth 2 -type f \
+      \( -name 'action.yml' -o -name 'action.yaml' \) -print0 2>/dev/null; } || true
 )
 [ "${#files[@]}" -gt 0 ] || { echo "pin-actions: no workflows"; exit 0; }
 
@@ -33,7 +36,7 @@ resolve() { # sets RESOLVED to "<sha> <kind>" (kind: tag|branch) or "" when unre
 
 rc=0
 for f in "${files[@]}"; do
-  # Candidate refs: not already a 40-hex SHA, not local, not docker.
+  # Candidate refs from `uses:` keys only: not already a 40-hex SHA, not local, not docker.
   while IFS= read -r ref; do
     [ -n "$ref" ] || continue
     full=${ref%@*}; tag=${ref##*@}; repo=$(printf '%s' "$full" | cut -d/ -f1-2)
@@ -43,15 +46,15 @@ for f in "${files[@]}"; do
     trailer="$tag"; [ "$kind" = "branch" ] && trailer="$tag (branch head, re-pin deliberately)"
     REF="$ref" FULL="$full" SHA="$sha" TRAILER="$trailer" perl -pi -e '
       chomp;
-      s{(uses:\h+)(["\x27]?)\Q$ENV{REF}\E\2\h*(#[^\n]*)?$}{
+      s{^(\h*(?:-\h+)?uses:\h+)(["\x27]?)\Q$ENV{REF}\E\2\h*(#[^\n]*)?$}{
         my ($lead,$q,$c)=($1,$2,$3);
         my $tr = $c ? $c : "# $ENV{TRAILER}";
         "$lead$q$ENV{FULL}\@$ENV{SHA}$q  $tr"
       }e;
       $_ .= "\n"' "$f"
     echo "pinned ${f#"$ROOT"/}: $ref -> $sha ($kind)"
-  done < <(grep -oE 'uses:[[:space:]]+["'"'"']?[A-Za-z0-9_.-]+/[A-Za-z0-9_./-]+@[A-Za-z0-9_./-]+' "$f" \
-    | sed -E 's/^uses:[[:space:]]+["'"'"']?//' \
-    | grep -vE '@[0-9a-f]{40}$' | grep -vE '^(\./|docker://)' | sort -u)
+  done < <(grep -E '^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]+' "$f" \
+    | sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]+["'"'"']?([^"'"'"'[:space:]#]+).*/\2/' \
+    | grep -vE '@[0-9a-fA-F]{40}$' | grep -vE '^(\./|docker://)' | grep -E '@' | sort -u)
 done
 exit $rc


### PR DESCRIPTION
Final canon refresh after the round-two reviewer findings, applied on top of the merged hygiene PR.

- `scripts/check-lessons.sh`: index targets compared as literal tokens (a `+` or `(` in a filename no longer breaks it), extension-less wikilinks accepted, BSD `find` supported, root `_index.md` required when lessons live in category directories.
- `scripts/check-actions-pinned.sh`, `scripts/pin-actions.sh`: only YAML `uses:` keys match (comments and scalars ignored), the SHA is validated on the reference itself, local composite action manifests are covered.
- `.github/workflows/pr-agent.yml`: the head-ref registry fallback also resolves the PR head for `issue_comment` runs (dotfiles#1567).

Verification: both guards OK on this tree, actionlint clean; the `hygiene` and `pr-agent / review` jobs on this PR are the live test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved pull request review automation so comments can be matched reliably to the correct pull request revision.
  - Expanded security checks to validate pinned references in local reusable actions as well as workflows.
  - Improved lesson-content validation for Markdown and Obsidian links, duplicate numbering, missing indexes, and portable cross-platform checks.
  - Updated action-pinning automation to cover local reusable actions and recognize valid YAML formats more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->